### PR TITLE
ValuesJsonConverter.cs refactoring

### DIFF
--- a/Source/Schema.NET/ValuesJsonConverter.cs
+++ b/Source/Schema.NET/ValuesJsonConverter.cs
@@ -163,7 +163,7 @@ namespace Schema.NET
 
         private static object ParseTokenArguments(JToken token, JsonToken tokenType, Type type, object value)
         {
-            const int SCHEMA_ORG_LENGTH = 18;
+            const int SCHEMA_ORG_LENGTH = 18; // equivalent to "http://schema.org/".Length
             object args = null;
             var unwrappedType = type.GetUnderlyingTypeFromNullable();
             if (unwrappedType.GetTypeInfo().IsEnum)

--- a/Source/Schema.NET/ValuesJsonConverter.cs
+++ b/Source/Schema.NET/ValuesJsonConverter.cs
@@ -45,44 +45,20 @@ namespace Schema.NET
             object argument = null;
 
             var tokenType = reader.TokenType;
-            var value = SanitizeReaderValue(reader, tokenType);
+            var value = reader.Value;
 
             var token = JToken.Load(reader);
             if (mainType.GenericTypeArguments.Length == 1)
             {
-                var type = mainType.GenericTypeArguments[0].GetUnderlyingTypeFromNullable();
+                var type = mainType.GenericTypeArguments[0];
                 if (tokenType == JsonToken.StartArray)
                 {
-                    argument = ReadJsonArray(token, type);
-                }
-                else if (type.IsPrimitiveType())
-                {
-                    argument = value;
-                }
-                else if (type == typeof(decimal))
-                {
-                    argument = Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+                    var unwrappedType = type.GetUnderlyingTypeFromNullable();
+                    argument = ReadJsonArray(token, unwrappedType);
                 }
                 else
                 {
-                    if (type.GetTypeInfo().IsEnum)
-                    {
-                        var enumString = token.ToString().Substring("http://schema.org/".Length);
-                        argument = Enum.Parse(type, enumString);
-                    }
-                    else
-                    {
-                        var typeName = GetTypeNameFromToken(token);
-                        if (string.IsNullOrEmpty(typeName))
-                        {
-                            argument = token.ToObject(type);
-                        }
-                        else
-                        {
-                            var builtType = Type.GetType($"{NamespacePrefix}{typeName}");
-                            argument = token.ToObject(builtType);
-                        }
-                    }
+                    argument = ParseTokenArguments(token, tokenType, type, value);
                 }
             }
             else
@@ -92,7 +68,8 @@ namespace Schema.NET
                     var items = new List<object>();
                     foreach (var type in mainType.GenericTypeArguments)
                     {
-                        var args = ReadJsonArray(token, type);
+                        var unwrappedType = type.GetUnderlyingTypeFromNullable();
+                        var args = ReadJsonArray(token, unwrappedType);
                         var genericType = typeof(OneOrMany<>).MakeGenericType(type);
                         var item = (IValues)Activator.CreateInstance(genericType, args);
                         items.Add(item);
@@ -102,54 +79,20 @@ namespace Schema.NET
                 }
                 else
                 {
-                    foreach (var type in mainType.GenericTypeArguments)
+                    for (var i = mainType.GenericTypeArguments.Length - 1; i >= 0; i--)
                     {
+                        var type = mainType.GenericTypeArguments[i];
+                        object args = null;
+
                         try
                         {
-                            object args;
-                            if (tokenType == JsonToken.StartObject)
-                            {
-                                var typeName = GetTypeNameFromToken(token);
-                                if (string.IsNullOrEmpty(typeName))
-                                {
-                                    args = token.ToObject(type);
-                                }
-                                else if (typeName == type.Name)
-                                {
-                                    args = token.ToObject(type);
-                                }
-                                else
-                                {
-                                    var builtType = Type.GetType($"{NamespacePrefix}{typeName}");
-                                    if (builtType != null && type.GetTypeInfo().IsAssignableFrom(builtType.GetTypeInfo()))
-                                    {
-                                        args = token.ToObject(builtType);
-                                    }
-                                    else
-                                    {
-                                        continue;
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                var unwrappedType = type.GetUnderlyingTypeFromNullable();
-                                if (unwrappedType.IsPrimitiveType())
-                                {
-                                    args = value;
-                                }
-                                else if (unwrappedType == typeof(decimal))
-                                {
-                                    args = Convert.ToDecimal(value, CultureInfo.InvariantCulture);
-                                }
-                                else
-                                {
-                                    args = token.ToObject(ToClass(type)); // This is expected to throw on some case
-                                }
-                            }
+                            args = ParseTokenArguments(token, tokenType, type, value);
 
-                            var genericType = typeof(OneOrMany<>).MakeGenericType(type);
-                            argument = Activator.CreateInstance(genericType, args);
+                            if (args != null)
+                            {
+                                var genericType = typeof(OneOrMany<>).MakeGenericType(type);
+                                argument = Activator.CreateInstance(genericType, args);
+                            }
                         }
 #pragma warning disable CA1031 // Do not catch general exception types
                         catch (Exception e)
@@ -159,6 +102,12 @@ namespace Schema.NET
                             Debug.WriteLine(e);
                         }
 #pragma warning restore CA1031 // Do not catch general exception types
+
+                        if (argument != null)
+                        {
+                            // return first valid argument, going from right to left in generic type arguments
+                            break;
+                        }
                     }
                 }
             }
@@ -211,6 +160,216 @@ namespace Schema.NET
         /// <param name="serializer">The JSON serializer.</param>
         public virtual void WriteObject(JsonWriter writer, object value, JsonSerializer serializer) =>
             serializer.Serialize(writer, value);
+
+        private static object ParseTokenArguments(JToken token, JsonToken tokenType, Type type, object value)
+        {
+            const int SCHEMA_ORG_LENGTH = 18;
+            object args = null;
+            var unwrappedType = type.GetUnderlyingTypeFromNullable();
+            if (unwrappedType.GetTypeInfo().IsEnum)
+            {
+                var enumString = token.ToString().Substring(SCHEMA_ORG_LENGTH);
+                args = Enum.Parse(unwrappedType, enumString);
+            }
+            else
+            {
+                if (tokenType == JsonToken.StartObject)
+                {
+                    args = ParseTokenObjectArguments(token, type, unwrappedType);
+                }
+                else
+                {
+                    args = ParseTokenValueArguments(token, tokenType, type, unwrappedType, value);
+                }
+            }
+
+            return args;
+        }
+
+        private static object ParseTokenObjectArguments(JToken token, Type type, Type unwrappedType)
+        {
+            object args = null;
+            var typeName = GetTypeNameFromToken(token);
+            if (string.IsNullOrEmpty(typeName))
+            {
+                args = token.ToObject(unwrappedType);
+            }
+            else if (typeName == type.Name)
+            {
+                args = token.ToObject(type);
+            }
+            else
+            {
+                var builtType = Type.GetType($"{NamespacePrefix}{typeName}");
+                if (builtType != null && type.GetTypeInfo().IsAssignableFrom(builtType.GetTypeInfo()))
+                {
+                    args = token.ToObject(builtType);
+                }
+            }
+
+            return args;
+        }
+
+        private static object ParseTokenValueArguments(JToken token, JsonToken tokenType, Type type, Type unwrappedType, object value)
+        {
+            object args = null;
+            if (unwrappedType.IsPrimitiveType())
+            {
+                if (value is string)
+                {
+                    if (unwrappedType == typeof(string))
+                    {
+                        args = value;
+                    }
+                    else if (unwrappedType == typeof(int))
+                    {
+                        if (int.TryParse((string)value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i))
+                        {
+                            args = i;
+                        }
+                    }
+                    else if (unwrappedType == typeof(long))
+                    {
+                        if (long.TryParse((string)value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i))
+                        {
+                            args = i;
+                        }
+                    }
+                    else if (unwrappedType == typeof(float))
+                    {
+                        if (float.TryParse((string)value, NumberStyles.Float, CultureInfo.InvariantCulture, out var i))
+                        {
+                            args = i;
+                        }
+                    }
+                    else if (unwrappedType == typeof(double))
+                    {
+                        if (double.TryParse((string)value, NumberStyles.Float, CultureInfo.InvariantCulture, out var i))
+                        {
+                            args = i;
+                        }
+                    }
+                    else if (unwrappedType == typeof(bool))
+                    {
+                        if (bool.TryParse((string)value, out var i))
+                        {
+                            args = i;
+                        }
+                    }
+                }
+                else if (value is short || value is int || value is long || value is float || value is double)
+                {
+                    // Can safely convert between numeric types
+                    if (unwrappedType == typeof(short) || unwrappedType == typeof(int) || unwrappedType == typeof(long) || unwrappedType == typeof(float) || unwrappedType == typeof(double))
+                    {
+                        args = Convert.ChangeType(value, unwrappedType, CultureInfo.InvariantCulture);
+                    }
+                }
+                else if (value is bool)
+                {
+                    if (unwrappedType == typeof(bool))
+                    {
+                        args = value;
+                    }
+                }
+                else if (value is DateTime || value is DateTimeOffset)
+                {
+                    // NO-OP: can't put a date into a primitive type
+                }
+                else
+                {
+                    args = value;
+                }
+            }
+            else if (unwrappedType == typeof(decimal))
+            {
+                if (value is string)
+                {
+                    if (decimal.TryParse((string)value, NumberStyles.Currency, CultureInfo.InvariantCulture, out var i))
+                    {
+                        args = i;
+                    }
+                }
+                else
+                {
+                    args = Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+                }
+            }
+            else if (unwrappedType == typeof(DateTime))
+            {
+                if (value is string)
+                {
+                    if (DateTime.TryParse((string)value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var i))
+                    {
+                        args = i;
+                    }
+                }
+                else if (value is DateTime)
+                {
+                    args = value;
+                }
+                else if (value is DateTimeOffset)
+                {
+                    args = ((DateTimeOffset)value).DateTime;
+                }
+                else if (value is short || value is int || value is long || value is float || value is double)
+                {
+                    // NO-OP: can't put a primitive type into a date
+                }
+                else
+                {
+                    args = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
+                }
+            }
+            else if (unwrappedType == typeof(DateTimeOffset))
+            {
+                if (value is string)
+                {
+                    if (DateTimeOffset.TryParse((string)value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var i))
+                    {
+                        args = i;
+                    }
+                }
+                else if (value is DateTime)
+                {
+                    args = new DateTimeOffset((DateTime)value);
+                }
+                else if (value is DateTimeOffset)
+                {
+                    args = value;
+                }
+                else
+                {
+                    args = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
+                }
+            }
+            else
+            {
+                var classType = ToClass(type);
+                if (tokenType == JsonToken.String)
+                {
+                    if (classType == typeof(Uri))
+                    {
+                        // REVIEW: Avoid invalid URIs being assigned as URI (Should we only allow absolute URIs?)
+                        if (Uri.TryCreate((string)value, UriKind.Absolute, out var i))
+                        {
+                            args = i;
+                        }
+                    }
+                }
+
+                // REVIEW: If argument still not assigned, only use ToObject if not casting primitive to interface or class
+                if (args == null)
+                {
+                    if (!type.GetTypeInfo().IsInterface && !type.GetTypeInfo().IsClass)
+                    {
+                        args = token.ToObject(classType); // This is expected to throw on some case
+                    }
+                }
+            }
+
+            return args;
+        }
 
         /// <summary>
         /// Gets the class type definition.
@@ -278,13 +437,10 @@ namespace Schema.NET
             }
         }
 
