### PR TITLE
Add support for IsNullOrWhiteSpace and improve tests

### DIFF
--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -107,7 +107,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(T item) => item != null && item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string) ? default : new OneOrMany<T>(item);
+        public static implicit operator OneOrMany<T>(T item) => item != null && IsStringNullOrWhiteSpace(item) ? default : new OneOrMany<T>(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(T[] array) => new OneOrMany<T>(array);
+        public static implicit operator OneOrMany<T>(T[] array) => new OneOrMany<T>(array?.Where(x => x != null && !IsStringNullOrWhiteSpace(x)));
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(List<T> list) => new OneOrMany<T>(list.Where(x => x != null && !(x.GetType() == typeof(string) && string.IsNullOrWhiteSpace(x as string))));
+        public static implicit operator OneOrMany<T>(List<T> list) => new OneOrMany<T>(list?.Where(x => x != null && !IsStringNullOrWhiteSpace(x)));
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -272,5 +272,7 @@ namespace Schema.NET
 
             return 0;
         }
+
+        private static bool IsStringNullOrWhiteSpace(T item) => item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string);
     }
 }

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -107,7 +107,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(T item) => new OneOrMany<T>(item);
+        public static implicit operator OneOrMany<T>(T item) => item != null && item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string) ? default : new OneOrMany<T>(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(List<T> list) => new OneOrMany<T>(list);
+        public static implicit operator OneOrMany<T>(List<T> list) => new OneOrMany<T>(list.Where(x => x != null && !(x.GetType() == typeof(string) && string.IsNullOrWhiteSpace(x as string))));
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -273,6 +273,12 @@ namespace Schema.NET
             return 0;
         }
 
+        /// <summary>
+        /// Checks whether the generic T item is a string that is either null or contains whitespace.
+        /// </summary>
+        /// <returns>
+        /// Returns true if the supplied item is a string that is null or contains whitespace.
+        /// </returns>
         private static bool IsStringNullOrWhiteSpace(T item) => item.GetType() == typeof(string) && string.IsNullOrWhiteSpace(item as string);
     }
 }

--- a/Tests/Schema.NET.Test/OneOrManyTest.cs
+++ b/Tests/Schema.NET.Test/OneOrManyTest.cs
@@ -243,7 +243,7 @@ namespace Schema.NET.Test
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("  ")]
-        public void ToString_EmptyOrWhiteSpace_BookOmitsNameProperty(string name)
+        public void ToString_NullEmptyOrWhiteSpace_BookOmitsNameProperty(string name)
         {
             var book = new Book() { Name = name };
             Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\"}", book.ToString());
@@ -254,7 +254,7 @@ namespace Schema.NET.Test
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("  ")]
-        public void ToString_EmptyOrWhiteSpace_BookOmitsNamePropertyFromList(string name)
+        public void ToString_NullEmptyOrWhiteSpace_BookOmitsNamePropertyFromList(string name)
         {
             var book = new Book() { Name = new List<string> { "Hamlet", name } };
             Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
@@ -265,10 +265,10 @@ namespace Schema.NET.Test
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("  ")]
-        public void ToString_EmptyOrWhiteSpace_OrganizationOmitsAddressProperty(string address)
+        public void ToString_NullEmptyOrWhiteSpace_BookOmitsNamePropertyFromArray(string name)
         {
-            var organization = new Organization() { Address = address };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
+            var book = new Book() { Name = new string[] { "Hamlet", name } };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
         }
 
         [Theory]
@@ -276,11 +276,21 @@ namespace Schema.NET.Test
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("  ")]
-        public void ToString_EmptyOrWhiteSpace_OrganizationOmitsNamePropertyFromList(string address)
+        public void ToString_NullEmptyOrWhiteSpace_OrganizationOmitsNamePropertyFromList(string address)
         {
             var organization = new Organization() { Name = new List<string> { "Cardiff, UK", address } };
             Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\",\"name\":\"Cardiff, UK\"}", organization.ToString());
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        public void ToString_NullEmptyOrWhiteSpace_OrganizationOmitsNamePropertyFromArray(string address)
+        {
+            var organization = new Organization() { Name = new string[] { "Cardiff, UK", address } };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\",\"name\":\"Cardiff, UK\"}", organization.ToString());
+        }
     }
 }

--- a/Tests/Schema.NET.Test/OneOrManyTest.cs
+++ b/Tests/Schema.NET.Test/OneOrManyTest.cs
@@ -237,5 +237,50 @@ namespace Schema.NET.Test
         [Fact]
         public void GetHashCode_TwoItems_HashCodeEqualToTwoItems() =>
             Assert.Equal(NET.HashCode.OfEach(new List<int>() { 1, 2 }), new OneOrMany<int>(1, 2).GetHashCode());
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        public void ToString_EmptyOrWhiteSpace_BookOmitsNameProperty(string name)
+        {
+            var book = new Book() { Name = name };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\"}", book.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        public void ToString_EmptyOrWhiteSpace_BookOmitsNamePropertyFromList(string name)
+        {
+            var book = new Book() { Name = new List<string> { "Hamlet", name } };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        public void ToString_EmptyOrWhiteSpace_OrganizationOmitsAddressProperty(string address)
+        {
+            var organization = new Organization() { Address = address };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        public void ToString_EmptyOrWhiteSpace_OrganizationOmitsNamePropertyFromList(string address)
+        {
+            var organization = new Organization() { Name = new List<string> { "Cardiff, UK", address } };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\",\"name\":\"Cardiff, UK\"}", organization.ToString());
+        }
+
     }
 }

--- a/Tests/Schema.NET.Test/core/EventTest.cs
+++ b/Tests/Schema.NET.Test/core/EventTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/events
     public class EventTest
     {
-        private static readonly string NullTelephone = null;
+        private static readonly string NullString = null;
         private static readonly ItemAvailability? NullItemAvailability = null;
 
         private readonly Event @event = new Event()
@@ -39,7 +39,8 @@ namespace Schema.NET.Test
                     Price = 30M, // Recommended
                     PriceCurrency = "USD", // Recommended
                     Availability = ItemAvailability.InStock, // Recommended
-                    ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)) // Recommended
+                    ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)), // Recommended
+                    Category = NullString,
                 },
                 new Offer
                 {
@@ -53,7 +54,7 @@ namespace Schema.NET.Test
             Performer = new Person() // Recommended
             {
                 Name = "Andy Lagunoff", // Recommended
-                Telephone = NullTelephone // Should be ignored
+                Telephone = NullString // Should be ignored
             }
         };
 

--- a/Tests/Schema.NET.Test/core/EventTest.cs
+++ b/Tests/Schema.NET.Test/core/EventTest.cs
@@ -40,7 +40,6 @@ namespace Schema.NET.Test
                     PriceCurrency = "USD", // Recommended
                     Availability = ItemAvailability.InStock, // Recommended
                     ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)), // Recommended
-                    Category = NullString,
                 },
                 new Offer
                 {


### PR DESCRIPTION
@RehanSaeed as discussed at https://github.com/RehanSaeed/Schema.NET/issues/29, please see updated IsNullOrWhiteSpace via implicit operators.

Everything works great for OneOrMany<>, however additional tests for Values<> have revealed that https://github.com/RehanSaeed/Schema.NET/issues/29 is only fixed for properties that use OneOrMany<> and not for properties that use Values<>.

See failing tests in this PR for examples.