### PR TITLE
Support deserialization

### DIFF
--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <Authors>Muhammad Rehan Saeed (RehanSaeed.com)</Authors>
     <Product>Schema.NET</Product>
     <Description>Schema.org objects turned into strongly typed C# POCO classes for use in .NET. All classes can be serialized into JSON/JSON-LD and XML, typically used to represent structured data in the head section of html page.</Description>
@@ -21,7 +21,7 @@
     <RepositoryUrl>https://github.com/RehanSaeed/Schema.NET.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Schema;.NET;Schema.org;Schema.NET;Structured Data;Google Structured Data</PackageTags>
-    <PackageReleaseNotes>Added array implicit conversion to Values&lt;T&gt;, fix serialization of enumerations, put name and description properties at the top, support combined classes, @id properties and use the all-layers.jsonld as the base.</PackageReleaseNotes>
+    <PackageReleaseNotes>Can now deserialize JSON into Schema.NET POCO types.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">

--- a/Source/Schema.NET/TimeSpanToISO8601DurationValuesConverter.cs
+++ b/Source/Schema.NET/TimeSpanToISO8601DurationValuesConverter.cs
@@ -15,15 +15,13 @@ namespace Schema.NET
         /// <inheritdoc />
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var valuesType = objectType.GetTypeInfo().IsGenericType && objectType.GetGenericTypeDefinition() == typeof(Nullable<>)
-                ? Nullable.GetUnderlyingType(objectType)
-                : objectType;
+            var valuesType = objectType.GetUnderlyingTypeFromNullable();
 
             if (valuesType.GenericTypeArguments.Length == 1)
             {
                 var mainType = valuesType.GenericTypeArguments[0];
-                Type genericType = typeof(Values<TimeSpan>);
-                if (mainType.GetTypeInfo().IsGenericType && mainType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                var genericType = typeof(Values<TimeSpan>);
+                if (mainType.IsNullable())
                 {
                     mainType = Nullable.GetUnderlyingType(mainType);
                     genericType = typeof(Values<TimeSpan?>);

--- a/Source/Schema.NET/TypeExtensions.cs
+++ b/Source/Schema.NET/TypeExtensions.cs
@@ -1,0 +1,16 @@
+namespace Schema.NET
+{
+    using System;
+    using System.Reflection;
+
+    internal static class TypeExtensions
+    {
+        public static bool IsNullable(this Type type) =>
+            type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+
+        public static bool IsPrimitiveType(this Type type) => type.GetTypeInfo().IsPrimitive || type == typeof(string);
+
+        public static Type GetUnderlyingTypeFromNullable(this Type type) =>
+            type.IsNullable() ? Nullable.GetUnderlyingType(type) : type;
+    }
+}

--- a/Source/Schema.NET/ValuesConverter.cs
+++ b/Source/Schema.NET/ValuesConverter.cs
@@ -147,7 +147,7 @@ namespace Schema.NET
                             }
                             else
                             {
-                                args = Activator.CreateInstance(type, value);
+                                args = token.ToObject(type); // This is expected to throw on some case
                             }
                         }
 
@@ -157,7 +157,8 @@ namespace Schema.NET
                     }
                     catch
                     {
-                        // Nasty, but we're trying to see which Activator instance is the right one...
+                        // Nasty, but we're trying brute force as a last resort, to
+                        // see which type has the right constructor for this value
                     }
                 }
             }

--- a/Tests/Schema.NET.Test/BookTest.cs
+++ b/Tests/Schema.NET.Test/BookTest.cs
@@ -1,25 +1,23 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
     using System.Collections.Generic;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/books
     public class BookTest
     {
-        // https://developers.google.com/search/docs/data-types/books
-        [Fact]
-        public void ToString_BookGoogleStructuredData_ReturnsExpectedJsonLd()
+        private Book book = new Book()
         {
-            var book = new Book()
+            Id = new Uri("http://example.com/book/1"),
+            Name = "The Catcher in the Rye",
+            Author = new Person()
             {
-                Id = new Uri("http://example.com/book/1"),
-                Name = "The Catcher in the Rye",
-                Author = new Person()
-                {
-                    Name = "J.D. Salinger"
-                },
-                Url = new Uri("http://www.barnesandnoble.com/store/info/offer/JDSalinger"),
-                WorkExample = new List<CreativeWork>()
+                Name = "J.D. Salinger"
+            },
+            Url = new Uri("http://www.barnesandnoble.com/store/info/offer/JDSalinger"),
+            WorkExample = new List<CreativeWork>()
                 {
                     new Book()
                     {
@@ -80,81 +78,89 @@
                         },
                     }
                 }
-            };
-            var expectedJson =
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Book\"," +
+            "\"@id\":\"http://example.com/book/1\"," +
+            "\"name\":\"The Catcher in the Rye\"," +
+            "\"url\":\"http://www.barnesandnoble.com/store/info/offer/JDSalinger\"," +
+            "\"author\":{" +
+                "\"@type\":\"Person\"," +
+                "\"name\":\"J.D. Salinger\"" +
+            "}," +
+            "\"workExample\":[" +
                 "{" +
-                    "\"@context\":\"http://schema.org\"," +
                     "\"@type\":\"Book\"," +
-                    "\"@id\":\"http://example.com/book/1\"," +
-                    "\"name\":\"The Catcher in the Rye\"," +
-                    "\"url\":\"http://www.barnesandnoble.com/store/info/offer/JDSalinger\"," +
-                    "\"author\":{" +
-                        "\"@type\":\"Person\"," +
-                        "\"name\":\"J.D. Salinger\"" +
-                    "}," +
-                    "\"workExample\":[" +
-                        "{" +
-                            "\"@type\":\"Book\"," +
-                            "\"potentialAction\":{" +
-                                "\"@type\":\"ReadAction\"," +
-                                "\"target\":{" +
-                                    "\"@type\":\"EntryPoint\"," +
-                                    "\"actionPlatform\":[" +
-                                        "\"http://schema.org/DesktopWebPlatform\"," +
-                                        "\"http://schema.org/IOSPlatform\"," +
-                                        "\"http://schema.org/AndroidPlatform\"" +
-                                    "]," +
-                                    "\"urlTemplate\":\"http://www.barnesandnoble.com/store/info/offer/0316769487?purchase=true\"" +
-                                "}," +
-                                "\"expectsAcceptanceOf\":{" +
-                                    "\"@type\":\"Offer\"," +
-                                    "\"availability\":\"http://schema.org/InStock\"," +
-                                    "\"eligibleRegion\":{" +
-                                        "\"@type\":\"Country\"," +
-                                        "\"name\":\"US\"" +
-                                    "}," +
-                                    "\"price\":6.99," +
-                                    "\"priceCurrency\":\"USD\"" +
-                                "}" +
-                            "}," +
-                            "\"bookEdition\":\"2nd Edition\"," +
-                            "\"bookFormat\":\"http://schema.org/Hardcover\"," +
-                            "\"isbn\":\"031676948\"" +
+                    "\"potentialAction\":{" +
+                        "\"@type\":\"ReadAction\"," +
+                        "\"target\":{" +
+                            "\"@type\":\"EntryPoint\"," +
+                            "\"actionPlatform\":[" +
+                                "\"http://schema.org/DesktopWebPlatform\"," +
+                                "\"http://schema.org/IOSPlatform\"," +
+                                "\"http://schema.org/AndroidPlatform\"" +
+                            "]," +
+                            "\"urlTemplate\":\"http://www.barnesandnoble.com/store/info/offer/0316769487?purchase=true\"" +
                         "}," +
-                        "{" +
-                            "\"@type\":\"Book\"," +
-                            "\"potentialAction\":{" +
-                                "\"@type\":\"ReadAction\"," +
-                                "\"target\":{" +
-                                    "\"@type\":\"EntryPoint\"," +
-                                    "\"actionPlatform\":[" +
-                                        "\"http://schema.org/DesktopWebPlatform\"," +
-                                        "\"http://schema.org/IOSPlatform\"," +
-                                        "\"http://schema.org/AndroidPlatform\"" +
-                                    "]," +
-                                    "\"urlTemplate\":\"http://www.barnesandnoble.com/store/info/offer/031676947?purchase=true\"" +
-                                "}," +
-                                "\"expectsAcceptanceOf\":{" +
-                                    "\"@type\":\"Offer\"," +
-                                    "\"availability\":\"http://schema.org/InStock\"," +
-                                    "\"eligibleRegion\":{" +
-                                        "\"@type\":\"Country\"," +
-                                        "\"name\":\"UK\"" +
-                                    "}," +
-                                    "\"price\":1.99," +
-                                    "\"priceCurrency\":\"USD\"" +
-                                "}" +
+                        "\"expectsAcceptanceOf\":{" +
+                            "\"@type\":\"Offer\"," +
+                            "\"availability\":\"http://schema.org/InStock\"," +
+                            "\"eligibleRegion\":{" +
+                                "\"@type\":\"Country\"," +
+                                "\"name\":\"US\"" +
                             "}," +
-                            "\"bookEdition\":\"1st Edition\"," +
-                            "\"bookFormat\":\"http://schema.org/EBook\"," +
-                            "\"isbn\":\"031676947\"" +
+                            "\"price\":6.99," +
+                            "\"priceCurrency\":\"USD\"" +
                         "}" +
-                    "]" +
-                "}";
+                    "}," +
+                    "\"bookEdition\":\"2nd Edition\"," +
+                    "\"bookFormat\":\"http://schema.org/Hardcover\"," +
+                    "\"isbn\":\"031676948\"" +
+                "}," +
+                "{" +
+                    "\"@type\":\"Book\"," +
+                    "\"potentialAction\":{" +
+                        "\"@type\":\"ReadAction\"," +
+                        "\"target\":{" +
+                            "\"@type\":\"EntryPoint\"," +
+                            "\"actionPlatform\":[" +
+                                "\"http://schema.org/DesktopWebPlatform\"," +
+                                "\"http://schema.org/IOSPlatform\"," +
+                                "\"http://schema.org/AndroidPlatform\"" +
+                            "]," +
+                            "\"urlTemplate\":\"http://www.barnesandnoble.com/store/info/offer/031676947?purchase=true\"" +
+                        "}," +
+                        "\"expectsAcceptanceOf\":{" +
+                            "\"@type\":\"Offer\"," +
+                            "\"availability\":\"http://schema.org/InStock\"," +
+                            "\"eligibleRegion\":{" +
+                                "\"@type\":\"Country\"," +
+                                "\"name\":\"UK\"" +
+                            "}," +
+                            "\"price\":1.99," +
+                            "\"priceCurrency\":\"USD\"" +
+                        "}" +
+                    "}," +
+                    "\"bookEdition\":\"1st Edition\"," +
+                    "\"bookFormat\":\"http://schema.org/EBook\"," +
+                    "\"isbn\":\"031676947\"" +
+                "}" +
+            "]" +
+        "}";
 