-        private static object SanitizeReaderValue(JsonReader reader, JsonToken tokenType) =>
-            tokenType == JsonToken.Integer ? Convert.ToInt32(reader.Value, CultureInfo.InvariantCulture) : reader.Value;
-
         private static string GetTypeNameFromToken(JToken token)
         {
-            var typeNameToken = token.Values().FirstOrDefault(t => t.Path.EndsWith("@type", StringComparison.Ordinal));
-            return typeNameToken?.Value<string>();
+            var o = token as JObject;
+            return o?.SelectToken("@type")?.ToString();
         }
     }
 }

--- a/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
@@ -1,0 +1,101 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class MusicAlbumTest
+    {
+        private readonly MusicAlbum musicAlbum = new MusicAlbum()
+        {
+            Name = "Hail to the Thief", // Required
+            Identifier = "1oW3v5Har9mvXnGk0x4fHm", // Recommended
+            Image = new List<IImageObject> {
+                new ImageObject() // Recommended
+                {
+                    ContentUrl = new Uri("https://i.scdn.co/image/5ded47fd3d05325dd0faaf4619481e1f25a21ec7") // Required
+                },
+                new ImageObject() // Recommended
+                {
+                    ContentUrl = new Uri("https://is4-ssl.mzstatic.com/image/thumb/Music69/v4/cc/1c/90/cc1c9039-c3ba-4256-e251-1687df46cb0a/cover.jpg/1400x1400bb.jpeg") // Required
+                },
+            },
+            SameAs = new Uri("https://music.apple.com/us/album/hail-to-the-thief/1097863576"), // Recommended
+            Url = new Uri("https://open.spotify.com/album/1oW3v5Har9mvXnGk0x4fHm"), // Recommended
+            DatePublished = new DateTime(2003, 5, 26), // Recommended
+            Offers = new Offer() // Recommended
+            {
+                Gtin12 = "634904078560"
+            },
+            NumTracks = 14, // Recommended
+            AlbumRelease = new MusicRelease() // Recommended
+            {
+                RecordLabel = new Organization()
+                {
+                    Name = "XL Recordings"// Required
+                }
+            },
+            ByArtist = new MusicGroup() // Recommended
+            {
+                Name = "Radiohead", // Required
+                Identifier = "4Z8W4fKeB5YxbusRsdQVPb" // Recommended
+            },
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\": \"http://schema.org\"," +
+            "\"@type\": \"MusicAlbum\"," +
+            "\"name\": \"Hail to the Thief\"," +
+            "\"identifier\": \"1oW3v5Har9mvXnGk0x4fHm\"," +
+            "\"image\": [{" +
+                    "\"$type\": \"Schema.NET.ImageObject, Schema.NET\"," +
+                    "\"@context\": \"http://schema.org\"," +
+                    "\"@type\": \"ImageObject\"," +
+                    "\"contentUrl\": \"https://i.scdn.co/image/5ded47fd3d05325dd0faaf4619481e1f25a21ec7\"" +
+                "}, {" +
+                    "\"$type\": \"Schema.NET.ImageObject, Schema.NET\"," +
+                    "\"@context\": \"http://schema.org\"," +
+                    "\"@type\": \"ImageObject\"," +
+                    "\"contentUrl\": \"https://is4-ssl.mzstatic.com/image/thumb/Music69/v4/cc/1c/90/cc1c9039-c3ba-4256-e251-1687df46cb0a/cover.jpg/1400x1400bb.jpeg\"" +
+                "}" +
+            "]," +
+            "\"sameAs\": \"https://music.apple.com/us/album/hail-to-the-thief/1097863576\"," +
+            "\"url\": \"https://open.spotify.com/album/1oW3v5Har9mvXnGk0x4fHm\"," +
+            "\"datePublished\": \"2003-05-26\"," +
+            "\"offers\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"Offer\"," +
+                "\"gtin12\": \"634904078560\"" +
+            "}," +
+            "\"numTracks\": 14," +
+            "\"albumRelease\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"MusicRelease\"," +
+                "\"recordLabel\": {" +
+                    "\"@context\": \"http://schema.org\"," +
+                    "\"@type\": \"Organization\"," +
+                    "\"name\": \"XL Recordings\"" +
+                "}" +
+            "}," +
+            "\"byArtist\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"MusicGroup\"," +
+                "\"name\": \"Radiohead\"," +
+                "\"identifier\": \"4Z8W4fKeB5YxbusRsdQVPb\"" +
+            "}" +
+        "}";
+
+        [Fact]
+        public void Deserializing_MusicAlbumJsonLd_ReturnsMusicAlbum()
+        {
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.musicAlbum.ToString(), JsonConvert.DeserializeObject<MusicAlbum>(this.json, serializerSettings).ToString());
+        }
+    }
+}

