### PR TITLE
Proposed fix for null value handling (#29)

### DIFF
--- a/Source/Schema.NET.Tool/ViewModels/Property.cs
+++ b/Source/Schema.NET.Tool/ViewModels/Property.cs
@@ -38,7 +38,7 @@ namespace Schema.NET.Tool.ViewModels
 
             var adjustedTypes = string.Join(", ", this.Types.Select(x => x.CSharpTypeString));
             var rootType = this.Types.Count == 1 ? "OneOrMany" : "Values";
-            var typeString = $"{rootType}<{adjustedTypes}>?";
+            var typeString = $"{rootType}<{adjustedTypes}>";
 
             stringBuilder.AppendIndentLine(indent, $"[DataMember(Name = \"{this.JsonName}\", Order = {this.Order})]");
 

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -9,13 +9,13 @@ namespace Schema.NET
     /// </summary>
     /// <typeparam name="T">The type of the values.</typeparam>
     /// <seealso cref="ICollection{T}" />
-    public struct OneOrMany<T> : IEnumerable<T>, IValue
+    public class OneOrMany<T> : IEnumerable<T>, IValue
     {
         private readonly List<T> collection;
         private readonly T item;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OneOrMany{T}"/> struct.
+        /// Initializes a new instance of the <see cref="OneOrMany{T}"/> class.
         /// </summary>
         /// <param name="item">The single item value.</param>
         public OneOrMany(T item)
@@ -30,7 +30,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OneOrMany{T}"/> struct.
+        /// Initializes a new instance of the <see cref="OneOrMany{T}"/> class.
         /// </summary>
         /// <param name="collection">The collection of values.</param>
         public OneOrMany(IEnumerable<T> collection)
@@ -39,7 +39,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OneOrMany{T}"/> struct.
+        /// Initializes a new instance of the <see cref="OneOrMany{T}"/> class.
         /// </summary>
         /// <param name="list">The list of values.</param>
         public OneOrMany(List<T> list)
@@ -92,8 +92,12 @@ namespace Schema.NET
                 {
                     return this.item;
                 }
+                else if (this.HasMany)
+                {
+                    return this.collection;
+                }
 
-                return this.collection;
+                return null;
             }
         }
 
@@ -114,27 +118,27 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator OneOrMany<T>(T item) => new OneOrMany<T>(item);
+        public static implicit operator OneOrMany<T>(T item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new OneOrMany<T>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T[]"/> to <see cref="OneOrMany{T}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator OneOrMany<T>(T[] array) => new OneOrMany<T>(array);
+        public static implicit operator OneOrMany<T>(T[] array) => array == null || array.Length == 0 ? null : new OneOrMany<T>(array);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T}"/> to <see cref="OneOrMany{T}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator OneOrMany<T>(List<T> list) => new OneOrMany<T>(list);
+        public static implicit operator OneOrMany<T>(List<T> list) => list == null || list.Count == 0 ? null : new OneOrMany<T>(list);
 
         /// <summary>
         /// Returns an enumerator that iterates through the <see cref="OneOrMany{T}"/>.
         /// </summary>
         /// <returns>An enumerator for the <see cref="OneOrMany{T}"/>.</returns>
-        public IEnumerator<T> GetEnumerator() => (this.collection ?? new List<T>() { this.item }).GetEnumerator();
+        public IEnumerator<T> GetEnumerator() => (this.collection ?? (this.item == null ? new List<T>() : new List<T>() { this.item })).GetEnumerator();
 
         /// <summary>
         /// Returns an enumerator that iterates through the <see cref="OneOrMany{T}"/>.