-            var json = book.ToString();
+        [Fact]
+        public void ToString_BookGoogleStructuredData_ReturnsExpectedJsonLd()
+        {
+            Assert.Equal(this.json, this.book.ToString());
+        }
 
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_BookJsonLd_ReturnsBook()
+        {
+            Assert.Equal(this.book.ToString(), JsonConvert.DeserializeObject<Book>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/BookTest.cs
+++ b/Tests/Schema.NET.Test/BookTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/books
     public class BookTest
     {
-        private Book book = new Book()
+        private readonly Book book = new Book()
         {
             Id = new Uri("http://example.com/book/1"),
             Name = "The Catcher in the Rye",
@@ -152,15 +152,11 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_BookGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_BookGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.book.ToString());
-        }
 
         [Fact]
-        public void Deserializing_BookJsonLd_ReturnsBook()
-        {
+        public void Deserializing_BookJsonLd_ReturnsBook() =>
             Assert.Equal(this.book.ToString(), JsonConvert.DeserializeObject<Book>(this.json).ToString());
-        }
     }
 }

--- a/Tests/Schema.NET.Test/BreadcrumbListTest.cs
+++ b/Tests/Schema.NET.Test/BreadcrumbListTest.cs
@@ -59,15 +59,11 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_BreadcrumbListGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_BreadcrumbListGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.breadcrumbList.ToString());
-        }
 
         [Fact]
-        public void Deserializing_BreadcrumbListJsonLd_ReturnsBreadcrumbList()
-        {
+        public void Deserializing_BreadcrumbListJsonLd_ReturnsBreadcrumbList() =>
             Assert.Equal(this.breadcrumbList.ToString(), JsonConvert.DeserializeObject<BreadcrumbList>(this.json).ToString());
-        }
     }
 }

--- a/Tests/Schema.NET.Test/BreadcrumbListTest.cs
+++ b/Tests/Schema.NET.Test/BreadcrumbListTest.cs
@@ -1,67 +1,73 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
     using System.Collections.Generic;
+    using Newtonsoft.Json;
     using Xunit;
 
     public class BreadcrumbListTest
     {
+        private readonly BreadcrumbList breadcrumbList = new BreadcrumbList()
+        {
+            ItemListElement = new List<ListItem>()
+            {
+                new ListItem()
+                {
+                    Position = 1,
+                    Item = new Book()
+                    {
+                        Name = "Books",
+                        Image = new Uri("http://example.com/images/icon-book.png")
+                    }
+                },
+                new ListItem()
+                {
+                    Position = 2,
+                    Item = new Person()
+                    {
+                        Name = "Authors",
+                        Image = new Uri("http://example.com/images/icon-author.png")
+                    }
+                }
+            }
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"BreadcrumbList\"," +
+            "\"itemListElement\":[" +
+                "{" +
+                    "\"@type\":\"ListItem\"," +
+                    "\"item\":{" + // Required
+                        "\"@type\":\"Book\"," +
+                        "\"name\":\"Books\"," + // Required
+                        "\"image\":\"http://example.com/images/icon-book.png\"" + // Optional
+                    "}," +
+                    "\"position\":1" + // Required
+                "}," +
+                "{" +
+                    "\"@type\":\"ListItem\"," +
+                    "\"item\":{" +
+                        "\"@type\":\"Person\"," +
+                        "\"name\":\"Authors\"," +
+                        "\"image\":\"http://example.com/images/icon-author.png\"" +
+                    "}," +
+                    "\"position\":2" +
+                "}" +
+            "]" +
+        "}";
+
         [Fact]
         public void ToString_BreadcrumbListGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var breadcrumbList = new BreadcrumbList()
-            {
-                ItemListElement = new List<ListItem>()
-                {
-                    new ListItem()
-                    {
-                        Position = 1,
-                        Item = new Book()
-                        {
-                            Name = "Books",
-                            Image = new Uri("http://example.com/images/icon-book.png")
-                        }
-                    },
-                    new ListItem()
-                    {
-                        Position = 2,
-                        Item = new Person()
-                        {
-                            Name = "Authors",
-                            Image = new Uri("http://example.com/images/icon-author.png")
-                        }
-                    }
-                }
-            };
-            var expectedJson =
-                "{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"BreadcrumbList\"," +
-                    "\"itemListElement\":[" +
-                        "{" +
-                            "\"@type\":\"ListItem\"," +
-                            "\"item\":{" + // Required
-                                "\"@type\":\"Book\"," +
-                                "\"name\":\"Books\"," + // Required
-                                "\"image\":\"http://example.com/images/icon-book.png\"" + // Optional
-                            "}," +
-                            "\"position\":1" + // Required
-                        "}," +
-                        "{" +
-                            "\"@type\":\"ListItem\"," +
-                            "\"item\":{" +
-                                "\"@type\":\"Person\"," +
-                                "\"name\":\"Authors\"," +
-                                "\"image\":\"http://example.com/images/icon-author.png\"" +
-                            "}," +
-                            "\"position\":2" +
-                        "}" +
-                    "]" +
-                "}";
+            Assert.Equal(this.json, this.breadcrumbList.ToString());
+        }
 
-            var json = breadcrumbList.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_BreadcrumbListJsonLd_ReturnsBreadcrumbList()
+        {
+            Assert.Equal(this.breadcrumbList.ToString(), JsonConvert.DeserializeObject<BreadcrumbList>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/ClaimReviewTest.cs
+++ b/Tests/Schema.NET.Test/ClaimReviewTest.cs
@@ -1,72 +1,83 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/factcheck
     public class ClaimReviewTest
     {
-        // https://developers.google.com/search/docs/data-types/factcheck
+        private readonly ClaimReview claimReview = new ClaimReview()
+        {
+            DatePublished = new DateTimeOffset(2016, 6, 22, 0, 0, 0, TimeSpan.Zero), // Required
+            Url = new Uri("http://example.com/news/science/worldisflat.html"), // Required
+            ItemReviewed = new CreativeWork() // Required
+            {
+                Author = new Organization() // Required
+                {
+                    Name = "Square World Society", // Required
+                    SameAs = new Uri("https://example.flatworlders.com/we-know-that-the-world-is-flat") // Recommended
+                },
+                DatePublished = new DateTimeOffset(2016, 6, 20, 0, 0, 0, TimeSpan.Zero), // Optional
+            },
+            ClaimReviewed = "The world is flat", // Required
+            Author = new Organization() // Required
+            {
+                Name = "Example.com science watch"
+            },
+            ReviewRating = new Rating() // Required
+            {
+                RatingValue = 1D, // Required
+                BestRating = 5D, // Required
+                WorstRating = 1D, // Required
+                AlternateName = "False" // Recommended
+            }
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"ClaimReview\"," +
+            "\"url\":\"http://example.com/news/science/worldisflat.html\"," +
+            "\"author\":{" +
+                "\"@type\":\"Organization\"," +
+                "\"name\":\"Example.com science watch\"" +
+            "}," +
+            "\"datePublished\":\"2016-06-22T00:00:00+00:00\"," +
+            "\"itemReviewed\":{" +
+                "\"@type\":\"CreativeWork\"," +
+                "\"author\":{" +
+                    "\"@type\":\"Organization\"," +
+                    "\"name\":\"Square World Society\"," +
+                    "\"sameAs\":\"https://example.flatworlders.com/we-know-that-the-world-is-flat\"" +
+                "}," +
+                "\"datePublished\":\"2016-06-20T00:00:00+00:00\"" +
+            "}," +
+            "\"reviewRating\":{" +
+                "\"@type\":\"Rating\"," +
+                "\"alternateName\":\"False\"," +
+                "\"bestRating\":5.0," +
+                "\"ratingValue\":1.0," +
+                "\"worstRating\":1.0" +
+            "}," +
+            "\"claimReviewed\":\"The world is flat\"" +
+        "}";
+
         [Fact]
         public void ToString_ClaimReviewGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var claimReview = new ClaimReview()
+            Assert.Equal(this.json, this.claimReview.ToString());
+        }
+
+        [Fact]
+        public void Deserializing_ClaimReviewJsonLd_ReturnsClaimReview()
+        {
+            var serializerSettings = new JsonSerializerSettings
             {
-                DatePublished = new DateTimeOffset(2016, 6, 22, 0, 0, 0, TimeSpan.Zero), // Required
-                Url = new Uri("http://example.com/news/science/worldisflat.html"), // Required
-                ItemReviewed = new CreativeWork() // Required
-                {
-                    Author = new Organization() // Required
-                    {
-                        Name = "Square World Society", // Required
-                        SameAs = new Uri("https://example.flatworlders.com/we-know-that-the-world-is-flat") // Recommended
-                    },
-                    DatePublished = new DateTimeOffset(2016, 6, 20, 0, 0, 0, TimeSpan.Zero), // Optional
-                },
-                ClaimReviewed = "The world is flat", // Required
-                Author = new Organization() // Required
-                {
-                    Name = "Example.com science watch"
-                },
-                ReviewRating = new Rating() // Required
-                {
-                    RatingValue = 1D, // Required
-                    BestRating = 5D, // Required
-                    WorstRating = 1D, // Required
-                    AlternateName = "False" // Recommended
-                }
+                DateParseHandling = DateParseHandling.DateTimeOffset
             };
-            var expectedJson =
-            "{" +
-                "\"@context\":\"http://schema.org\"," +
-                "\"@type\":\"ClaimReview\"," +
-                "\"url\":\"http://example.com/news/science/worldisflat.html\"," +
-                "\"author\":{" +
-                    "\"@type\":\"Organization\"," +
-                    "\"name\":\"Example.com science watch\"" +
-                "}," +
-                "\"datePublished\":\"2016-06-22T00:00:00+00:00\"," +
-                "\"itemReviewed\":{" +
-                    "\"@type\":\"CreativeWork\"," +
-                    "\"author\":{" +
-                        "\"@type\":\"Organization\"," +
-                        "\"name\":\"Square World Society\"," +
-                        "\"sameAs\":\"https://example.flatworlders.com/we-know-that-the-world-is-flat\"" +
-                    "}," +
-                    "\"datePublished\":\"2016-06-20T00:00:00+00:00\"" +
-                "}," +
-                "\"reviewRating\":{" +
-                    "\"@type\":\"Rating\"," +
-                    "\"alternateName\":\"False\"," +
-                    "\"bestRating\":5.0," +
-                    "\"ratingValue\":1.0," +
-                    "\"worstRating\":1.0" +
-                "}," +
-                "\"claimReviewed\":\"The world is flat\"" +
-            "}";
 
-            var json = claimReview.ToString();
-
-            Assert.Equal(expectedJson, json);
+            Assert.Equal(this.claimReview.ToString(), JsonConvert.DeserializeObject<ClaimReview>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/ClaimReviewTest.cs
+++ b/Tests/Schema.NET.Test/ClaimReviewTest.cs
@@ -64,15 +64,13 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_ClaimReviewGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_ClaimReviewGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.claimReview.ToString());
-        }
 
         [Fact]
         public void Deserializing_ClaimReviewJsonLd_ReturnsClaimReview()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/CourseTest.cs
+++ b/Tests/Schema.NET.Test/CourseTest.cs
@@ -1,39 +1,46 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/courses
     public class CourseTest
     {
-        // https://developers.google.com/search/docs/data-types/courses
+        private readonly Course course = new Course()
+        {
+            Name = "Introduction to Computer Science and Programming", // Required
+            Description = "Introductory CS course laying out the basics.", // Required
+            Provider = new Organization() // Recommended
+            {
+                Name = "University of Technology - Eureka",
+                SameAs = new Uri("http://www.ut-eureka.edu")
+            }
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Course\"," +
+            "\"name\":\"Introduction to Computer Science and Programming\"," +
+            "\"description\":\"Introductory CS course laying out the basics.\"," +
+            "\"provider\":{" +
+                "\"@type\":\"Organization\"," +
+                "\"name\":\"University of Technology - Eureka\"," +
+                "\"sameAs\":\"http://www.ut-eureka.edu\"" +
+            "}" +
+        "}";
+
         [Fact]
         public void ToString_CourseGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var course = new Course()
-            {
-                Name = "Introduction to Computer Science and Programming", // Required
-                Description = "Introductory CS course laying out the basics.", // Required
-                Provider = new Organization() // Recommended
-                {
-                    Name = "University of Technology - Eureka",
-                    SameAs = new Uri("http://www.ut-eureka.edu")
-                }
-            };
-            var expectedJson = "{" +
-                "\"@context\":\"http://schema.org\"," +
-                "\"@type\":\"Course\"," +
-                "\"name\":\"Introduction to Computer Science and Programming\"," +
-                "\"description\":\"Introductory CS course laying out the basics.\"," +
-                "\"provider\":{" +
-                    "\"@type\":\"Organization\"," +
-                    "\"name\":\"University of Technology - Eureka\"," +
-                    "\"sameAs\":\"http://www.ut-eureka.edu\"" +
-                "}" +
-            "}";
+            Assert.Equal(this.json, this.course.ToString());
+        }
 
-            var json = course.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_CourseJsonLd_ReturnsCourse()
+        {
+            Assert.Equal(this.course.ToString(), JsonConvert.DeserializeObject<Course>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/CourseTest.cs
+++ b/Tests/Schema.NET.Test/CourseTest.cs
@@ -32,15 +32,11 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_CourseGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_CourseGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.course.ToString());
-        }
 
         [Fact]
-        public void Deserializing_CourseJsonLd_ReturnsCourse()
-        {
+        public void Deserializing_CourseJsonLd_ReturnsCourse() =>
             Assert.Equal(this.course.ToString(), JsonConvert.DeserializeObject<Course>(this.json).ToString());
-        }
     }
 }

--- a/Tests/Schema.NET.Test/EventTest.cs
+++ b/Tests/Schema.NET.Test/EventTest.cs
@@ -76,15 +76,13 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_EventGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_EventGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.@event.ToString());
-        }
 
         [Fact]
         public void Deserializing_EventJsonLd_ReturnsEvent()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/EventTest.cs
+++ b/Tests/Schema.NET.Test/EventTest.cs
@@ -1,84 +1,95 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/events
     public class EventTest
     {
-        // https://developers.google.com/search/docs/data-types/events
+        private readonly Event @event = new Event()
+        {
+            Name = "Jan Lieberman Concert Series: Journey in Jazz", // Required
+            Description = "Join us for an afternoon of Jazz with Santa Clara resident and pianist Andy Lagunoff. Complimentary food and beverages will be served.", // Recommended
+            StartDate = new DateTimeOffset(2017, 4, 24, 19, 30, 0, TimeSpan.FromHours(-8)), // Required
+            Location = new Place() // Required
+            {
+                Name = "Santa Clara City Library, Central Park Library", // Recommended
+                Address = new PostalAddress() // Required
+                {
+                    StreetAddress = "2635 Homestead Rd",
+                    AddressLocality = "Santa Clara",
+                    PostalCode = "95051",
+                    AddressRegion = "CA",
+                    AddressCountry = "US"
+                }
+            },
+            Image = new Uri("http://www.example.com/event_image/12345"), // Recommended
+            EndDate = new DateTimeOffset(2017, 4, 24, 23, 0, 0, TimeSpan.FromHours(-8)), // Recommended
+            Offers = new Offer() // Recommended
+            {
+                Url = new Uri("https://www.example.com/event_offer/12345_201803180430"), // Recommended
+                Price = 30M, // Recommended
+                PriceCurrency = "USD", // Recommended
+                Availability = ItemAvailability.InStock, // Recommended
+                ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)) // Recommended
+            },
+            Performer = new Person() // Recommended
+            {
+                Name = "Andy Lagunoff" // Recommended
+            }
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Event\"," +
+            "\"name\":\"Jan Lieberman Concert Series: Journey in Jazz\"," +
+            "\"description\":\"Join us for an afternoon of Jazz with Santa Clara resident and pianist Andy Lagunoff. Complimentary food and beverages will be served.\"," +
+            "\"image\":\"http://www.example.com/event_image/12345\"," +
+            "\"location\":{" +
+                "\"@type\":\"Place\"," +
+                "\"name\":\"Santa Clara City Library, Central Park Library\"," +
+                "\"address\":{" +
+                    "\"@type\":\"PostalAddress\"," +
+                    "\"addressCountry\":\"US\"," +
+                    "\"addressLocality\":\"Santa Clara\"," +
+                    "\"addressRegion\":\"CA\"," +
+                    "\"postalCode\":\"95051\"," +
+                    "\"streetAddress\":\"2635 Homestead Rd\"" +
+                "}" +
+            "}," +
+            "\"offers\":{" +
+                "\"@type\":\"Offer\"," +
+                "\"url\":\"https://www.example.com/event_offer/12345_201803180430\"," +
+                "\"availability\":\"http://schema.org/InStock\"," +
+                "\"price\":30.0," +
+                "\"priceCurrency\":\"USD\"," +
+                "\"validFrom\":\"2017-01-20T16:20:00-08:00\"" +
+            "}," +
+            "\"performer\":{" +
+                "\"@type\":\"Person\"," +
+                "\"name\":\"Andy Lagunoff\"" +
+            "}," +
+            "\"startDate\":\"2017-04-24T19:30:00-08:00\"," +
+            "\"endDate\":\"2017-04-24T23:00:00-08:00\"" +
+        "}";
+
         [Fact]
         public void ToString_EventGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var @event = new Event()
+            Assert.Equal(this.json, this.@event.ToString());
+        }
+
+        [Fact]
+        public void Deserializing_EventJsonLd_ReturnsEvent()
+        {
+            var serializerSettings = new JsonSerializerSettings
             {
-                Name = "Jan Lieberman Concert Series: Journey in Jazz", // Required
-                Description = "Join us for an afternoon of Jazz with Santa Clara resident and pianist Andy Lagunoff. Complimentary food and beverages will be served.", // Recommended
-                StartDate = new DateTimeOffset(2017, 4, 24, 19, 30, 0, TimeSpan.FromHours(-8)), // Required
-                Location = new Place() // Required
-                {
-                    Name = "Santa Clara City Library, Central Park Library", // Recommended
-                    Address = new PostalAddress() // Required
-                    {
-                        StreetAddress = "2635 Homestead Rd",
-                        AddressLocality = "Santa Clara",
-                        PostalCode = "95051",
-                        AddressRegion = "CA",
-                        AddressCountry = "US"
-                    }
-                },
-                Image = new Uri("http://www.example.com/event_image/12345"), // Recommended
-                EndDate = new DateTimeOffset(2017, 4, 24, 23, 0, 0, TimeSpan.FromHours(-8)), // Recommended
-                Offers = new Offer() // Recommended
-                {
-                    Url = new Uri("https://www.example.com/event_offer/12345_201803180430"), // Recommended
-                    Price = 30M, // Recommended
-                    PriceCurrency = "USD", // Recommended
-                    Availability = ItemAvailability.InStock, // Recommended
-                    ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)) // Recommended
-                },
-                Performer = new Person() // Recommended
-                {
-                    Name = "Andy Lagunoff" // Recommended
-                }
+                DateParseHandling = DateParseHandling.DateTimeOffset
             };