--- a/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
@@ -11,7 +11,8 @@ namespace Schema.NET.Test
         {
             Name = "Hail to the Thief", // Required
             Identifier = "1oW3v5Har9mvXnGk0x4fHm", // Recommended
-            Image = new List<IImageObject> {
+            Image = new List<IImageObject> // Recommended
+            {
                 new ImageObject() // Recommended
                 {
                     ContentUrl = new Uri("https://i.scdn.co/image/5ded47fd3d05325dd0faaf4619481e1f25a21ec7") // Required

--- a/Tests/Schema.NET.Test/core/MusicEventTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicEventTest.cs
@@ -1,0 +1,105 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class MusicEventTest
+    {
+        private readonly MusicEvent musicEvent = new MusicEvent()
+        {
+            Name = "Arash & Tohi", // Required
+            Identifier = "vv1AaZAQ8Gkds-P77",
+            Url = new Uri("https://www.ticketmaster.com/arash-tohi-hollywood-california-06-22-2019/event/09005690F1865104"), // Recommended
+            Location = new MusicVenue() // Recommended
+            {
+                Name = "Dolby Theatre", // Required
+                Identifier = "KovZpZAdtaEA" // Recommended
+            },
+            Offers = new Offer() // Recommended
+            {
+                Url = new Uri("https://www.ticketmaster.com/arash-tohi-hollywood-california-06-22-2019/event/09005690F1865104"), // Recommended
+                AvailabilityStarts = DateTimeOffset.Parse("2019-04-24T21:00:00-07:00"), // Recommended
+                AvailabilityEnds = DateTimeOffset.Parse("2019-06-23T01:00:00-07:00"), // Recommended
+                PriceSpecification = new PriceSpecification() // Recommended
+                {
+                    MinPrice = 80, // Recommended
+                    MaxPrice = 295, // Recommended
+                    PriceCurrency = "USD" // Recommended
+                }
+            },
+            Performer = new List<IOrganization>() // Recommended
+            {
+                new MusicGroup() // Recommended
+                {
+                    Name = "Arash", // Required
+                    Identifier = "K8vZ917ukD7" // Recommended
+                },
+                new MusicGroup() // Recommended
+                {
+                    Name = "Tohi", // Required
+                    Identifier = "K8vZ917bA70" // Recommended
+                }
+            },
+            StartDate = DateTimeOffset.Parse("2019-06-23T03:00:00-07:00") // Recommended
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\": \"http://schema.org\"," +
+            "\"@type\": \"MusicEvent\"," +
+            "\"name\": \"Arash & Tohi\"," +
+            "\"identifier\": \"vv1AaZAQ8Gkds-P77\"," +
+            "\"url\": \"https://www.ticketmaster.com/arash-tohi-hollywood-california-06-22-2019/event/09005690F1865104\"," +
+            "\"location\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"MusicVenue\"," +
+                "\"name\": \"Dolby Theatre\"," +
+                "\"identifier\": \"KovZpZAdtaEA\"" +
+            "}," +
+            "\"offers\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"Offer\"," +
+                "\"url\": \"https://www.ticketmaster.com/arash-tohi-hollywood-california-06-22-2019/event/09005690F1865104\"," +
+                "\"availabilityEnds\": \"2019-06-23T01:00:00-07:00\"," +
+                "\"availabilityStarts\": \"2019-04-24T21:00:00-07:00\"," +
+                "\"priceSpecification\": {" +
+                    "\"@context\": \"http://schema.org\"," +
+                    "\"@type\": \"PriceSpecification\"," +
+                    "\"maxPrice\": 295," +
+                    "\"minPrice\": 80," +
+                    "\"priceCurrency\": \"USD\"" +
+                "}" +
+            "}," +
+            "\"performer\": [" +
+                "{" +
+                    "\"$type\": \"Schema.NET.MusicGroup, Schema.NET\"," +
+                    "\"@context\": \"http://schema.org\"," +
+                    "\"@type\": \"MusicGroup\"," +
+                    "\"name\": \"Arash\"," +
+                    "\"identifier\": \"K8vZ917ukD7\"" +
+                "}," +
+                "{" +
+                    "\"$type\": \"Schema.NET.MusicGroup, Schema.NET\"," +
+                    "\"@context\": \"http://schema.org\"," +
+                    "\"@type\": \"MusicGroup\"," +
+                    "\"name\": \"Tohi\"," +
+                    "\"identifier\": \"K8vZ917bA70\"" +
+                "}" +
+            "]," +
+            "\"startDate\": \"2019-06-23T03:00:00-07:00\"" +
+        "}";
+
+        [Fact]
+        public void Deserializing_MusicEventJsonLd_ReturnsMusicEvent()
+        {
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.musicEvent.ToString(), JsonConvert.DeserializeObject<MusicEvent>(this.json, serializerSettings).ToString());
+        }
+    }
+}

--- a/Tests/Schema.NET.Test/core/MusicGroupTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicGroupTest.cs
@@ -1,0 +1,47 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class MusicGroupTest
+    {
+        private readonly MusicGroup musicGroup = new MusicGroup()
+        {
+            Name = "Radiohead", // Required
+            Identifier = "4Z8W4fKeB5YxbusRsdQVPb", // Recommended
+            Image = new ImageObject() // Recommended
+            {
+                ContentUrl = new Uri("https://i.scdn.co/image/afcd616e1ef2d2786f47b3b4a8a6aeea24a72adc") // Required
+            },
+            SameAs = new Uri("https://music.apple.com/us/artist/radiohead/657515"), // Recommended
+            Url = new Uri("https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb") // Recommended
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\": \"http://schema.org\"," +
+            "\"@type\": \"MusicGroup\"," +
+            "\"name\": \"Radiohead\"," +
+            "\"identifier\": \"4Z8W4fKeB5YxbusRsdQVPb\"," +
+            "\"image\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"ImageObject\"," +
+                "\"contentUrl\": \"https://i.scdn.co/image/afcd616e1ef2d2786f47b3b4a8a6aeea24a72adc\"" +
+            "}," +
+            "\"sameAs\": \"https://music.apple.com/us/artist/radiohead/657515\"," +
+            "\"url\": \"https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb\"" +
+        "}";
+
+        [Fact]
+        public void Deserializing_MusicGroupJsonLd_ReturnsMusicGroup()
+        {
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.musicGroup.ToString(), JsonConvert.DeserializeObject<MusicGroup>(this.json, serializerSettings).ToString());
+        }
+    }
+}

--- a/Tests/Schema.NET.Test/core/MusicRecordingTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicRecordingTest.cs
@@ -1,0 +1,79 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class MusicRecordingTest
+    {
+        private readonly MusicRecording musicRecording = new MusicRecording()
+        {
+            Name = "2 + 2 = 5", // Required
+            Identifier = "37kUGdEJJ7NaMl5LFW4EA4", // Recommended
+            Image = new ImageObject() // Recommended
+            {
+                ContentUrl = new Uri("https://is4-ssl.mzstatic.com/image/thumb/Music69/v4/cc/1c/90/cc1c9039-c3ba-4256-e251-1687df46cb0a/cover.jpg/1400x1400bb.jpeg") // Required
+            },
+            SameAs = new Uri("https://music.apple.com/us/album/2-2-5/1097863576?i=1097863810"), // Recommended
+            Url = new Uri("https://open.spotify.com/track/37kUGdEJJ7NaMl5LFW4EA4"), // Recommended
+            DatePublished = new DateTime(2003, 5, 26), // Recommended
+            IsFamilyFriendly = true, // Recommended
+            Position = "1.1", // Recommended
+            ByArtist = new MusicGroup() // Recommended
+            {
+                Name = "Radiohead", // Required
+                Identifier = "4Z8W4fKeB5YxbusRsdQVPb" // Recommended
+            },
+            Duration = new TimeSpan(0, 0, 3, 19, 360), // Recommended
+            InAlbum = new MusicAlbum() // Recommended
+            {
+                Name = "Hail To the Thief", // Required
+                Identifier = "1oW3v5Har9mvXnGk0x4fHm" // Recommended
+            },
+            IsrcCode = "GBAYE0300801" // Recommended
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\": \"http://schema.org\"," +
+            "\"@type\": \"MusicRecording\"," +
+            "\"name\": \"2 + 2 = 5\"," +
+            "\"identifier\": \"37kUGdEJJ7NaMl5LFW4EA4\"," +
+            "\"image\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"ImageObject\"," +
+                "\"contentUrl\": \"https://is4-ssl.mzstatic.com/image/thumb/Music69/v4/cc/1c/90/cc1c9039-c3ba-4256-e251-1687df46cb0a/cover.jpg/1400x1400bb.jpeg\"" +
+            "}," +
+            "\"sameAs\": \"https://music.apple.com/us/album/2-2-5/1097863576?i=1097863810\"," +
+            "\"url\": \"https://open.spotify.com/track/37kUGdEJJ7NaMl5LFW4EA4\"," +
+            "\"datePublished\": \"2003-05-26\"," +
+            "\"isFamilyFriendly\": true," +
+            "\"position\": \"1.1\"," +
+            "\"byArtist\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"MusicGroup\"," +
+                "\"name\": \"Radiohead\"," +
+                "\"identifier\": \"4Z8W4fKeB5YxbusRsdQVPb\"" +
+            "}," +
+            "\"duration\": \"PT3M19.36S\"," +
+            "\"inAlbum\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"MusicAlbum\"," +
+                "\"name\": \"Hail To the Thief\"," +
+                "\"identifier\": \"1oW3v5Har9mvXnGk0x4fHm\"" +
+            "}," +
+            "\"isrcCode\": \"GBAYE0300801\"" +
+        "}";
+
+        [Fact]
+        public void Deserializing_MusicRecordingJsonLd_ReturnsMusicRecording()
+        {
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.musicRecording.ToString(), JsonConvert.DeserializeObject<MusicRecording>(this.json, serializerSettings).ToString());
+        }
+    }
+}

--- a/Tests/Schema.NET.Test/core/MusicVenueTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicVenueTest.cs
@@ -16,7 +16,8 @@ namespace Schema.NET.Test
             {
                 ContentUrl = new Uri("https://s1.ticketm.net/dam/v/e6b/380fa861-3f46-44a9-a514-21553f7fbe6b_379601_SOURCE.jpg") // Required
             },
-            SameAs = new List<Uri> {
+            SameAs = new List<Uri>
+            {
                 new Uri("https://www.twitter.com/dolbytheatre"), // Recommended
                 new Uri("http://www.dolbytheatre.com") // Recommended
             },

--- a/Tests/Schema.NET.Test/core/MusicVenueTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicVenueTest.cs
@@ -1,0 +1,86 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class MusicVenueTest
+    {
+        private readonly MusicVenue musicVenue = new MusicVenue()
+        {
+            Name = "Dolby Theatre", // Required
+            Description = "Host to a range of prestigious events including movie premieres, concerts & the Oscars http://www.dolbytheatre.com", // Recommended
+            Identifier = "KovZpZAdtaEA", // Recommended
+            Image = new ImageObject() // Recommended
+            {
+                ContentUrl = new Uri("https://s1.ticketm.net/dam/v/e6b/380fa861-3f46-44a9-a514-21553f7fbe6b_379601_SOURCE.jpg") // Required
+            },
+            SameAs = new List<Uri> {
+                new Uri("https://www.twitter.com/dolbytheatre"), // Recommended
+                new Uri("http://www.dolbytheatre.com") // Recommended
+            },
+            Url = new Uri("https://foursquare.com/dolbytheatre"), // Recommended
+            Address = new PostalAddress() // Recommended
+            {
+                StreetAddress = "6801 Hollywood Blvd", // Recommended
+                AddressLocality = "Los Angeles", // Recommended
+                AddressRegion = "CA", // Recommended
+                PostalCode = "90028", // Recommended
+                AddressCountry = "US" // Recommended
+            },
+            Geo = new GeoCoordinates() // Recommended
+            {
+                Latitude = "34.1018929033898", // Recommended
+                Longitude = "-118.340147939959" // Recommended
+            },
+            Telephone = "(323) 308-6300" // Recommended
+        };
+
+        private readonly string json =
+        "{" +
+            "\"@context\": \"http://schema.org\"," +
+            "\"@type\": \"MusicVenue\"," +
+            "\"name\": \"Dolby Theatre\"," +
+            "\"description\": \"Host to a range of prestigious events including movie premieres, concerts & the Oscars http://www.dolbytheatre.com\"," +
+            "\"identifier\": \"KovZpZAdtaEA\"," +
+            "\"image\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"ImageObject\"," +
+                "\"contentUrl\": \"https://s1.ticketm.net/dam/v/e6b/380fa861-3f46-44a9-a514-21553f7fbe6b_379601_SOURCE.jpg\"" +
+            "}," +
+            "\"sameAs\": [" +
+                "\"https://www.twitter.com/dolbytheatre\"," +
+                "\"http://www.dolbytheatre.com\"" +
+            "]," +
+            "\"url\": \"https://foursquare.com/dolbytheatre\"," +
+            "\"address\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"PostalAddress\"," +
+                "\"addressCountry\": \"US\"," +
+                "\"addressLocality\": \"Los Angeles\"," +
+                "\"addressRegion\": \"CA\"," +
+                "\"postalCode\": \"90028\"," +
+                "\"streetAddress\": \"6801 Hollywood Blvd\"" +
+            "}," +
+            "\"geo\": {" +
+                "\"@context\": \"http://schema.org\"," +
+                "\"@type\": \"GeoCoordinates\"," +
+                "\"latitude\": \"34.1018929033898\"," +
+                "\"longitude\": \"-118.340147939959\"" +
+            "}," +
+            "\"telephone\": \"(323) 308-6300\"" +
+        "}";
+
+        [Fact]
+        public void Deserializing_MusicVenueJsonLd_ReturnsMusicVenue()
+        {
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            Assert.Equal(this.musicVenue.ToString(), JsonConvert.DeserializeObject<MusicVenue>(this.json, serializerSettings).ToString());
+        }
+    }
+}


### PR DESCRIPTION
@RehanSaeed I've refactored ValuesJsonConverter.cs a good bit.

This passes all unit tests, and even better, doesn't hit your exception 'catch' statements for any of the unit tests. Note some of the // REVIEW comments.

I may have taken liberties with reusing common refactored methods between the single type, and multiple type arg, use cases, but it seems to work.

NOTE: I've kept same semantics where it picks the *last* matching type in the list, by going right-to-left and selecting first one that matches.  This should be a perf benefit, since it was doing wasted work before.