--- a/Source/Schema.NET/PropertyValueSpecification.Partial.cs
+++ b/Source/Schema.NET/PropertyValueSpecification.Partial.cs
@@ -16,34 +16,34 @@ namespace Schema.NET
         {
             var stringBuilder = new StringBuilder();
 
-            if (this.ValueMaxLength.HasValue && this.ValueMaxLength.Value.First().HasValue)
+            if (this.ValueMaxLength != null && this.ValueMaxLength.First() != null)
             {
                 stringBuilder.Append("maxlength=");
-                stringBuilder.Append(this.ValueMaxLength.Value.First().Value);
+                stringBuilder.Append(this.ValueMaxLength.First().Value);
             }
 
-            if (this.ValueMinLength.HasValue && this.ValueMinLength.Value.First().HasValue)
+            if (this.ValueMinLength != null && this.ValueMinLength.First() != null)
             {
                 AppendSpace(stringBuilder);
                 stringBuilder.Append("minlength=");
-                stringBuilder.Append(this.ValueMinLength.Value.First().Value);
+                stringBuilder.Append(this.ValueMinLength.First().Value);
             }
 
-            if (this.ValueName.HasValue && this.ValueName.Value.First() != null)
+            if (this.ValueName != null && this.ValueName.First() != null)
             {
                 AppendSpace(stringBuilder);
                 stringBuilder.Append("name=");
-                stringBuilder.Append(this.ValueName.Value.First());
+                stringBuilder.Append(this.ValueName.First());
             }
 
-            if (this.ValuePattern.HasValue && this.ValuePattern.Value.First() != null)
+            if (this.ValuePattern != null && this.ValuePattern.First() != null)
             {
                 AppendSpace(stringBuilder);
                 stringBuilder.Append("pattern=");
-                stringBuilder.Append(this.ValuePattern.Value.First());
+                stringBuilder.Append(this.ValuePattern.First());
             }
 
-            if (this.ValueRequired.HasValue && this.ValueRequired.Value.First().HasValue)
+            if (this.ValueRequired != null && this.ValueRequired.First() != null)
             {
                 AppendSpace(stringBuilder);
                 stringBuilder.Append("required");

--- a/Source/Schema.NET/ValuesConverter.cs
+++ b/Source/Schema.NET/ValuesConverter.cs
@@ -190,7 +190,7 @@ namespace Schema.NET
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var values = (IValue)value;
-            var obj = values.Value;
+            var obj = values?.Value;
             if (obj == null)
             {
                 writer.WriteNull();

--- a/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
@@ -10,7 +10,7 @@ namespace Schema.NET
     /// <typeparam name="T3">The third type the values can take.</typeparam>
     /// <typeparam name="T4">The fourth type the values can take.</typeparam>
     /// <seealso cref="IValue" />
-    public struct Values<T1, T2, T3, T4> : IValue
+    public class Values<T1, T2, T3, T4> : IValue
     {
         private readonly OneOrMany<T1> value1;
         private readonly OneOrMany<T2> value2;
@@ -18,7 +18,7 @@ namespace Schema.NET
         private readonly OneOrMany<T4> value4;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T1"/>.</param>
         public Values(OneOrMany<T1> value)
@@ -30,7 +30,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T2"/>.</param>
         public Values(OneOrMany<T2> value)
@@ -42,7 +42,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T3"/>.</param>
         public Values(OneOrMany<T3> value)
@@ -54,7 +54,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> class.
         /// </summary>
         /// <param name="values">The value of type <typeparamref name="T4"/>.</param>
         public Values(OneOrMany<T4> values)
@@ -92,19 +92,19 @@ namespace Schema.NET
         {
             get
             {
-                if (this.value1.Count > 0)
+                if (this.value1?.Count > 0)
                 {
                     return ((IValue)this.value1).Value;
                 }
-                else if (this.value2.Count > 0)
+                else if (this.value2?.Count > 0)
                 {
                     return ((IValue)this.value2).Value;
                 }
-                else if (this.value3.Count > 0)
+                else if (this.value3?.Count > 0)
                 {
                     return ((IValue)this.value3).Value;
                 }
-                else if (this.value4.Count > 0)
+                else if (this.value4?.Count > 0)
                 {
                     return ((IValue)this.value4).Value;
                 }
@@ -118,55 +118,55 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(T1 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T1 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2, T3, T4>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(T2 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T2 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2, T3, T4>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(T3 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T3 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2, T3, T4>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T4"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(T4 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T4 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2, T3, T4>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(List<T1> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T1> list) => list == null || list.Count == 0 ? null : new Values<T1, T2, T3, T4>(list);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(List<T2> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T2> list) => list == null || list.Count == 0 ? null : new Values<T1, T2, T3, T4>(list);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T3}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(List<T3> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T3> list) => list == null || list.Count == 0 ? null : new Values<T1, T2, T3, T4>(list);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T4}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3, T4>(List<T4> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T4> list) => list == null || list.Count == 0 ? null : new Values<T1, T2, T3, T4>(list);
     }
 }

--- a/Source/Schema.NET/Values{T1,T2,T3}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3}.cs
@@ -9,14 +9,14 @@ namespace Schema.NET
     /// <typeparam name="T2">The second type the values can take.</typeparam>
     /// <typeparam name="T3">The third type the values can take.</typeparam>
     /// <seealso cref="IValue" />
-    public struct Values<T1, T2, T3> : IValue
+    public class Values<T1, T2, T3> : IValue
     {
         private readonly OneOrMany<T1> value1;
         private readonly OneOrMany<T2> value2;
         private readonly OneOrMany<T3> value3;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2,T3}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T1"/>.</param>
         public Values(OneOrMany<T1> value)
@@ -27,7 +27,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2,T3}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T2"/>.</param>
         public Values(OneOrMany<T2> value)
@@ -38,7 +38,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2,T3}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T3"/>.</param>
         public Values(OneOrMany<T3> value)
@@ -70,15 +70,15 @@ namespace Schema.NET
         {
             get
             {
-                if (this.value1.Count > 0)
+                if (this.value1?.Count > 0)
                 {
                     return ((IValue)this.value1).Value;
                 }
-                else if (this.value2.Count > 0)
+                else if (this.value2?.Count > 0)
                 {
                     return ((IValue)this.value2).Value;
                 }
-                else if (this.value3.Count > 0)
+                else if (this.value3?.Count > 0)
                 {
                     return ((IValue)this.value3).Value;
                 }
@@ -92,41 +92,41 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3>(T1 item) => new Values<T1, T2, T3>(item);
+        public static implicit operator Values<T1, T2, T3>(T1 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2, T3>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3>(T2 item) => new Values<T1, T2, T3>(item);
+        public static implicit operator Values<T1, T2, T3>(T2 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2, T3>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3>(T3 item) => new Values<T1, T2, T3>(item);
+        public static implicit operator Values<T1, T2, T3>(T3 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2, T3>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3>(List<T1> list) => new Values<T1, T2, T3>(list);
+        public static implicit operator Values<T1, T2, T3>(List<T1> list) => list == null || list.Count == 0 ? null : new Values<T1, T2, T3>(list);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3>(List<T2> list) => new Values<T1, T2, T3>(list);
+        public static implicit operator Values<T1, T2, T3>(List<T2> list) => list == null || list.Count == 0 ? null : new Values<T1, T2, T3>(list);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T3}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2, T3>(List<T3> list) => new Values<T1, T2, T3>(list);
+        public static implicit operator Values<T1, T2, T3>(List<T3> list) => list == null || list.Count == 0 ? null : new Values<T1, T2, T3>(list);
     }
 }

--- a/Source/Schema.NET/Values{T1,T2}.cs
+++ b/Source/Schema.NET/Values{T1,T2}.cs
@@ -8,13 +8,13 @@ namespace Schema.NET
     /// <typeparam name="T1">The first type the values can take.</typeparam>
     /// <typeparam name="T2">The second type the values can take.</typeparam>
     /// <seealso cref="IValue" />
-    public struct Values<T1, T2> : IValue
+    public class Values<T1, T2> : IValue
     {
         private readonly OneOrMany<T1> value1;
         private readonly OneOrMany<T2> value2;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T1"/>.</param>
         public Values(OneOrMany<T1> value)
@@ -24,7 +24,7 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Values{T1,T2}"/> struct.
+        /// Initializes a new instance of the <see cref="Values{T1,T2}"/> class.
         /// </summary>
         /// <param name="value">The value of type <typeparamref name="T2"/>.</param>
         public Values(OneOrMany<T2> value)
@@ -50,11 +50,11 @@ namespace Schema.NET
         {
             get
             {
-                if (this.value1.Count > 0)
+                if (this.value1?.Count > 0)
                 {
                     return ((IValue)this.value1).Value;
                 }
-                else if (this.value2.Count > 0)
+                else if (this.value2?.Count > 0)
                 {
                     return ((IValue)this.value2).Value;
                 }
@@ -68,27 +68,27 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2>(T1 item) => new Values<T1, T2>(item);
+        public static implicit operator Values<T1, T2>(T1 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2>(T2 item) => new Values<T1, T2>(item);
+        public static implicit operator Values<T1, T2>(T2 item) => item == null || (item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string)) ? null : new Values<T1, T2>(item);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2>(List<T1> list) => new Values<T1, T2>(list);
+        public static implicit operator Values<T1, T2>(List<T1> list) => list == null || list.Count == 0 ? null : new Values<T1, T2>(list);
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Values<T1, T2>(List<T2> list) => new Values<T1, T2>(list);
+        public static implicit operator Values<T1, T2>(List<T2> list) => list == null || list.Count == 0 ? null : new Values<T1, T2>(list);
     }
 }

--- a/Tests/Schema.NET.Test/EventTest.cs
+++ b/Tests/Schema.NET.Test/EventTest.cs
@@ -1,12 +1,16 @@
 namespace Schema.NET.Test
 {
     using System;
+    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Xunit;
 
     // https://developers.google.com/search/docs/data-types/events
     public class EventTest
     {
+        private static readonly Organization NullOrganization = null;
+        private static readonly ItemAvailability? NullItemAvailability = null;
+
         private readonly Event @event = new Event()
         {
             Name = "Jan Lieberman Concert Series: Journey in Jazz", // Required
@@ -14,7 +18,9 @@ namespace Schema.NET.Test
             StartDate = new DateTimeOffset(2017, 4, 24, 19, 30, 0, TimeSpan.FromHours(-8)), // Required
             Location = new Place() // Required
             {
+                Id = null,
                 Name = "Santa Clara City Library, Central Park Library", // Recommended
+                Description = "   ",  // Should be ignored
                 Address = new PostalAddress() // Required
                 {
                     StreetAddress = "2635 Homestead Rd",
@@ -26,18 +32,31 @@ namespace Schema.NET.Test
             },
             Image = new Uri("http://www.example.com/event_image/12345"), // Recommended
             EndDate = new DateTimeOffset(2017, 4, 24, 23, 0, 0, TimeSpan.FromHours(-8)), // Recommended
-            Offers = new Offer() // Recommended
+            Offers = new List<Offer>() // Recommended
             {
-                Url = new Uri("https://www.example.com/event_offer/12345_201803180430"), // Recommended
-                Price = 30M, // Recommended
-                PriceCurrency = "USD", // Recommended
-                Availability = ItemAvailability.InStock, // Recommended
-                ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)) // Recommended
+                new Offer
+                {
+                    Url = new Uri("https://www.example.com/event_offer/12345_201803180430"), // Recommended
+                    Price = 30M, // Recommended
+                    PriceCurrency = "USD", // Recommended
+                    Availability = ItemAvailability.InStock, // Recommended
+                    ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)) // Recommended
+                },
+                new Offer
+                {
+                    Url = new Uri("https://www.example.com/event_offer/12345_201803180430"), // Recommended
+                    Price = 30M, // Recommended
+                    PriceCurrency = "USD", // Recommended
+                    Availability = NullItemAvailability, // Should be ignored
+                    ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)) // Recommended
+                },
             },
             Performer = new Person() // Recommended
             {
-                Name = "Andy Lagunoff" // Recommended
-            }
+                Name = "Andy Lagunoff", // Recommended
+                Telephone = NullOrganization?.Telephone // Should be ignored
+            },
+            Attendee = new List<Person>() // Should be ignored
         };
 
         private readonly string json =
@@ -59,14 +78,22 @@ namespace Schema.NET.Test
                     "\"streetAddress\":\"2635 Homestead Rd\"" +
                 "}" +
             "}," +
-            "\"offers\":{" +
-                "\"@type\":\"Offer\"," +
-                "\"url\":\"https://www.example.com/event_offer/12345_201803180430\"," +
-                "\"availability\":\"http://schema.org/InStock\"," +
-                "\"price\":30.0," +
-                "\"priceCurrency\":\"USD\"," +
-                "\"validFrom\":\"2017-01-20T16:20:00-08:00\"" +
-            "}," +
+            "\"offers\":[" +
+                "{" +
+                    "\"@type\":\"Offer\"," +
+                    "\"url\":\"https://www.example.com/event_offer/12345_201803180430\"," +
+                    "\"availability\":\"http://schema.org/InStock\"," +
+                    "\"price\":30.0," +
+                    "\"priceCurrency\":\"USD\"," +
+                    "\"validFrom\":\"2017-01-20T16:20:00-08:00\"" +
+                "},{" +
+                    "\"@type\":\"Offer\"," +
+                    "\"url\":\"https://www.example.com/event_offer/12345_201803180430\"," +
+                    "\"price\":30.0," +
+                    "\"priceCurrency\":\"USD\"," +
+                    "\"validFrom\":\"2017-01-20T16:20:00-08:00\"" +
+                "}" +
+            "]," +
             "\"performer\":{" +
                 "\"@type\":\"Person\"," +
                 "\"name\":\"Andy Lagunoff\"" +
@@ -84,7 +111,8 @@ namespace Schema.NET.Test
         {
             var serializerSettings = new JsonSerializerSettings()
             {
-                DateParseHandling = DateParseHandling.DateTimeOffset
+                DateParseHandling = DateParseHandling.DateTimeOffset,
+                NullValueHandling = NullValueHandling.Ignore
             };
 
             Assert.Equal(this.@event.ToString(), JsonConvert.DeserializeObject<Event>(this.json, serializerSettings).ToString());


### PR DESCRIPTION
This project is really great! We've used it as the basis for [OpenActive.NET](https://www.nuget.org/packages/OpenActive.NET/) - which builds on Schema.NET to create a client library for the [OpenActive](https://www.openactive.io/) Initiative. The OpenActive [model](https://www.w3.org/2017/08/modelling-opportunity-data/) builds on Schema.org, so building on this library was the perfect fit. OpenActive.NET references the Schema.NET NuGet package and we were able to do everything using extensions and inheritance alone, which is ideal - great work making such an extensible framework!

We'd love to continue to contribute to Schema.NET as OpenActive evolves, as it looks like our objectives are completely aligned here.

The only issue we've had is that we needed to fix https://github.com/RehanSaeed/Schema.NET/issues/29 to make Schema.NET work for OpenActive data publishers, who frequently have null values in their source data.

For null handling OpenActive has some specific requirements (which apply to Schema.org JSON-LD too, though they are not _required_ there), when serialising:
- Nulls _must_ be ignored
- Empty arrays _must_ be ignored
- Strings that are empty or contain whitespace _must_ be ignored.

For comparison with schema.org: although the last two in the context of schema.org just make for better structured data (Google won't do anything with empty arrays or blank strings, so there is no scenario where they would be included in data intentionally), references for ignoring nulls are part of the JSON-LD spec:
> A key-value pair in the body of a JSON-LD document whose value is null has the same meaning as if the key-value pair was not defined. - [JSON-LD spec](https://json-ld.org/spec/latest/json-ld/#terminology)

Hence we'd be keen to propose that all three of the above requirements are also baked into Schema.NET :)

Back to https://github.com/RehanSaeed/Schema.NET/issues/29, following some investigation there seems to be a little more to this, especially if we want to ignore null values in all circumstances... As soon as we create a non-default struct value, Json.NET will not allow the value to be hidden easily even if properties of that value are null. If the `ValuesConverter` uses `writer.WriteNull()` when rendering the value, it will ignore the setting of `NullValueHandling.Ignore` (which is applied before `ValuesConverter.WriteJson` is even called). Unless we want to unwind during JSON writing ([messy](https://stackoverflow.com/questions/33241039/nullvaluehandling-ignore-with-jsonconverterwritejson)) we need to prevent even creating the non-default struct in the first place. To complicate this further even a default struct value is not recognised by `DefaultValueHandling.Ignore`, which means it looks like we need to switch back to classes from structs.

The PR here does exactly this, and keeps the existing null checks in place in the constructors to ensure that IValue classes with null values aren’t accidentally created. It also improves the `EventTest` to cover the various null and empty scenarios.

Note the CI errors as this PR does not include the regenerated model for readability (the regenerated model just removes the Nullable shorthand `T?` due to the struct->class change). The regenerated model can be found in our fork (diff [here](https://github.com/RehanSaeed/Schema.NET/compare/master...openactive:master)) for reference. 

The main downside I can see is any performance impact of switching from structs to classes, which doesn't seem to have a significant effect on performance from a quick test. What testing have you done on structs vs. classes in the scenario here? Do you think we need to do more or given the average size of a Schema.org document (small for structured data) would you be happy to accept a PR on this issue without this?

Look forward to your thoughts,

Nick