-            var expectedJson =
-                "{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"Event\"," +
-                    "\"name\":\"Jan Lieberman Concert Series: Journey in Jazz\"," +
-                    "\"description\":\"Join us for an afternoon of Jazz with Santa Clara resident and pianist Andy Lagunoff. Complimentary food and beverages will be served.\"," +
-                    "\"image\":\"http://www.example.com/event_image/12345\"," +
-                    "\"location\":{" +
-                        "\"@type\":\"Place\"," +
-                        "\"name\":\"Santa Clara City Library, Central Park Library\"," +
-                        "\"address\":{" +
-                            "\"@type\":\"PostalAddress\"," +
-                            "\"addressCountry\":\"US\"," +
-                            "\"addressLocality\":\"Santa Clara\"," +
-                            "\"addressRegion\":\"CA\"," +
-                            "\"postalCode\":\"95051\"," +
-                            "\"streetAddress\":\"2635 Homestead Rd\"" +
-                        "}" +
-                    "}," +
-                    "\"offers\":{" +
-                        "\"@type\":\"Offer\"," +
-                        "\"url\":\"https://www.example.com/event_offer/12345_201803180430\"," +
-                        "\"availability\":\"http://schema.org/InStock\"," +
-                        "\"price\":30.0," +
-                        "\"priceCurrency\":\"USD\"," +
-                        "\"validFrom\":\"2017-01-20T16:20:00-08:00\"" +
-                    "}," +
-                    "\"performer\":{" +
-                        "\"@type\":\"Person\"," +
-                        "\"name\":\"Andy Lagunoff\"" +
-                    "}," +
-                    "\"startDate\":\"2017-04-24T19:30:00-08:00\"," +
-                    "\"endDate\":\"2017-04-24T23:00:00-08:00\"" +
-                "}";
 
