### PR TITLE
Support type array

### DIFF
--- a/Source/Schema.NET/ValuesConverter.cs
+++ b/Source/Schema.NET/ValuesConverter.cs
@@ -219,6 +219,22 @@ namespace Schema.NET
         private static string GetTypeNameFromToken(JToken token)
         {
             var typeNameToken = token.Values().FirstOrDefault(t => t.Path.EndsWith("@type"));
+            if (typeNameToken is JArray array)
+            {
+                if (!array.Any())
+                {
+                    throw new ArgumentException("Type was an empty array");
+                }
+
+                typeNameToken.Parent.Remove();
+                if (token is JContainer container)
+                {
+                    var value = array.First.Value<string>();
+                    container.Add(new JProperty("@type", value));
+                    return value;
+                }
+            }
+
             return typeNameToken?.Value<string>();
         }
     }

--- a/Tests/Schema.NET.Test/MultipleTypeTest.cs
+++ b/Tests/Schema.NET.Test/MultipleTypeTest.cs
@@ -1,0 +1,44 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class MultipleTypeTest
+    {
+        private readonly Course course = new Course()
+        {
+            Name = "Introduction to Computer Science and Programming", // Required
+            Description = "Introductory CS course laying out the basics.", // Required
+            Provider = new Organization() // Recommended
+            {
+                Name = "University of Technology - Eureka",
+                SameAs = new Uri("http://www.ut-eureka.edu")
+            }
+        };
+
+        private readonly string json =
+            "{" +
+            "\"@context\":\"http://schema.org\"," +
+            "\"@type\":\"Course\"," +
+            "\"name\":\"Introduction to Computer Science and Programming\"," +
+            "\"description\":\"Introductory CS course laying out the basics.\"," +
+            "\"provider\":{" +
+            "\"@type\":[\"Organization\"]," + // Note the array that defines the type(s)
+            "\"name\":\"University of Technology - Eureka\"," +
+            "\"sameAs\":\"http://www.ut-eureka.edu\"" +
+            "}" +
+            "}";
+
+        [Fact]
+        public void Should_deserialize_to_the_first_type()
+        {
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.course.ToString(), JsonConvert.DeserializeObject<Course>(this.json, serializerSettings).ToString());
+        }
+    }
+}


### PR DESCRIPTION
According to the [spec](https://json-ld.org/spec/latest/json-ld/#specifying-the-type), type can be defined as an array. For C#, this is obviously not valid, so we arbitrarily choose the first one.

Note that this is only valid for sub-properties and not for the main object itself. The reason for that is that the Type property on Thing does not have a custom converter (nor should it?). I'd guess most people will specify the type on their own deserialization call, anyway.