### PR TITLE
Adding passing unit test for unknown schema.net types.

### DIFF
--- a/Tests/Schema.NET.Test/ThingTest.cs
+++ b/Tests/Schema.NET.Test/ThingTest.cs
@@ -6,7 +6,7 @@ namespace Schema.NET.Test
 
     public class ThingTest
     {
-        private Thing thing = new Thing()
+        private readonly Thing thing = new Thing()
         {
             Name = "New Object",
             Description = "This is the description of a new object we can't deserialize",

--- a/Tests/Schema.NET.Test/ThingTest.cs
+++ b/Tests/Schema.NET.Test/ThingTest.cs
@@ -1,0 +1,32 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class ThingTest
+    {
+        private Thing thing = new Thing()
+        {
+            Name = "New Object",
+            Description = "This is the description of a new object we can't deserialize",
+            Image = new Uri("https://example.com/image.jpg")
+        };
+
+        private readonly string json =
+            "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"NewObject\"," +
+            "\"name\":\"New Object\"," +
+            "\"description\":\"This is the description of a new object we can't deserialize\"," +
+            "\"image\":\"https://example.com/image.jpg\"," +
+            "\"someProperty\":\"not supported\"" +
+            "}";
+
+        [Fact]
+        public void Deserializing_NewObjectJsonLd_ReturnsThing()
+        {
+            Assert.Equal(this.thing.ToString(), JsonConvert.DeserializeObject<Thing>(this.json).ToString());
+        }
+    }
+}


### PR DESCRIPTION
- Unknown types are deserialized as Thing.
- Unknown properties are ignored.