-            var json = @event.ToString();
-
-            Assert.Equal(expectedJson, json);
+            Assert.Equal(this.@event.ToString(), JsonConvert.DeserializeObject<Event>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/ItemListTest.cs
+++ b/Tests/Schema.NET.Test/ItemListTest.cs
@@ -1,7 +1,9 @@
-﻿namespace Schema.NET.Test
+
+namespace Schema.NET.Test
 {
     using System;
     using System.Collections.Generic;
+    using Newtonsoft.Json;
     using Xunit;
 
     public class ItemListTest
@@ -104,6 +106,60 @@
             var json = itemList.ToString();
 
             Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void Deserializing_ItemListJsonLd_ReturnsItemList()
+        {
+            // All items in the list must be of the same type. Recipe, Film, Course, Article, Recipe are supported.
+            var itemList = new ItemList()
+            {
+                ItemListElement = new List<ListItem>() // Required
+                {
+                    new ListItem() // Required
+                    {
+                        Position = 1, // Required
+                        Item = new Recipe() // Required
+                        {
+                            Name = "Recipe 1"
+                        }
+                    },
+                    new ListItem()
+                    {
+                        Position = 2,
+                        Item = new Recipe()
+                        {
+                            Name = "Recipe 2"
+                        }
+                    }
+                }
+            };
+
+            var json =
+            "{" +
+                "\"@context\":\"http://schema.org\"," +
+                "\"@type\":\"ItemList\"," +
+                "\"itemListElement\":[" +
+                    "{" +
+                        "\"@type\":\"ListItem\"," +
+                        "\"item\":{" +
+                            "\"@type\":\"Recipe\"," +
+                            "\"name\":\"Recipe 1\"" +
+                        "}," +
+                        "\"position\":1" +
+                    "}," +
+                    "{" +
+                        "\"@type\":\"ListItem\"," +
+                        "\"item\":{" +
+                            "\"@type\":\"Recipe\"," +
+                            "\"name\":\"Recipe 2\"" +
+                            "}," +
+                        "\"position\":2" +
+                    "}" +
+                "]" +
+            "}";
+
+            Assert.Equal(itemList.ToString(), JsonConvert.DeserializeObject<ItemList>(json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/ItemListTest.cs
+++ b/Tests/Schema.NET.Test/ItemListTest.cs
@@ -1,4 +1,3 @@
-
 namespace Schema.NET.Test
 {
     using System;

--- a/Tests/Schema.NET.Test/JobPostingTest.cs
+++ b/Tests/Schema.NET.Test/JobPostingTest.cs
@@ -96,7 +96,12 @@ namespace Schema.NET.Test
         [Fact]
         public void Deserializing_JobPostingJsonLd_ReturnsJobPosting()
         {
-            Assert.Equal(this.jobPosting.ToString(), JsonConvert.DeserializeObject<JobPosting>(this.json).ToString());
+            var serializerSettings = new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.jobPosting.ToString(), JsonConvert.DeserializeObject<JobPosting>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/JobPostingTest.cs
+++ b/Tests/Schema.NET.Test/JobPostingTest.cs
@@ -88,15 +88,13 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_JobPostingGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_JobPostingGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.jobPosting.ToString());
-        }
 
         [Fact]
         public void Deserializing_JobPostingJsonLd_ReturnsJobPosting()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/JobPostingTest.cs
+++ b/Tests/Schema.NET.Test/JobPostingTest.cs
@@ -1,96 +1,102 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/job-postings
     public class JobPostingTest
     {
-        // https://developers.google.com/search/docs/data-types/job-postings
+        private readonly JobPosting jobPosting = new JobPosting()
+        {
+            Title = "Fitter and Turner", // Required
+            Description = "<p>Widget assembly role for pressing wheel assemblies.</p><p><strong>Educational Requirements:</strong> Completed level 2 ISTA Machinist Apprenticeship.</p><p><strong>Required Experience:</strong> At least 3 years in a machinist role.</p>", // Required
+            Identifier = new PropertyValue() // Recommended
+            {
+                Name = "MagsRUs Wheel Company",
+                Value = "1234567"
+            },
+            DatePosted = new DateTimeOffset(2017, 1, 18, 0, 0, 0, TimeSpan.Zero), // Required
+            ValidThrough = new DateTimeOffset(2017, 3, 18, 0, 0, 0, TimeSpan.Zero), // Required
+            EmploymentType = "CONTRACTOR", // Recommended FULL_TIME, PART_TIME, CONTRACTOR, TEMPORARY,INTERN, VOLUNTEER, PER_DIEM, OTHER
+            HiringOrganization = new Organization() // Required
+            {
+                Name = "MagsRUs Wheel Company",
+                SameAs = new Uri("http://www.magsruswheelcompany.com")
+            },
+            JobLocation = new Place() // Required
+            {
+                Address = new PostalAddress()
+                {
+                    AddressCountry = "US",
+                    AddressLocality = "Detroit",
+                    AddressRegion = "MI",
+                    PostalCode = "48201",
+                    StreetAddress = "555 Clancy St"
+                }
+            },
+            BaseSalary = new MonetaryAmount() // Recommended
+            {
+                Currency = "USD",
+                Value = new QuantitativeValue()
+                {
+                    Value = 40D,
+                    UnitText = "HOUR" // HOUR, WEEK, MONTH, YEAR
+                }
+            }
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"JobPosting\"," +
+            "\"title\":\"Fitter and Turner\"," +
+            "\"description\":\"<p>Widget assembly role for pressing wheel assemblies.</p><p><strong>Educational Requirements:</strong> Completed level 2 ISTA Machinist Apprenticeship.</p><p><strong>Required Experience:</strong> At least 3 years in a machinist role.</p>\"," +
+            "\"identifier\":{" +
+                "\"@type\":\"PropertyValue\"," +
+                "\"name\":\"MagsRUs Wheel Company\"," +
+                "\"value\":\"1234567\"" +
+            "}," +
+            "\"baseSalary\":{" +
+                "\"@type\":\"MonetaryAmount\"," +
+                "\"currency\":\"USD\"," +
+                "\"value\":{" +
+                    "\"@type\":\"QuantitativeValue\"," +
+                    "\"unitText\":\"HOUR\"," +
+                    "\"value\":40.0" +
+                "}" +
+            "}," +
+            "\"datePosted\":\"2017-01-18T00:00:00+00:00\"," +
+            "\"employmentType\":\"CONTRACTOR\"," +
+            "\"hiringOrganization\":{" +
+                "\"@type\":\"Organization\"," +
+                "\"name\":\"MagsRUs Wheel Company\"," +
+                "\"sameAs\":\"http://www.magsruswheelcompany.com\"" +
+            "}," +
+            "\"jobLocation\":{" +
+                "\"@type\":\"Place\"," +
+                "\"address\":{" +
+                    "\"@type\":\"PostalAddress\"," +
+                    "\"addressCountry\":\"US\"," +
+                    "\"addressLocality\":\"Detroit\"," +
+                    "\"addressRegion\":\"MI\"," +
+                    "\"postalCode\":\"48201\"," +
+                    "\"streetAddress\":\"555 Clancy St\"" +
+                "}" +
+            "}," +
+            "\"validThrough\":\"2017-03-18T00:00:00+00:00\"" +
+        "}";
+
         [Fact]
         public void ToString_JobPostingGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var jobPosting = new JobPosting()
-            {
-                Title = "Fitter and Turner", // Required
-                Description = "<p>Widget assembly role for pressing wheel assemblies.</p><p><strong>Educational Requirements:</strong> Completed level 2 ISTA Machinist Apprenticeship.</p><p><strong>Required Experience:</strong> At least 3 years in a machinist role.</p>", // Required
-                Identifier = new PropertyValue() // Recommended
-                {
-                    Name = "MagsRUs Wheel Company",
-                    Value = "1234567"
-                },
-                DatePosted = new DateTimeOffset(2017, 1, 18, 0, 0, 0, TimeSpan.Zero), // Required
-                ValidThrough = new DateTimeOffset(2017, 3, 18, 0, 0, 0, TimeSpan.Zero), // Required
-                EmploymentType = "CONTRACTOR", // Recommended FULL_TIME, PART_TIME, CONTRACTOR, TEMPORARY,INTERN, VOLUNTEER, PER_DIEM, OTHER
-                HiringOrganization = new Organization() // Required
-                {
-                    Name = "MagsRUs Wheel Company",
-                    SameAs = new Uri("http://www.magsruswheelcompany.com")
-                },
-                JobLocation = new Place() // Required
-                {
-                    Address = new PostalAddress()
-                    {
-                        AddressCountry = "US",
-                        AddressLocality = "Detroit",
-                        AddressRegion = "MI",
-                        PostalCode = "48201",
-                        StreetAddress = "555 Clancy St"
-                    }
-                },
-                BaseSalary = new MonetaryAmount() // Recommended
-                {
-                    Currency = "USD",
-                    Value = new QuantitativeValue()
-                    {
-                        Value = 40D,
-                        UnitText = "HOUR" // HOUR, WEEK, MONTH, YEAR
-                    }
-                }
-            };
-            var expectedJson =
-            "{" +
-                "\"@context\":\"http://schema.org\"," +
-                "\"@type\":\"JobPosting\"," +
-                "\"title\":\"Fitter and Turner\"," +
-                "\"description\":\"<p>Widget assembly role for pressing wheel assemblies.</p><p><strong>Educational Requirements:</strong> Completed level 2 ISTA Machinist Apprenticeship.</p><p><strong>Required Experience:</strong> At least 3 years in a machinist role.</p>\"," +
-                "\"identifier\":{" +
-                    "\"@type\":\"PropertyValue\"," +
-                    "\"name\":\"MagsRUs Wheel Company\"," +
-                    "\"value\":\"1234567\"" +
-                "}," +
-                "\"baseSalary\":{" +
-                    "\"@type\":\"MonetaryAmount\"," +
-                    "\"currency\":\"USD\"," +
-                    "\"value\":{" +
-                        "\"@type\":\"QuantitativeValue\"," +
-                        "\"unitText\":\"HOUR\"," +
-                        "\"value\":40.0" +
-                    "}" +
-                "}," +
-                "\"datePosted\":\"2017-01-18T00:00:00+00:00\"," +
-                "\"employmentType\":\"CONTRACTOR\"," +
-                "\"hiringOrganization\":{" +
-                    "\"@type\":\"Organization\"," +
-                    "\"name\":\"MagsRUs Wheel Company\"," +
-                    "\"sameAs\":\"http://www.magsruswheelcompany.com\"" +
-                "}," +
-                "\"jobLocation\":{" +
-                    "\"@type\":\"Place\"," +
-                    "\"address\":{" +
-                        "\"@type\":\"PostalAddress\"," +
-                        "\"addressCountry\":\"US\"," +
-                        "\"addressLocality\":\"Detroit\"," +
-                        "\"addressRegion\":\"MI\"," +
-                        "\"postalCode\":\"48201\"," +
-                        "\"streetAddress\":\"555 Clancy St\"" +
-                    "}" +
-                "}," +
-                "\"validThrough\":\"2017-03-18T00:00:00+00:00\"" +
-            "}";
+            Assert.Equal(this.json, this.jobPosting.ToString());
+        }
 
-            var json = jobPosting.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_JobPostingJsonLd_ReturnsJobPosting()
+        {
+            Assert.Equal(this.jobPosting.ToString(), JsonConvert.DeserializeObject<JobPosting>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/NewsArticleTest.cs
+++ b/Tests/Schema.NET.Test/NewsArticleTest.cs
@@ -67,15 +67,13 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_ArticleGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_ArticleGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.article.ToString());
-        }
 
         [Fact]
         public void Deserializing_NewsArticleJsonLd_ReturnsNewsArticle()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/NewsArticleTest.cs
+++ b/Tests/Schema.NET.Test/NewsArticleTest.cs
@@ -1,75 +1,81 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
     public class NewsArticleTest
     {
+        private readonly NewsArticle article = new NewsArticle()
+        {
+            MainEntityOfPage = new Uri("https://google.com/article"), // Ignored
+            Headline = "Article headline", // Recommended
+            Image = new ImageObject() // Recommended
+            {
+                Url = new Uri("https://google.com/thumbnail1.jpg"), // Recommended
+                Height = 800, // Recommended
+                Width = 800 // Recommended
+            },
+            DatePublished = new DateTimeOffset(2015, 2, 5, 8, 0, 0, TimeSpan.Zero), // Ignored
+            DateModified = new DateTimeOffset(2015, 2, 5, 9, 20, 0, TimeSpan.Zero), // Ignored
+            Author = new Person() // Ignored
+            {
+                Name = "John Doe" // Ignored
+            },
+            Publisher = new Organization() // Ignored
+            {
+                Name = "Google",
+                Logo = new ImageObject() // Ignored
+                {
+                    Url = new Uri("https://google.com/logo.jpg"), // Ignored
+                    Height = 60, // Ignored
+                    Width = 600 // Ignored
+                }
+            },
+            Description = "A most wonderful article" // Ignored
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"NewsArticle\"," +
+            "\"description\":\"A most wonderful article\"," +
+            "\"image\":{" +
+                "\"@type\":\"ImageObject\"," +
+                "\"url\":\"https://google.com/thumbnail1.jpg\"," +
+                "\"height\":800," +
+                "\"width\":800" +
+            "}," +
+            "\"mainEntityOfPage\":\"https://google.com/article\"," +
+            "\"author\":{" +
+                "\"@type\":\"Person\"," +
+                "\"name\":\"John Doe\"" +
+            "}," +
+            "\"dateModified\":\"2015-02-05T09:20:00+00:00\"," +
+            "\"datePublished\":\"2015-02-05T08:00:00+00:00\"," +
+            "\"headline\":\"Article headline\"," +
+            "\"publisher\":{" +
+                "\"@type\":\"Organization\"," +
+                "\"name\":\"Google\"," +
+                "\"logo\":{" +
+                    "\"@type\":\"ImageObject\"," +
+                    "\"url\":\"https://google.com/logo.jpg\"," +
+                    "\"height\":60," +
+                    "\"width\":600" +
+                "}" +
+            "}" +
+        "}";
+
         [Fact]
         public void ToString_ArticleGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var article = new NewsArticle()
-            {
-                MainEntityOfPage = new Uri("https://google.com/article"), // Ignored
-                Headline = "Article headline", // Recommended
-                Image = new ImageObject() // Recommended
-                {
-                    Url = new Uri("https://google.com/thumbnail1.jpg"), // Recommended
-                    Height = 800, // Recommended
-                    Width = 800 // Recommended
-                },
-                DatePublished = new DateTimeOffset(2015, 2, 5, 8, 0, 0, TimeSpan.Zero), // Ignored
-                DateModified = new DateTimeOffset(2015, 2, 5, 9, 20, 0, TimeSpan.Zero), // Ignored
-                Author = new Person() // Ignored
-                {
-                    Name = "John Doe" // Ignored
-                },
-                Publisher = new Organization() // Ignored
-                {
-                    Name = "Google",
-                    Logo = new ImageObject() // Ignored
-                    {
-                        Url = new Uri("https://google.com/logo.jpg"), // Ignored
-                        Height = 60, // Ignored
-                        Width = 600 // Ignored
-                    }
-                },
-                Description = "A most wonderful article" // Ignored
-            };
-            var expectedJson =
-                "{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"NewsArticle\"," +
-                    "\"description\":\"A most wonderful article\"," +
-                    "\"image\":{" +
-                        "\"@type\":\"ImageObject\"," +
-                        "\"url\":\"https://google.com/thumbnail1.jpg\"," +
-                        "\"height\":800," +
-                        "\"width\":800" +
-                    "}," +
-                    "\"mainEntityOfPage\":\"https://google.com/article\"," +
-                    "\"author\":{" +
-                        "\"@type\":\"Person\"," +
-                        "\"name\":\"John Doe\"" +
-                    "}," +
-                    "\"dateModified\":\"2015-02-05T09:20:00+00:00\"," +
-                    "\"datePublished\":\"2015-02-05T08:00:00+00:00\"," +
-                    "\"headline\":\"Article headline\"," +
-                    "\"publisher\":{" +
-                        "\"@type\":\"Organization\"," +
-                        "\"name\":\"Google\"," +
-                        "\"logo\":{" +
-                            "\"@type\":\"ImageObject\"," +
-                            "\"url\":\"https://google.com/logo.jpg\"," +
-                            "\"height\":60," +
-                            "\"width\":600" +
-                        "}" +
-                    "}" +
-                "}";
+            Assert.Equal(this.json, this.article.ToString());
+        }
 
-            var json = article.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_NewsArticleJsonLd_ReturnsNewsArticle()
+        {
+            Assert.Equal(this.article.ToString(), JsonConvert.DeserializeObject<NewsArticle>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/NewsArticleTest.cs
+++ b/Tests/Schema.NET.Test/NewsArticleTest.cs
@@ -75,7 +75,12 @@ namespace Schema.NET.Test
         [Fact]
         public void Deserializing_NewsArticleJsonLd_ReturnsNewsArticle()
         {
-            Assert.Equal(this.article.ToString(), JsonConvert.DeserializeObject<NewsArticle>(this.json).ToString());
+            var serializerSettings = new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.article.ToString(), JsonConvert.DeserializeObject<NewsArticle>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/OrganizationTest.cs
+++ b/Tests/Schema.NET.Test/OrganizationTest.cs
@@ -39,15 +39,11 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_CorporateContactsGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_CorporateContactsGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.organization.ToString());
-        }
 
         [Fact]
-        public void Deserializing_OrganizationJsonLd_ReturnsOrganization()
-        {
+        public void Deserializing_OrganizationJsonLd_ReturnsOrganization() =>
             Assert.Equal(this.organization.ToString(), JsonConvert.DeserializeObject<Organization>(this.json).ToString());
-        }
     }
 }

--- a/Tests/Schema.NET.Test/OrganizationTest.cs
+++ b/Tests/Schema.NET.Test/OrganizationTest.cs
@@ -1,66 +1,53 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/corporate-contacts
+    // https://developers.google.com/search/docs/data-types/logo
     public class OrganizationTest
     {
-        // https://developers.google.com/search/docs/data-types/corporate-contacts
+        private readonly Organization organization = new Organization()
+        {
+            AreaServed = "GB", // Recommended. Omit for global.
+            ContactPoint = new ContactPoint() // Required
+            {
+                AvailableLanguage = "English", // Recommended
+                ContactOption = ContactPointOption.TollFree, // Recommended
+                ContactType = "customer service", // Required
+                Telephone = "+1-401-555-1212" // Required
+            },
+            Url = new Uri("https://example.com"), // Required
+            Logo = new Uri("https://example.com/logo.png")
+        };
+
+        private readonly string json =
+        @"{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Organization\"," +
+            "\"url\":\"https://example.com\"," +
+            "\"areaServed\":\"GB\"," +
+            "\"contactPoint\":{" +
+                "\"@type\":\"ContactPoint\"," +
+                "\"availableLanguage\":\"English\"," +
+                "\"contactOption\":\"http://schema.org/TollFree\"," +
+                "\"contactType\":\"customer service\"," +
+                "\"telephone\":\"+1-401-555-1212\"" +
+            "}," +
+            "\"logo\":\"https://example.com/logo.png\"" +
+        "}";
+
         [Fact]
         public void ToString_CorporateContactsGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var organization = new Organization()
-            {
-                AreaServed = "GB", // Recommended. Omit for global.
-                ContactPoint = new ContactPoint() // Required
-                {
-                    AvailableLanguage = "English", // Recommended
-                    ContactOption = ContactPointOption.TollFree, // Recommended
-                    ContactType = "customer service", // Required
-                    Telephone = "+1-401-555-1212" // Required
-                },
-                Url = new Uri("https://example.com") // Required
-            };
-            var expectedJson =
-                @"{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"Organization\"," +
-                    "\"url\":\"https://example.com\"," +
-                    "\"areaServed\":\"GB\"," +
-                    "\"contactPoint\":{" +
-                        "\"@type\":\"ContactPoint\"," +
-                        "\"availableLanguage\":\"English\"," +
-                        "\"contactOption\":\"http://schema.org/TollFree\"," +
-                        "\"contactType\":\"customer service\"," +
-                        "\"telephone\":\"+1-401-555-1212\"" +
-                    "}" +
-                "}";
-
-            var json = organization.ToString();
-
-            Assert.Equal(expectedJson, json);
+            Assert.Equal(this.json, this.organization.ToString());
         }
 
-        // https://developers.google.com/search/docs/data-types/logo
         [Fact]
-        public void ToString_LogoGoogleStructuredData_ReturnsExpectedJsonLd()
+        public void Deserializing_OrganizationJsonLd_ReturnsOrganization()
         {
-            var organization = new Organization()
-            {
-                Logo = new Uri("https://example.com/logo.png"), // Required
-                Url = new Uri("https://example.com") // Required
-            };
-            var expectedJson =
-                @"{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"Organization\"," +
-                    "\"url\":\"https://example.com\"," +
-                    "\"logo\":\"https://example.com/logo.png\"" +
-                "}";
-
-            var json = organization.ToString();
-
-            Assert.Equal(expectedJson, json);
+            Assert.Equal(this.organization.ToString(), JsonConvert.DeserializeObject<Organization>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/PersonTest.cs
+++ b/Tests/Schema.NET.Test/PersonTest.cs
@@ -36,15 +36,11 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_SiteNameGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_SiteNameGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.person.ToString());
-        }
 
         [Fact]
-        public void Deserializing_PersonJsonLd_ReturnsPerson()
-        {
+        public void Deserializing_PersonJsonLd_ReturnsPerson() =>
             Assert.Equal(this.person.ToString(), JsonConvert.DeserializeObject<Person>(this.json).ToString());
-        }
     }
 }

--- a/Tests/Schema.NET.Test/PersonTest.cs
+++ b/Tests/Schema.NET.Test/PersonTest.cs
@@ -1,44 +1,50 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
     using System.Collections.Generic;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/social-profile-links
     public class PersonTest
     {
-        // https://developers.google.com/search/docs/data-types/social-profile-links
+        private readonly Person person = new Person()
+        {
+            Name = "Name", // Required
+            SameAs = new List<Uri>() // Required
+            {
+                new Uri("http://www.facebook.com/your-profile"),
+                new Uri("http://instagram.com/yourProfile"),
+                new Uri("http://www.linkedin.com/in/yourprofile"),
+                new Uri("http://plus.google.com/your_profile")
+            },
+            Url = new Uri("https://example.com") // Required
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Person\"," +
+            "\"name\":\"Name\"," +
+            "\"sameAs\":[" +
+                "\"http://www.facebook.com/your-profile\"," +
+                "\"http://instagram.com/yourProfile\"," +
+                "\"http://www.linkedin.com/in/yourprofile\"," +
+                "\"http://plus.google.com/your_profile\"" +
+            "]," +
+            "\"url\":\"https://example.com\"" +
+        "}";
+
         [Fact]
         public void ToString_SiteNameGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var person = new Person()
-            {
-                Name = "Name", // Required
-                SameAs = new List<Uri>() // Required
-                {
-                    new Uri("http://www.facebook.com/your-profile"),
-                    new Uri("http://instagram.com/yourProfile"),
-                    new Uri("http://www.linkedin.com/in/yourprofile"),
-                    new Uri("http://plus.google.com/your_profile")
-                },
-                Url = new Uri("https://example.com") // Required
-            };
-            var expectedJson =
-                "{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"Person\"," +
-                    "\"name\":\"Name\"," +
-                    "\"sameAs\":[" +
-                        "\"http://www.facebook.com/your-profile\"," +
-                        "\"http://instagram.com/yourProfile\"," +
-                        "\"http://www.linkedin.com/in/yourprofile\"," +
-                        "\"http://plus.google.com/your_profile\"" +
-                    "]," +
-                    "\"url\":\"https://example.com\"" +
-                "}";
+            Assert.Equal(this.json, this.person.ToString());
+        }
 
-            var json = person.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_PersonJsonLd_ReturnsPerson()
+        {
+            Assert.Equal(this.person.ToString(), JsonConvert.DeserializeObject<Person>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/ProductTest.cs
+++ b/Tests/Schema.NET.Test/ProductTest.cs
@@ -1,79 +1,85 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/products
     public class ProductTest
     {
-        // https://developers.google.com/search/docs/data-types/products
+        private readonly Product product = new Product()
+        {
+            Name = "Executive Anvil", // Required
+            Description = "Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveller looking for something to drop from a height.", // Recommended
+            Image = new Uri("http://www.example.com/anvil_executive.jpg"), // Required
+            Mpn = "925872", // Recommended
+            Brand = new Brand() // Recommended
+            {
+                Name = "ACME"
+            },
+            AggregateRating = new AggregateRating() // Recommended
+            {
+                ReviewCount = 89,
+                RatingValue = 4.4D
+            },
+            Review = null, // Recommended
+            Offers = new Offer() // Recommended
+            {
+                Url = null, // Recommended
+                ItemOffered = null, // Recommended
+                PriceCurrency = "USD", // Required
+                Price = 119.99M, // Required
+                PriceValidUntil = new DateTimeOffset(2020, 11, 5, 0, 0, 0, TimeSpan.Zero), // Recommended
+                ItemCondition = OfferItemCondition.UsedCondition,
+                Availability = ItemAvailability.InStock, // Recommended
+                Seller = new Organization()
+                {
+                    Name = "Executive Objects"
+                }
+            }
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Product\"," +
+            "\"name\":\"Executive Anvil\"," +
+            "\"description\":\"Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveller looking for something to drop from a height.\"," +
+            "\"image\":\"http://www.example.com/anvil_executive.jpg\"," +
+            "\"aggregateRating\":{" +
+                "\"@type\":\"AggregateRating\"," +
+                "\"ratingValue\":4.4," +
+                "\"reviewCount\":89" +
+            "}," +
+            "\"brand\":{" +
+                "\"@type\":\"Brand\"," +
+                "\"name\":\"ACME\"" +
+            "}," +
+            "\"mpn\":\"925872\"," +
+            "\"offers\":{" +
+                "\"@type\":\"Offer\"," +
+                "\"availability\":\"http://schema.org/InStock\"," +
+                "\"itemCondition\":\"http://schema.org/UsedCondition\"," +
+                "\"price\":119.99," +
+                "\"priceCurrency\":\"USD\"," +
+                "\"priceValidUntil\":\"2020-11-05T00:00:00+00:00\"," +
+                "\"seller\":{" +
+                    "\"@type\":\"Organization\"," +
+                    "\"name\":\"Executive Objects\"" +
+                "}" +
+            "}" +
+        "}";
+
         [Fact]
         public void ToString_ProductGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var product = new Product()
-            {
-                Name = "Executive Anvil", // Required
-                Description = "Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveller looking for something to drop from a height.", // Recommended
-                Image = new Uri("http://www.example.com/anvil_executive.jpg"), // Required
-                Mpn = "925872", // Recommended
-                Brand = new Brand() // Recommended
-                {
-                    Name = "ACME"
-                },
-                AggregateRating = new AggregateRating() // Recommended
-                {
-                    ReviewCount = 89,
-                    RatingValue = 4.4D
-                },
-                Review = null, // Recommended
-                Offers = new Offer() // Recommended
-                {
-                    Url = null, // Recommended
-                    ItemOffered = null, // Recommended
-                    PriceCurrency = "USD", // Required
-                    Price = 119.99M, // Required
-                    PriceValidUntil = new DateTimeOffset(2020, 11, 5, 0, 0, 0, TimeSpan.Zero), // Recommended
-                    ItemCondition = OfferItemCondition.UsedCondition,
-                    Availability = ItemAvailability.InStock, // Recommended
-                    Seller = new Organization()
-                    {
-                        Name = "Executive Objects"
-                    }
-                }
-            };
-            var expectedJson =
-            "{" +
-                "\"@context\":\"http://schema.org\"," +
-                "\"@type\":\"Product\"," +
-                "\"name\":\"Executive Anvil\"," +
-                "\"description\":\"Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveller looking for something to drop from a height.\"," +
-                "\"image\":\"http://www.example.com/anvil_executive.jpg\"," +
-                "\"aggregateRating\":{" +
-                    "\"@type\":\"AggregateRating\"," +
-                    "\"ratingValue\":4.4," +
-                    "\"reviewCount\":89" +
-                "}," +
-                "\"brand\":{" +
-                    "\"@type\":\"Brand\"," +
-                    "\"name\":\"ACME\"" +
-                "}," +
-                "\"mpn\":\"925872\"," +
-                "\"offers\":{" +
-                    "\"@type\":\"Offer\"," +
-                    "\"availability\":\"http://schema.org/InStock\"," +
-                    "\"itemCondition\":\"http://schema.org/UsedCondition\"," +
-                    "\"price\":119.99," +
-                    "\"priceCurrency\":\"USD\"," +
-                    "\"priceValidUntil\":\"2020-11-05T00:00:00+00:00\"," +
-                    "\"seller\":{" +
-                        "\"@type\":\"Organization\"," +
-                        "\"name\":\"Executive Objects\"" +
-                    "}" +
-                "}" +
-            "}";
+            Assert.Equal(this.json, this.product.ToString());
+        }
 
-            var json = product.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_ProductJsonLd_ReturnsProduct()
+        {
+            Assert.Equal(this.product.ToString(), JsonConvert.DeserializeObject<Product>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/ProductTest.cs
+++ b/Tests/Schema.NET.Test/ProductTest.cs
@@ -79,7 +79,12 @@ namespace Schema.NET.Test
         [Fact]
         public void Deserializing_ProductJsonLd_ReturnsProduct()
         {
-            Assert.Equal(this.product.ToString(), JsonConvert.DeserializeObject<Product>(this.json).ToString());
+            var serializerSettings = new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.product.ToString(), JsonConvert.DeserializeObject<Product>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/ProductTest.cs
+++ b/Tests/Schema.NET.Test/ProductTest.cs
@@ -71,15 +71,13 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_ProductGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_ProductGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.product.ToString());
-        }
 
         [Fact]
         public void Deserializing_ProductJsonLd_ReturnsProduct()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/RecipeTest.cs
+++ b/Tests/Schema.NET.Test/RecipeTest.cs
@@ -84,7 +84,12 @@ namespace Schema.NET.Test
         [Fact]
         public void Deserializing_RecipeJsonLd_ReturnsRecipe()
         {
-            Assert.Equal(this.recipe.ToString(), JsonConvert.DeserializeObject<Recipe>(this.json).ToString());
+            var serializerSettings = new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.recipe.ToString(), JsonConvert.DeserializeObject<Recipe>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/RecipeTest.cs
+++ b/Tests/Schema.NET.Test/RecipeTest.cs
@@ -76,15 +76,13 @@ namespace Schema.NET.Test
             "}";
 
         [Fact]
-        public void ToString_CarouselGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_CarouselGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.recipe.ToString());
-        }
 
         [Fact]
         public void Deserializing_RecipeJsonLd_ReturnsRecipe()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/RecipeTest.cs
+++ b/Tests/Schema.NET.Test/RecipeTest.cs
@@ -2,83 +2,89 @@ namespace Schema.NET.Test
 {
     using System;
     using System.Collections.Generic;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/guides/mark-up-listings
     public class RecipeTest
     {
-        // https://developers.google.com/search/docs/guides/mark-up-listings
+        private readonly Recipe recipe = new Recipe()
+        {
+            Name = "Grandma's Holiday Apple Pie",
+            Image = new Uri("https://example.com/image.jpg"),
+            Author = new Person()
+            {
+                Name = "Carol Smith"
+            },
+            DatePublished = new DateTimeOffset(2009, 11, 5, 0, 0, 0, TimeSpan.Zero),
+            Description = "This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.",
+            AggregateRating = new AggregateRating()
+            {
+                RatingValue = 4D,
+                ReviewCount = 35
+            },
+            PrepTime = new TimeSpan(0, 30, 0),
+            CookTime = new TimeSpan(1, 0, 0),
+            TotalTime = new TimeSpan(1, 30, 0),
+            RecipeYield = "1 9 inch pie (8 servings)",
+            Nutrition = new NutritionInformation()
+            {
+                ServingSize = "1 medium slice",
+                Calories = "250 cal",
+                FatContent = "12 g"
+            },
+            RecipeIngredient = new List<string>()
+            {
+                "Thinly-sliced apples:6 cups",
+                "White sugar:3/4 cup"
+            },
+            RecipeInstructions = "1. Cut and peel apples..."
+        };
+
+        private readonly string json =
+            "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Recipe\"," +
+            "\"name\":\"Grandma's Holiday Apple Pie\"," +
+            "\"description\":\"This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.\"," +
+            "\"image\":\"https://example.com/image.jpg\"," +
+            "\"aggregateRating\":{" +
+                "\"@type\":\"AggregateRating\"," +
+                "\"ratingValue\":4.0," +
+                "\"reviewCount\":35" +
+            "}," +
+            "\"author\":{" +
+                "\"@type\":\"Person\"," +
+                "\"name\":\"Carol Smith\"" +
+            "}," +
+            "\"datePublished\":\"2009-11-05T00:00:00+00:00\"," +
+            "\"prepTime\":\"PT30M\"," +
+            "\"totalTime\":\"PT1H30M\"," +
+            "\"cookTime\":\"PT1H\"," +
+            "\"nutrition\":{" +
+                "\"@type\":\"NutritionInformation\"," +
+                "\"calories\":\"250 cal\"," +
+                "\"fatContent\":\"12 g\"," +
+                "\"servingSize\":\"1 medium slice\"" +
+            "}," +
+            "\"recipeIngredient\":[" +
+                "\"Thinly-sliced apples:6 cups\"," +
+                "\"White sugar:3/4 cup\"" +
+            "]," +
+            "\"recipeInstructions\":\"1. Cut and peel apples...\"," +
+            "\"recipeYield\":\"1 9 inch pie (8 servings)\"" +
+            "}";
+
         [Fact]
         public void ToString_CarouselGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var recipe = new Recipe()
-            {
-                Name = "Grandma's Holiday Apple Pie",
-                Image = new Uri("https://example.com/image.jpg"),
-                Author = new Person()
-                {
-                    Name = "Carol Smith"
-                },
-                DatePublished = new DateTimeOffset(2009, 11, 5, 0, 0, 0, TimeSpan.Zero),
-                Description = "This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.",
-                AggregateRating = new AggregateRating()
-                {
-                    RatingValue = 4D,
-                    ReviewCount = 35
-                },
-                PrepTime = new TimeSpan(0, 30, 0),
-                CookTime = new TimeSpan(1, 0, 0),
-                TotalTime = new TimeSpan(1, 30, 0),
-                RecipeYield = "1 9 inch pie (8 servings)",
-                Nutrition = new NutritionInformation()
-                {
-                    ServingSize = "1 medium slice",
-                    Calories = "250 cal",
-                    FatContent = "12 g"
-                },
-                RecipeIngredient = new List<string>()
-                {
-                    "Thinly-sliced apples:6 cups",
-                    "White sugar:3/4 cup"
-                },
-                RecipeInstructions = "1. Cut and peel apples..."
-            };
-            var expectedJson =
-                "{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"Recipe\"," +
-                    "\"name\":\"Grandma's Holiday Apple Pie\"," +
-                    "\"description\":\"This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.\"," +
-                    "\"image\":\"https://example.com/image.jpg\"," +
-                    "\"aggregateRating\":{" +
-                        "\"@type\":\"AggregateRating\"," +
-                        "\"ratingValue\":4.0," +
-                        "\"reviewCount\":35" +
-                    "}," +
-                    "\"author\":{" +
-                        "\"@type\":\"Person\"," +
-                        "\"name\":\"Carol Smith\"" +
-                    "}," +
-                    "\"datePublished\":\"2009-11-05T00:00:00+00:00\"," +
-                    "\"prepTime\":\"PT30M\"," +
-                    "\"totalTime\":\"PT1H30M\"," +
-                    "\"cookTime\":\"PT1H\"," +
-                    "\"nutrition\":{" +
-                        "\"@type\":\"NutritionInformation\"," +
-                        "\"calories\":\"250 cal\"," +
-                        "\"fatContent\":\"12 g\"," +
-                        "\"servingSize\":\"1 medium slice\"" +
-                    "}," +
-                    "\"recipeIngredient\":[" +
-                        "\"Thinly-sliced apples:6 cups\"," +
-                        "\"White sugar:3/4 cup\"" +
-                    "]," +
-                    "\"recipeInstructions\":\"1. Cut and peel apples...\"," +
-                    "\"recipeYield\":\"1 9 inch pie (8 servings)\"" +
-                 "}";
+            Assert.Equal(this.json, this.recipe.ToString());
+        }
 
-            var json = recipe.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_RecipeJsonLd_ReturnsRecipe()
+        {
+            Assert.Equal(this.recipe.ToString(), JsonConvert.DeserializeObject<Recipe>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/RestaurantTest.cs
+++ b/Tests/Schema.NET.Test/RestaurantTest.cs
@@ -118,15 +118,13 @@ namespace Schema.NET.Test
         "}";
 
         [Fact]
-        public void ToString_RestaurantGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_RestaurantGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.restaurant.ToString());
-        }
 
         [Fact]
         public void Deserializing_RestaurantJsonLd_ReturnsRestaurant()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/RestaurantTest.cs
+++ b/Tests/Schema.NET.Test/RestaurantTest.cs
@@ -126,7 +126,12 @@ namespace Schema.NET.Test
         [Fact]
         public void Deserializing_RestaurantJsonLd_ReturnsRestaurant()
         {
-            Assert.Equal(this.restaurant.ToString(), JsonConvert.DeserializeObject<Restaurant>(this.json).ToString());
+            var serializerSettings = new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.restaurant.ToString(), JsonConvert.DeserializeObject<Restaurant>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/RestaurantTest.cs
+++ b/Tests/Schema.NET.Test/RestaurantTest.cs
@@ -1,126 +1,132 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/local-businesses
     public class RestaurantTest
     {
-        // https://developers.google.com/search/docs/data-types/local-businesses
+        private readonly Restaurant restaurant = new Restaurant()
+        {
+            Id = new Uri("http://davessteakhouse.example.com"),
+            Name = "Dave's Steak House",
+            Image = new Uri("http://davessteakhouse.example.com/logo.jpg"),
+            SameAs = new Uri("http://davessteakhouse.example.com"),
+            ServesCuisine = "Steak House",
+            PriceRange = "$$$",
+            Address = new PostalAddress()
+            {
+                AddressCountry = "US",
+                AddressLocality = "New York",
+                AddressRegion = "NY",
+                PostalCode = "10019",
+                StreetAddress = "148 W 51st St"
+            },
+            Telephone = "+12122459600",
+            Geo = new GeoCoordinates()
+            {
+                Latitude = 40.761293D,
+                Longitude = -73.982294
+            },
+            AggregateRating = new AggregateRating()
+            {
+                RatingValue = 88D,
+                BestRating = 100D,
+                WorstRating = 1D,
+                RatingCount = 20
+            },
+            Review = new Review()
+            {
+                Description = "Great old fashioned steaks but the salads are sub par.",
+                Url = new Uri("http://www.localreviews.com/restaurants/1/2/3/daves-steak-house.html"),
+                Author = new Person()
+                {
+                    Name = "Lisa Kennedy",
+                    SameAs = new Uri("https://plus.google.com/114108465800532712602")
+                },
+                Publisher = new Organization()
+                {
+                    Name = "Denver Post",
+                    SameAs = new Uri("http://www.denverpost.com")
+                },
+                DatePublished = new DateTimeOffset(2014, 3, 13, 20, 0, 0, TimeSpan.Zero),
+                InLanguage = "en",
+                ReviewRating = new Rating()
+                {
+                    WorstRating = 1D,
+                    BestRating = 4D,
+                    RatingValue = 3.5
+                }
+            }
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Restaurant\"," +
+            "\"@id\":\"http://davessteakhouse.example.com\"," +
+            "\"name\":\"Dave's Steak House\"," +
+            "\"image\":\"http://davessteakhouse.example.com/logo.jpg\"," +
+            "\"sameAs\":\"http://davessteakhouse.example.com\"," +
+            "\"address\":{" +
+                "\"@type\":\"PostalAddress\"," +
+                "\"addressCountry\":\"US\"," +
+                "\"addressLocality\":\"New York\"," +
+                "\"addressRegion\":\"NY\"," +
+                "\"postalCode\":\"10019\"," +
+                "\"streetAddress\":\"148 W 51st St\"" +
+            "}," +
+            "\"aggregateRating\":{" +
+                "\"@type\":\"AggregateRating\"," +
+                "\"bestRating\":100.0," +
+                "\"ratingValue\":88.0," +
+                "\"worstRating\":1.0," +
+                "\"ratingCount\":20" +
+            "}," +
+            "\"geo\":{" +
+                "\"@type\":\"GeoCoordinates\"," +
+                "\"latitude\":40.761293," +
+                "\"longitude\":-73.982294" +
+            "}," +
+            "\"review\":{" +
+                "\"@type\":\"Review\"," +
+                "\"description\":\"Great old fashioned steaks but the salads are sub par.\"," +
+                "\"url\":\"http://www.localreviews.com/restaurants/1/2/3/daves-steak-house.html\"," +
+                "\"author\":{" +
+                    "\"@type\":\"Person\"," +
+                    "\"name\":\"Lisa Kennedy\"," +
+                    "\"sameAs\":\"https://plus.google.com/114108465800532712602\"" +
+                "}," +
+                "\"datePublished\":\"2014-03-13T20:00:00+00:00\"," +
+                "\"inLanguage\":\"en\"," +
+                "\"publisher\":{" +
+                    "\"@type\":\"Organization\"," +
+                    "\"name\":\"Denver Post\"," +
+                    "\"sameAs\":\"http://www.denverpost.com\"" +
+                "}," +
+                "\"reviewRating\":{" +
+                    "\"@type\":\"Rating\"," +
+                    "\"bestRating\":4.0," +
+                    "\"ratingValue\":3.5," +
+                    "\"worstRating\":1.0" +
+                "}" +
+            "}," +
+            "\"telephone\":\"+12122459600\"," +
+            "\"priceRange\":\"$$$\"," +
+            "\"servesCuisine\":\"Steak House\"" +
+        "}";
+
         [Fact]
         public void ToString_RestaurantGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var restaurant = new Restaurant()
-            {
-                Id = new Uri("http://davessteakhouse.example.com"),
-                Name = "Dave's Steak House",
-                Image = new Uri("http://davessteakhouse.example.com/logo.jpg"),
-                SameAs = new Uri("http://davessteakhouse.example.com"),
-                ServesCuisine = "Steak House",
-                PriceRange = "$$$",
-                Address = new PostalAddress()
-                {
-                    AddressCountry = "US",
-                    AddressLocality = "New York",
-                    AddressRegion = "NY",
-                    PostalCode = "10019",
-                    StreetAddress = "148 W 51st St"
-                },
-                Telephone = "+12122459600",
-                Geo = new GeoCoordinates()
-                {
-                    Latitude = 40.761293D,
-                    Longitude = -73.982294
-                },
-                AggregateRating = new AggregateRating()
-                {
-                    RatingValue = 88D,
-                    BestRating = 100D,
-                    WorstRating = 1D,
-                    RatingCount = 20
-                },
-                Review = new Review()
-                {
-                    Description = "Great old fashioned steaks but the salads are sub par.",
-                    Url = new Uri("http://www.localreviews.com/restaurants/1/2/3/daves-steak-house.html"),
-                    Author = new Person()
-                    {
-                        Name = "Lisa Kennedy",
-                        SameAs = new Uri("https://plus.google.com/114108465800532712602")
-                    },
-                    Publisher = new Organization()
-                    {
-                        Name = "Denver Post",
-                        SameAs = new Uri("http://www.denverpost.com")
-                    },
-                    DatePublished = new DateTimeOffset(2014, 3, 13, 20, 0, 0, TimeSpan.Zero),
-                    InLanguage = "en",
-                    ReviewRating = new Rating()
-                    {
-                        WorstRating = 1D,
-                        BestRating = 4D,
-                        RatingValue = 3.5
-                    }
-                }
-            };
-            var expectedJson =
-            "{" +
-                "\"@context\":\"http://schema.org\"," +
-                "\"@type\":\"Restaurant\"," +
-                "\"@id\":\"http://davessteakhouse.example.com\"," +
-                "\"name\":\"Dave's Steak House\"," +
-                "\"image\":\"http://davessteakhouse.example.com/logo.jpg\"," +
-                "\"sameAs\":\"http://davessteakhouse.example.com\"," +
-                "\"address\":{" +
-                    "\"@type\":\"PostalAddress\"," +
-                    "\"addressCountry\":\"US\"," +
-                    "\"addressLocality\":\"New York\"," +
-                    "\"addressRegion\":\"NY\"," +
-                    "\"postalCode\":\"10019\"," +
-                    "\"streetAddress\":\"148 W 51st St\"" +
-                "}," +
-                "\"aggregateRating\":{" +
-                    "\"@type\":\"AggregateRating\"," +
-                    "\"bestRating\":100.0," +
-                    "\"ratingValue\":88.0," +
-                    "\"worstRating\":1.0," +
-                    "\"ratingCount\":20" +
-                "}," +
-                "\"geo\":{" +
-                    "\"@type\":\"GeoCoordinates\"," +
-                    "\"latitude\":40.761293," +
-                    "\"longitude\":-73.982294" +
-                "}," +
-                "\"review\":{" +
-                    "\"@type\":\"Review\"," +
-                    "\"description\":\"Great old fashioned steaks but the salads are sub par.\"," +
-                    "\"url\":\"http://www.localreviews.com/restaurants/1/2/3/daves-steak-house.html\"," +
-                    "\"author\":{" +
-                        "\"@type\":\"Person\"," +
-                        "\"name\":\"Lisa Kennedy\"," +
-                        "\"sameAs\":\"https://plus.google.com/114108465800532712602\"" +
-                    "}," +
-                    "\"datePublished\":\"2014-03-13T20:00:00+00:00\"," +
-                    "\"inLanguage\":\"en\"," +
-                    "\"publisher\":{" +
-                        "\"@type\":\"Organization\"," +
-                        "\"name\":\"Denver Post\"," +
-                        "\"sameAs\":\"http://www.denverpost.com\"" +
-                    "}," +
-                    "\"reviewRating\":{" +
-                        "\"@type\":\"Rating\"," +
-                        "\"bestRating\":4.0," +
-                        "\"ratingValue\":3.5," +
-                        "\"worstRating\":1.0" +
-                    "}" +
-                "}," +
-                "\"telephone\":\"+12122459600\"," +
-                "\"priceRange\":\"$$$\"," +
-                "\"servesCuisine\":\"Steak House\"" +
-            "}";
+            Assert.Equal(this.json, this.restaurant.ToString());
+        }
 
-            var json = restaurant.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_RestaurantJsonLd_ReturnsRestaurant()
+        {
+            Assert.Equal(this.restaurant.ToString(), JsonConvert.DeserializeObject<Restaurant>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.137" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.0-beta004" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Label="Tools">

--- a/Tests/Schema.NET.Test/VideoObjectTest.cs
+++ b/Tests/Schema.NET.Test/VideoObjectTest.cs
@@ -1,70 +1,76 @@
 namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
+    // https://developers.google.com/search/docs/data-types/articles
     public class VideoObjectTest
     {
-        // https://developers.google.com/search/docs/data-types/articles
+        private readonly VideoObject videoObject = new VideoObject()
+        {
+            Name = "Title", // Required
+            Description = "Video description", // Required
+            ThumbnailUrl = new Uri("https://www.example.com/thumbnail.jpg"), // Required
+            Expires = new DateTimeOffset(2016, 2, 5, 8, 0, 0, TimeSpan.Zero), // Recommended
+            UploadDate = new DateTimeOffset(2015, 2, 5, 8, 0, 0, TimeSpan.Zero), // Required
+            Duration = new TimeSpan(0, 1, 33), // Recommended
+            Publisher = new Organization()
+            {
+                Name = "Example Publisher", // Required
+                Logo = new ImageObject() // Required
+                {
+                    Height = 60, // Required
+                    Url = new Uri("https://example.com/logo.jpg"), // Required
+                    Width = 600 // Required
+                }
+            },
+            ContentUrl = new Uri("https://www.example.com/video123.flv"), // Recommended
+            EmbedUrl = new Uri("https://www.example.com/videoplayer.swf?video=123"), // Recommended
+            InteractionStatistic = new InteractionCounter()
+            {
+                UserInteractionCount = 2347 // Recommended
+            },
+        };
+
+        private readonly string json =
+            "{" +
+                "\"@context\":\"http://schema.org\"," +
+                "\"@type\":\"VideoObject\"," +
+                "\"name\":\"Title\"," +
+                "\"description\":\"Video description\"," +
+                "\"expires\":\"2016-02-05T08:00:00+00:00\"," +
+                "\"interactionStatistic\":{" +
+                    "\"@type\":\"InteractionCounter\"," +
+                    "\"userInteractionCount\":2347" +
+                "}," +
+                "\"publisher\":{" +
+                    "\"@type\":\"Organization\"," +
+                    "\"name\":\"Example Publisher\"," +
+                    "\"logo\":{" +
+                        "\"@type\":\"ImageObject\"," +
+                        "\"url\":\"https://example.com/logo.jpg\"," +
+                        "\"height\":60," +
+                        "\"width\":600" +
+                    "}" +
+                "}," +
+                "\"thumbnailUrl\":\"https://www.example.com/thumbnail.jpg\"," +
+                "\"contentUrl\":\"https://www.example.com/video123.flv\"," +
+                "\"duration\":\"PT1M33S\"," +
+                "\"embedUrl\":\"https://www.example.com/videoplayer.swf?video=123\"," +
+                "\"uploadDate\":\"2015-02-05T08:00:00+00:00\"" +
+            "}";
+
         [Fact]
         public void ToString_VideoGoogleStructuredData_ReturnsExpectedJsonLd()
         {
-            var videoObject = new VideoObject()
-            {
-                Name = "Title", // Required
-                Description = "Video description", // Required
-                ThumbnailUrl = new Uri("https://www.example.com/thumbnail.jpg"), // Required
-                Expires = new DateTimeOffset(2016, 2, 5, 8, 0, 0, TimeSpan.Zero), // Recommended
-                UploadDate = new DateTimeOffset(2015, 2, 5, 8, 0, 0, TimeSpan.Zero), // Required
-                Duration = new TimeSpan(0, 1, 33), // Recommended
-                Publisher = new Organization()
-                {
-                    Name = "Example Publisher", // Required
-                    Logo = new ImageObject() // Required
-                    {
-                        Height = 60, // Required
-                        Url = new Uri("https://example.com/logo.jpg"), // Required
-                        Width = 600 // Required
-                    }
-                },
-                ContentUrl = new Uri("https://www.example.com/video123.flv"), // Recommended
-                EmbedUrl = new Uri("https://www.example.com/videoplayer.swf?video=123"), // Recommended
-                InteractionStatistic = new InteractionCounter()
-                {
-                    UserInteractionCount = 2347 // Recommended
-                },
-            };
-            var expectedJson =
-                "{" +
-                    "\"@context\":\"http://schema.org\"," +
-                    "\"@type\":\"VideoObject\"," +
-                    "\"name\":\"Title\"," +
-                    "\"description\":\"Video description\"," +
-                    "\"expires\":\"2016-02-05T08:00:00+00:00\"," +
-                    "\"interactionStatistic\":{" +
-                        "\"@type\":\"InteractionCounter\"," +
-                        "\"userInteractionCount\":2347" +
-                    "}," +
-                    "\"publisher\":{" +
-                        "\"@type\":\"Organization\"," +
-                        "\"name\":\"Example Publisher\"," +
-                        "\"logo\":{" +
-                            "\"@type\":\"ImageObject\"," +
-                            "\"url\":\"https://example.com/logo.jpg\"," +
-                            "\"height\":60," +
-                            "\"width\":600" +
-                        "}" +
-                    "}," +
-                    "\"thumbnailUrl\":\"https://www.example.com/thumbnail.jpg\"," +
-                    "\"contentUrl\":\"https://www.example.com/video123.flv\"," +
-                    "\"duration\":\"PT1M33S\"," +
-                    "\"embedUrl\":\"https://www.example.com/videoplayer.swf?video=123\"," +
-                    "\"uploadDate\":\"2015-02-05T08:00:00+00:00\"" +
-                "}";
+            Assert.Equal(this.json, this.videoObject.ToString());
+        }
 
-            var json = videoObject.ToString();
-
-            Assert.Equal(expectedJson, json);
+        [Fact]
+        public void Deserializing_VideoObjectJsonLd_ReturnsVideoObject()
+        {
+            Assert.Equal(this.videoObject.ToString(), JsonConvert.DeserializeObject<VideoObject>(this.json).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/VideoObjectTest.cs
+++ b/Tests/Schema.NET.Test/VideoObjectTest.cs
@@ -70,7 +70,12 @@ namespace Schema.NET.Test
         [Fact]
         public void Deserializing_VideoObjectJsonLd_ReturnsVideoObject()
         {
-            Assert.Equal(this.videoObject.ToString(), JsonConvert.DeserializeObject<VideoObject>(this.json).ToString());
+            var serializerSettings = new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.videoObject.ToString(), JsonConvert.DeserializeObject<VideoObject>(this.json, serializerSettings).ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/VideoObjectTest.cs
+++ b/Tests/Schema.NET.Test/VideoObjectTest.cs
@@ -62,15 +62,13 @@ namespace Schema.NET.Test
             "}";
 
         [Fact]
-        public void ToString_VideoGoogleStructuredData_ReturnsExpectedJsonLd()
-        {
+        public void ToString_VideoGoogleStructuredData_ReturnsExpectedJsonLd() =>
             Assert.Equal(this.json, this.videoObject.ToString());
-        }
 
         [Fact]
         public void Deserializing_VideoObjectJsonLd_ReturnsVideoObject()
         {
-            var serializerSettings = new JsonSerializerSettings
+            var serializerSettings = new JsonSerializerSettings()
             {
                 DateParseHandling = DateParseHandling.DateTimeOffset
             };

--- a/Tests/Schema.NET.Test/WebsiteTest.cs
+++ b/Tests/Schema.NET.Test/WebsiteTest.cs
@@ -87,6 +87,5 @@ namespace Schema.NET.Test
 
             Assert.Equal(website.ToString(), JsonConvert.DeserializeObject<WebSite>(json).ToString());
         }
-
     }
 }

--- a/Tests/Schema.NET.Test/WebsiteTest.cs
+++ b/Tests/Schema.NET.Test/WebsiteTest.cs
@@ -1,6 +1,7 @@
-﻿namespace Schema.NET.Test
+namespace Schema.NET.Test
 {
     using System;
+    using Newtonsoft.Json;
     using Xunit;
 
     public class WebsiteTest
@@ -58,5 +59,34 @@
 
             Assert.Equal(expectedJson, json);
         }
+
+        [Fact]
+        public void Deserializing_WebSiteJsonLd_ReturnsWebSite()
+        {
+            var website = new WebSite()
+            {
+                PotentialAction = new SearchAction() // Required
+                {
+                    Target = new Uri("http://example.com/search?&q={query}"), // Required
+                    QueryInput = "required" // Required
+                },
+                Url = new Uri("https://example.com") // Required
+            };
+
+            var json =
+            "{" +
+                "\"@context\":\"http://schema.org\"," +
+                "\"@type\":\"WebSite\"," +
+                "\"potentialAction\":{" +
+                    "\"@type\":\"SearchAction\"," +
+                    "\"target\":\"http://example.com/search?&q={query}\"," +
+                    "\"query-input\":\"required\"" +
+                "}," +
+                "\"url\":\"https://example.com\"" +
+            "}";
+
+            Assert.Equal(website.ToString(), JsonConvert.DeserializeObject<WebSite>(json).ToString());
+        }
+
     }
 }


### PR DESCRIPTION
This PR is an initial implementation of the deserialization of Schema.org object, by adding the ReadJson method to both converters. I'll try to make several comments in the files below, but here's the general overview:

- It deserializes Values\<T\> classes
- It deserializes the remaining Values<T...> classes, but there's a fallback to figure out the right T for the type of persisted data
- It deserializes Enums
- It respects the @type properties, when they exist
- It supports generic lists and figures out the correct derived type, i.e., List\<CreativeWork\> with Book elements
- It has unit tests, although they rely on ToString too much. This is because it's not trivial (and maybe doesn't even make sense) to implement Equals
- I've kept the unit tests in a separate commit, because I did some structural changes that can be bit aggressive to the original code
- It relies on Activator and GetTypeInfo to get and instantiate the correct types, so the performance may need tweaking

Hope it helps