### PR TITLE
fixing null Values<T>

### DIFF
--- a/Source/Schema.NET.Tool/ViewModels/Property.cs
+++ b/Source/Schema.NET.Tool/ViewModels/Property.cs
@@ -35,7 +35,7 @@ namespace Schema.NET.Tool.ViewModels
                 }
                 else
                 {
-                    return $"Values<{adjustedTypesString}>?";
+                    return $"Values<{adjustedTypesString}>";
                 }
             }
         }

--- a/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
@@ -27,7 +27,7 @@ namespace Schema.NET
             this.Value2 = default;
             this.Value3 = default;
             this.Value4 = default;
-            this.HasValue1 = value.Count > 0 ? true : false;
+            this.HasValue1 = value.Count > 0;
             this.HasValue2 = false;
             this.HasValue3 = false;
             this.HasValue4 = false;
@@ -44,7 +44,7 @@ namespace Schema.NET
             this.Value3 = default;
             this.Value4 = default;
             this.HasValue1 = false;
-            this.HasValue2 = value.Count > 0 ? true : false;
+            this.HasValue2 = value.Count > 0;
             this.HasValue3 = false;
             this.HasValue4 = false;
         }
@@ -61,7 +61,7 @@ namespace Schema.NET
             this.Value4 = default;
             this.HasValue1 = false;
             this.HasValue2 = false;
-            this.HasValue3 = value.Count > 0 ? true : false;
+            this.HasValue3 = value.Count > 0;
             this.HasValue4 = false;
         }
 
@@ -78,7 +78,7 @@ namespace Schema.NET
             this.HasValue1 = false;
             this.HasValue2 = false;
             this.HasValue3 = false;
-            this.HasValue4 = value.Count > 0 ? true : false;
+            this.HasValue4 = value.Count > 0;
         }
 
         /// <summary>
@@ -501,7 +501,7 @@ namespace Schema.NET
                     return this.Value4.Equals(other.Value4);
                 }
             }
-            else if (!other.HasValue1 && !other.HasValue2 && !other.HasValue3 && !other.HasValue4 && !this.HasValue1 && !this.HasValue2 && !this.HasValue3 && !this.HasValue4)
+            else if (!other.HasValue && !this.HasValue)
             {
                 return true;
             }

--- a/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
@@ -27,7 +27,7 @@ namespace Schema.NET
             this.Value2 = default;
             this.Value3 = default;
             this.Value4 = default;
-            this.HasValue1 = true;
+            this.HasValue1 = value.Count > 0 ? true : false;
             this.HasValue2 = false;
             this.HasValue3 = false;
             this.HasValue4 = false;
@@ -44,7 +44,7 @@ namespace Schema.NET
             this.Value3 = default;
             this.Value4 = default;
             this.HasValue1 = false;
-            this.HasValue2 = true;
+            this.HasValue2 = value.Count > 0 ? true : false;
             this.HasValue3 = false;
             this.HasValue4 = false;
         }
@@ -61,24 +61,24 @@ namespace Schema.NET
             this.Value4 = default;
             this.HasValue1 = false;
             this.HasValue2 = false;
-            this.HasValue3 = true;
+            this.HasValue3 = value.Count > 0 ? true : false;
             this.HasValue4 = false;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> struct.
         /// </summary>
-        /// <param name="values">The value of type <typeparamref name="T4"/>.</param>
-        public Values(OneOrMany<T4> values)
+        /// <param name="value">The value of type <typeparamref name="T4"/>.</param>
+        public Values(OneOrMany<T4> value)
         {
             this.Value1 = default;
             this.Value2 = default;
             this.Value3 = default;
-            this.Value4 = values;
+            this.Value4 = value;
             this.HasValue1 = false;
             this.HasValue2 = false;
             this.HasValue3 = false;
-            this.HasValue4 = true;
+            this.HasValue4 = value.Count > 0 ? true : false;
         }
 
         /// <summary>
@@ -500,6 +500,10 @@ namespace Schema.NET
                 {
                     return this.Value4.Equals(other.Value4);
                 }
+            }
+            else if (!other.HasValue1 && !other.HasValue2 && !other.HasValue3 && !other.HasValue4 && !this.HasValue1 && !this.HasValue2 && !this.HasValue3 && !this.HasValue4)
+            {
+                return true;
             }
 
             return false;

--- a/Source/Schema.NET/Values{T1,T2,T3}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3}.cs
@@ -25,7 +25,7 @@ namespace Schema.NET
             this.Value1 = value;
             this.Value2 = default;
             this.Value3 = default;
-            this.HasValue1 = true;
+            this.HasValue1 = value.Count > 0 ? true : false;
             this.HasValue2 = false;
             this.HasValue3 = false;
         }
@@ -40,7 +40,7 @@ namespace Schema.NET
             this.Value2 = value;
             this.Value3 = default;
             this.HasValue1 = false;
-            this.HasValue2 = true;
+            this.HasValue2 = value.Count > 0 ? true : false;
             this.HasValue3 = false;
         }
 
@@ -55,7 +55,7 @@ namespace Schema.NET
             this.Value3 = value;
             this.HasValue1 = false;
             this.HasValue2 = false;
-            this.HasValue3 = true;
+            this.HasValue3 = value.Count > 0 ? true : false;
         }
 
         /// <summary>
@@ -424,6 +424,10 @@ namespace Schema.NET
                 {
                     return this.Value3.Equals(other.Value3);
                 }
+            }
+            else if (!other.HasValue1 && !other.HasValue2 && !other.HasValue3 && !this.HasValue1 && !this.HasValue2 && !this.HasValue3)
+            {
+                return true;
             }
 
             return false;

--- a/Source/Schema.NET/Values{T1,T2,T3}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3}.cs
@@ -25,7 +25,7 @@ namespace Schema.NET
             this.Value1 = value;
             this.Value2 = default;
             this.Value3 = default;
-            this.HasValue1 = value.Count > 0 ? true : false;
+            this.HasValue1 = value.Count > 0;
             this.HasValue2 = false;
             this.HasValue3 = false;
         }
@@ -40,7 +40,7 @@ namespace Schema.NET
             this.Value2 = value;
             this.Value3 = default;
             this.HasValue1 = false;
-            this.HasValue2 = value.Count > 0 ? true : false;
+            this.HasValue2 = value.Count > 0;
             this.HasValue3 = false;
         }
 
@@ -55,7 +55,7 @@ namespace Schema.NET
             this.Value3 = value;
             this.HasValue1 = false;
             this.HasValue2 = false;
-            this.HasValue3 = value.Count > 0 ? true : false;
+            this.HasValue3 = value.Count > 0;
         }
 
         /// <summary>
@@ -425,7 +425,7 @@ namespace Schema.NET
                     return this.Value3.Equals(other.Value3);
                 }
             }
-            else if (!other.HasValue1 && !other.HasValue2 && !other.HasValue3 && !this.HasValue1 && !this.HasValue2 && !this.HasValue3)
+            else if (!other.HasValue && !this.HasValue)
             {
                 return true;
             }

--- a/Source/Schema.NET/Values{T1,T2}.cs
+++ b/Source/Schema.NET/Values{T1,T2}.cs
@@ -23,7 +23,7 @@ namespace Schema.NET
         {
             this.Value1 = value;
             this.Value2 = default;
-            this.HasValue1 = value.Count > 0 ? true : false;
+            this.HasValue1 = value.Count > 0;
             this.HasValue2 = false;
         }
 
@@ -36,7 +36,7 @@ namespace Schema.NET
             this.Value1 = default;
             this.Value2 = value;
             this.HasValue1 = false;
-            this.HasValue2 = value.Count > 0 ? true : false;
+            this.HasValue2 = value.Count > 0;
         }
 
         /// <summary>
@@ -324,7 +324,7 @@ namespace Schema.NET
                     return this.Value2.Equals(other.Value2);
                 }
             }
-            else if (!other.HasValue1 && !other.HasValue2 && !this.HasValue1 && !this.HasValue2)
+            else if (!other.HasValue && !this.HasValue)
             {
                 return true;
             }

--- a/Source/Schema.NET/Values{T1,T2}.cs
+++ b/Source/Schema.NET/Values{T1,T2}.cs
@@ -23,7 +23,7 @@ namespace Schema.NET
         {
             this.Value1 = value;
             this.Value2 = default;
-            this.HasValue1 = true;
+            this.HasValue1 = value.Count > 0 ? true : false;
             this.HasValue2 = false;
         }
 
@@ -36,7 +36,7 @@ namespace Schema.NET
             this.Value1 = default;
             this.Value2 = value;
             this.HasValue1 = false;
-            this.HasValue2 = true;
+            this.HasValue2 = value.Count > 0 ? true : false;
         }
 
         /// <summary>
@@ -323,6 +323,10 @@ namespace Schema.NET
                 {
                     return this.Value2.Equals(other.Value2);
                 }
+            }
+            else if (!other.HasValue1 && !other.HasValue2 && !this.HasValue1 && !this.HasValue2)
+            {
+                return true;
             }
 
             return false;

--- a/Source/Schema.NET/bib/Chapter.cs
+++ b/Source/Schema.NET/bib/Chapter.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// The page on which the work ends; for example "138" or "xvi".
         /// </summary>
-        Values<int?, string>? PageEnd { get; set; }
+        Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
-        Values<int?, string>? PageStart { get; set; }
+        Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".
@@ -42,14 +42,14 @@
         /// </summary>
         [DataMember(Name = "pageEnd", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageEnd { get; set; }
+        public Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
         [DataMember(Name = "pageStart", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageStart { get; set; }
+        public Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".

--- a/Source/Schema.NET/bib/combined/AudioObjectAndBook.cs
+++ b/Source/Schema.NET/bib/combined/AudioObjectAndBook.cs
@@ -49,7 +49,7 @@
         /// </summary>
         [DataMember(Name = "caption", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMediaObject, string>? Caption { get; set; }
+        public Values<IMediaObject, string> Caption { get; set; }
 
         /// <summary>
         /// The illustrator of the book.

--- a/Source/Schema.NET/core/Accommodation.cs
+++ b/Source/Schema.NET/core/Accommodation.cs
@@ -22,7 +22,7 @@
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
         /// Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// Indications regarding the permitted usage of the accommodation.
@@ -32,7 +32,7 @@
         /// <summary>
         /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
         /// </summary>
-        Values<bool?, string>? PetsAllowed { get; set; }
+        Values<bool?, string> PetsAllowed { get; set; }
     }
 
     /// <summary>
@@ -71,7 +71,7 @@
         /// </summary>
         [DataMember(Name = "numberOfRooms", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        public virtual Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// Indications regarding the permitted usage of the accommodation.
@@ -85,6 +85,6 @@
         /// </summary>
         [DataMember(Name = "petsAllowed", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, string>? PetsAllowed { get; set; }
+        public Values<bool?, string> PetsAllowed { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Action.cs
+++ b/Source/Schema.NET/core/Action.cs
@@ -18,13 +18,13 @@
         /// <summary>
         /// The direct performer or driver of the action (animate or inanimate). e.g. &lt;em&gt;John&lt;/em&gt; wrote a book.
         /// </summary>
-        Values<IOrganization, IPerson>? Agent { get; set; }
+        Values<IOrganization, IPerson> Agent { get; set; }
 
         /// <summary>
         /// The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to &lt;em&gt;December&lt;/em&gt;. For media, including audio and video, it's the time offset of the end of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
         /// Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
         /// </summary>
-        OneOrMany<DateTimeOffset?> EndTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> EndTime { get; set; }
 
         /// <summary>
         /// For failed actions, more information on the cause of the failure.
@@ -39,7 +39,7 @@
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// The object upon which the action is carried out, whose state is kept intact or changed. Also known as the semantic roles patient, affected or undergoer (which change their state) or theme (which doesn't). e.g. John read &lt;em&gt;a book&lt;/em&gt;.
@@ -49,7 +49,7 @@
         /// <summary>
         /// Other co-agents that participated in the action indirectly. e.g. John wrote a book with &lt;em&gt;Steve&lt;/em&gt;.
         /// </summary>
-        Values<IOrganization, IPerson>? Participant { get; set; }
+        Values<IOrganization, IPerson> Participant { get; set; }
 
         /// <summary>
         /// The result produced in the action. e.g. John wrote &lt;em&gt;a book&lt;/em&gt;.
@@ -60,12 +60,12 @@
         /// The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from &lt;em&gt;January&lt;/em&gt; to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
         /// Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
         /// </summary>
-        OneOrMany<DateTimeOffset?> StartTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> StartTime { get; set; }
 
         /// <summary>
         /// Indicates a target EntryPoint for an Action.
         /// </summary>
-        Values<IEntryPoint, Uri>? Target { get; set; }
+        Values<IEntryPoint, Uri> Target { get; set; }
     }
 
     /// <summary>
@@ -93,7 +93,7 @@
         /// </summary>
         [DataMember(Name = "agent", Order = 107)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Agent { get; set; }
+        public Values<IOrganization, IPerson> Agent { get; set; }
 
         /// <summary>
         /// The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to &lt;em&gt;December&lt;/em&gt;. For media, including audio and video, it's the time offset of the end of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
@@ -101,7 +101,7 @@
         /// </summary>
         [DataMember(Name = "endTime", Order = 108)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> EndTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> EndTime { get; set; }
 
         /// <summary>
         /// For failed actions, more information on the cause of the failure.
@@ -122,7 +122,7 @@
         /// </summary>
         [DataMember(Name = "location", Order = 111)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        public Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// The object upon which the action is carried out, whose state is kept intact or changed. Also known as the semantic roles patient, affected or undergoer (which change their state) or theme (which doesn't). e.g. John read &lt;em&gt;a book&lt;/em&gt;.
@@ -136,7 +136,7 @@
         /// </summary>
         [DataMember(Name = "participant", Order = 113)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Participant { get; set; }
+        public Values<IOrganization, IPerson> Participant { get; set; }
 
         /// <summary>
         /// The result produced in the action. e.g. John wrote &lt;em&gt;a book&lt;/em&gt;.
@@ -151,13 +151,13 @@
         /// </summary>
         [DataMember(Name = "startTime", Order = 115)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> StartTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> StartTime { get; set; }
 
         /// <summary>
         /// Indicates a target EntryPoint for an Action.
         /// </summary>
         [DataMember(Name = "target", Order = 116)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IEntryPoint, Uri>? Target { get; set; }
+        public Values<IEntryPoint, Uri> Target { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ActionAccessSpecification.cs
+++ b/Source/Schema.NET/core/ActionAccessSpecification.cs
@@ -12,23 +12,23 @@
         /// <summary>
         /// The end of the availability of the product or service included in the offer.
         /// </summary>
-        OneOrMany<DateTimeOffset?> AvailabilityEnds { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityEnds { get; set; }
 
         /// <summary>
         /// The beginning of the availability of the product or service included in the offer.
         /// </summary>
-        OneOrMany<DateTimeOffset?> AvailabilityStarts { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityStarts { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
-        Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/ineligibleRegion"&gt;ineligibleRegion&lt;/a&gt;.
         /// </summary>
-        Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// An Offer which must be accepted before the user can perform the Action. For example, the user may need to buy a movie before being able to watch it.
@@ -38,7 +38,7 @@
         /// <summary>
         /// Indicates if use of the media require a subscription  (either paid or free). Allowed values are &lt;code&gt;true&lt;/code&gt; or &lt;code&gt;false&lt;/code&gt; (note that an earlier version had 'yes', 'no').
         /// </summary>
-        Values<bool?, IMediaSubscription>? RequiresSubscription { get; set; }
+        Values<bool?, IMediaSubscription> RequiresSubscription { get; set; }
     }
 
     /// <summary>
@@ -57,22 +57,22 @@
         /// The end of the availability of the product or service included in the offer.
         /// </summary>
         [DataMember(Name = "availabilityEnds", Order = 206)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> AvailabilityEnds { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityEnds { get; set; }
 
         /// <summary>
         /// The beginning of the availability of the product or service included in the offer.
         /// </summary>
         [DataMember(Name = "availabilityStarts", Order = 207)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> AvailabilityStarts { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityStarts { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
         [DataMember(Name = "category", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.&lt;br/&gt;&lt;br/&gt;
@@ -80,7 +80,7 @@
         /// </summary>
         [DataMember(Name = "eligibleRegion", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        public Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// An Offer which must be accepted before the user can perform the Action. For example, the user may need to buy a movie before being able to watch it.
@@ -94,6 +94,6 @@
         /// </summary>
         [DataMember(Name = "requiresSubscription", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, IMediaSubscription>? RequiresSubscription { get; set; }
+        public Values<bool?, IMediaSubscription> RequiresSubscription { get; set; }
     }
 }

--- a/Source/Schema.NET/core/AggregateOffer.cs
+++ b/Source/Schema.NET/core/AggregateOffer.cs
@@ -17,7 +17,7 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<decimal?, string>? HighPrice { get; set; }
+        Values<decimal?, string> HighPrice { get; set; }
 
         /// <summary>
         /// The lowest price of all offers available.&lt;br/&gt;&lt;br/&gt;
@@ -27,7 +27,7 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<decimal?, string>? LowPrice { get; set; }
+        Values<decimal?, string> LowPrice { get; set; }
 
         /// <summary>
         /// The number of offers for the product.
@@ -62,7 +62,7 @@
         /// </summary>
         [DataMember(Name = "highPrice", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, string>? HighPrice { get; set; }
+        public Values<decimal?, string> HighPrice { get; set; }
 
         /// <summary>
         /// The lowest price of all offers available.&lt;br/&gt;&lt;br/&gt;
@@ -74,7 +74,7 @@
         /// </summary>
         [DataMember(Name = "lowPrice", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, string>? LowPrice { get; set; }
+        public Values<decimal?, string> LowPrice { get; set; }
 
         /// <summary>
         /// The number of offers for the product.

--- a/Source/Schema.NET/core/AllocateAction.cs
+++ b/Source/Schema.NET/core/AllocateAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A goal towards an action is taken. Can be concrete or abstract.
         /// </summary>
-        Values<MedicalDevicePurpose?, IThing>? Purpose { get; set; }
+        Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "purpose", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<MedicalDevicePurpose?, IThing>? Purpose { get; set; }
+        public Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
     }
 }

--- a/Source/Schema.NET/core/AnatomicalSystem.cs
+++ b/Source/Schema.NET/core/AnatomicalSystem.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// Specifying something physically contained by something else. Typically used here for the underlying anatomical structures, such as organs, that comprise the anatomical system.
         /// </summary>
-        Values<IAnatomicalStructure, IAnatomicalSystem>? ComprisedOf { get; set; }
+        Values<IAnatomicalStructure, IAnatomicalSystem> ComprisedOf { get; set; }
 
         /// <summary>
         /// A medical condition associated with this anatomy.
@@ -59,7 +59,7 @@
         /// </summary>
         [DataMember(Name = "comprisedOf", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, IAnatomicalSystem>? ComprisedOf { get; set; }
+        public Values<IAnatomicalStructure, IAnatomicalSystem> ComprisedOf { get; set; }
 
         /// <summary>
         /// A medical condition associated with this anatomy.

--- a/Source/Schema.NET/core/Apartment.cs
+++ b/Source/Schema.NET/core/Apartment.cs
@@ -34,7 +34,7 @@
         /// </summary>
         [DataMember(Name = "numberOfRooms", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        public override Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).

--- a/Source/Schema.NET/core/Article.cs
+++ b/Source/Schema.NET/core/Article.cs
@@ -23,17 +23,17 @@
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Article"&gt;Article&lt;/a&gt;, typically a &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;, the backstory property provides a textual summary giving a brief explanation of why and how an article was created. In a journalistic setting this could include information about reporting process, methods, interviews, data sources, etc.
         /// </summary>
-        Values<ICreativeWork, string>? Backstory { get; set; }
+        Values<ICreativeWork, string> Backstory { get; set; }
 
         /// <summary>
         /// The page on which the work ends; for example "138" or "xvi".
         /// </summary>
-        Values<int?, string>? PageEnd { get; set; }
+        Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
-        Values<int?, string>? PageStart { get; set; }
+        Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".
@@ -49,7 +49,7 @@
         /// For more sophisticated markup of speakable sections beyond simple ID references, either CSS selectors or XPath expressions to pick out document section(s) as speakable. For this
         /// we define a supporting type, &lt;a class="localLink" href="http://schema.org/SpeakableSpecification"&gt;SpeakableSpecification&lt;/a&gt;  which is defined to be a possible value of the &lt;em&gt;speakable&lt;/em&gt; property.
         /// </summary>
-        Values<ISpeakableSpecification, Uri>? Speakable { get; set; }
+        Values<ISpeakableSpecification, Uri> Speakable { get; set; }
 
         /// <summary>
         /// The number of words in the text of the Article.
@@ -89,21 +89,21 @@
         /// </summary>
         [DataMember(Name = "backstory", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, string>? Backstory { get; set; }
+        public Values<ICreativeWork, string> Backstory { get; set; }
 
         /// <summary>
         /// The page on which the work ends; for example "138" or "xvi".
         /// </summary>
         [DataMember(Name = "pageEnd", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageEnd { get; set; }
+        public Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
         [DataMember(Name = "pageStart", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageStart { get; set; }
+        public Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".
@@ -123,7 +123,7 @@
         /// </summary>
         [DataMember(Name = "speakable", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ISpeakableSpecification, Uri>? Speakable { get; set; }
+        public Values<ISpeakableSpecification, Uri> Speakable { get; set; }
 
         /// <summary>
         /// The number of words in the text of the Article.

--- a/Source/Schema.NET/core/AudioObject.cs
+++ b/Source/Schema.NET/core/AudioObject.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The caption for this object. For downloadable machine formats (closed caption, subtitles etc.) use MediaObject and indicate the &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt;.
         /// </summary>
-        Values<IMediaObject, string>? Caption { get; set; }
+        Values<IMediaObject, string> Caption { get; set; }
 
         /// <summary>
         /// If this MediaObject is an AudioObject or VideoObject, the transcript of that object.
@@ -37,7 +37,7 @@
         /// </summary>
         [DataMember(Name = "caption", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMediaObject, string>? Caption { get; set; }
+        public Values<IMediaObject, string> Caption { get; set; }
 
         /// <summary>
         /// If this MediaObject is an AudioObject or VideoObject, the transcript of that object.

--- a/Source/Schema.NET/core/AuthorizeAction.cs
+++ b/Source/Schema.NET/core/AuthorizeAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "recipient", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/BankAccount.cs
+++ b/Source/Schema.NET/core/BankAccount.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// The type of a bank account.
         /// </summary>
-        Values<string, Uri>? BankAccountType { get; set; }
+        Values<string, Uri> BankAccountType { get; set; }
     }
 
     /// <summary>
@@ -56,6 +56,6 @@
         /// </summary>
         [DataMember(Name = "bankAccountType", Order = 408)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? BankAccountType { get; set; }
+        public Values<string, Uri> BankAccountType { get; set; }
     }
 }

--- a/Source/Schema.NET/core/BedDetails.cs
+++ b/Source/Schema.NET/core/BedDetails.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The type of bed to which the BedDetail refers, i.e. the type of bed available in the quantity indicated by quantity.
         /// </summary>
-        Values<BedType?, string>? TypeOfBed { get; set; }
+        Values<BedType?, string> TypeOfBed { get; set; }
     }
 
     /// <summary>
@@ -44,6 +44,6 @@
         /// </summary>
         [DataMember(Name = "typeOfBed", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<BedType?, string>? TypeOfBed { get; set; }
+        public Values<BedType?, string> TypeOfBed { get; set; }
     }
 }

--- a/Source/Schema.NET/core/BorrowAction.cs
+++ b/Source/Schema.NET/core/BorrowAction.cs
@@ -16,7 +16,7 @@
         /// <summary>
         /// A sub property of participant. The person that lends the object being borrowed.
         /// </summary>
-        Values<IOrganization, IPerson>? Lender { get; set; }
+        Values<IOrganization, IPerson> Lender { get; set; }
     }
 
     /// <summary>
@@ -40,6 +40,6 @@
         /// </summary>
         [DataMember(Name = "lender", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Lender { get; set; }
+        public Values<IOrganization, IPerson> Lender { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Brand.cs
+++ b/Source/Schema.NET/core/Brand.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// An associated logo.
         /// </summary>
-        Values<IImageObject, Uri>? Logo { get; set; }
+        Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -54,7 +54,7 @@
         /// </summary>
         [DataMember(Name = "logo", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Logo { get; set; }
+        public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A review of the item.

--- a/Source/Schema.NET/core/BroadcastChannel.cs
+++ b/Source/Schema.NET/core/BroadcastChannel.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The frequency used for over-the-air broadcasts. Numeric values or simple ranges e.g. 87-99. In addition a shortcut idiom is supported for frequences of AM and FM radio channels, e.g. "87 FM".
         /// </summary>
-        Values<IBroadcastFrequencySpecification, string>? BroadcastFrequency { get; set; }
+        Values<IBroadcastFrequencySpecification, string> BroadcastFrequency { get; set; }
 
         /// <summary>
         /// The type of service required to have access to the channel (e.g. Standard or Premium).
@@ -27,7 +27,7 @@
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        Values<string, Uri>? Genre { get; set; }
+        Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// The CableOrSatelliteService offering the channel.
@@ -64,7 +64,7 @@
         /// </summary>
         [DataMember(Name = "broadcastFrequency", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBroadcastFrequencySpecification, string>? BroadcastFrequency { get; set; }
+        public Values<IBroadcastFrequencySpecification, string> BroadcastFrequency { get; set; }
 
         /// <summary>
         /// The type of service required to have access to the channel (e.g. Standard or Premium).
@@ -78,7 +78,7 @@
         /// </summary>
         [DataMember(Name = "genre", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// The CableOrSatelliteService offering the channel.

--- a/Source/Schema.NET/core/BroadcastFrequencySpecification.cs
+++ b/Source/Schema.NET/core/BroadcastFrequencySpecification.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The frequency in MHz for a particular broadcast.
         /// </summary>
-        Values<double?, IQuantitativeValue>? BroadcastFrequencyValue { get; set; }
+        Values<double?, IQuantitativeValue> BroadcastFrequencyValue { get; set; }
 
         /// <summary>
         /// The modulation (e.g. FM, AM, etc) used by a particular broadcast service
@@ -42,7 +42,7 @@
         /// </summary>
         [DataMember(Name = "broadcastFrequencyValue", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, IQuantitativeValue>? BroadcastFrequencyValue { get; set; }
+        public Values<double?, IQuantitativeValue> BroadcastFrequencyValue { get; set; }
 
         /// <summary>
         /// The modulation (e.g. FM, AM, etc) used by a particular broadcast service

--- a/Source/Schema.NET/core/BroadcastService.cs
+++ b/Source/Schema.NET/core/BroadcastService.cs
@@ -27,7 +27,7 @@
         /// <summary>
         /// The frequency used for over-the-air broadcasts. Numeric values or simple ranges e.g. 87-99. In addition a shortcut idiom is supported for frequences of AM and FM radio channels, e.g. "87 FM".
         /// </summary>
-        Values<IBroadcastFrequencySpecification, string>? BroadcastFrequency { get; set; }
+        Values<IBroadcastFrequencySpecification, string> BroadcastFrequency { get; set; }
 
         /// <summary>
         /// The timezone in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 format&lt;/a&gt; for which the service bases its broadcasts
@@ -88,7 +88,7 @@
         /// </summary>
         [DataMember(Name = "broadcastFrequency", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBroadcastFrequencySpecification, string>? BroadcastFrequency { get; set; }
+        public Values<IBroadcastFrequencySpecification, string> BroadcastFrequency { get; set; }
 
         /// <summary>
         /// The timezone in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 format&lt;/a&gt; for which the service bases its broadcasts

--- a/Source/Schema.NET/core/BusTrip.cs
+++ b/Source/Schema.NET/core/BusTrip.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The stop or station from which the bus arrives.
         /// </summary>
-        Values<IBusStation, IBusStop>? ArrivalBusStop { get; set; }
+        Values<IBusStation, IBusStop> ArrivalBusStop { get; set; }
 
         /// <summary>
         /// The name of the bus (e.g. Bolt Express).
@@ -27,7 +27,7 @@
         /// <summary>
         /// The stop or station from which the bus departs.
         /// </summary>
-        Values<IBusStation, IBusStop>? DepartureBusStop { get; set; }
+        Values<IBusStation, IBusStop> DepartureBusStop { get; set; }
     }
 
     /// <summary>
@@ -47,7 +47,7 @@
         /// </summary>
         [DataMember(Name = "arrivalBusStop", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBusStation, IBusStop>? ArrivalBusStop { get; set; }
+        public Values<IBusStation, IBusStop> ArrivalBusStop { get; set; }
 
         /// <summary>
         /// The name of the bus (e.g. Bolt Express).
@@ -68,6 +68,6 @@
         /// </summary>
         [DataMember(Name = "departureBusStop", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBusStation, IBusStop>? DepartureBusStop { get; set; }
+        public Values<IBusStation, IBusStop> DepartureBusStop { get; set; }
     }
 }

--- a/Source/Schema.NET/core/BuyAction.cs
+++ b/Source/Schema.NET/core/BuyAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        Values<IOrganization, IPerson>? Seller { get; set; }
+        Values<IOrganization, IPerson> Seller { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "seller", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Seller { get; set; }
+        public Values<IOrganization, IPerson> Seller { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ChooseAction.cs
+++ b/Source/Schema.NET/core/ChooseAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of object. The options subject to this action.
         /// </summary>
-        Values<string, IThing>? ActionOption { get; set; }
+        Values<string, IThing> ActionOption { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "actionOption", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IThing>? ActionOption { get; set; }
+        public Values<string, IThing> ActionOption { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Clip.cs
+++ b/Source/Schema.NET/core/Clip.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// Position of the clip within an ordered group of clips.
         /// </summary>
-        Values<int?, string>? ClipNumber { get; set; }
+        Values<int?, string> ClipNumber { get; set; }
 
         /// <summary>
         /// A director of e.g. tv, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip.
@@ -32,7 +32,7 @@
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The episode to which this clip belongs.
@@ -79,7 +79,7 @@
         /// </summary>
         [DataMember(Name = "clipNumber", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? ClipNumber { get; set; }
+        public Values<int?, string> ClipNumber { get; set; }
 
         /// <summary>
         /// A director of e.g. tv, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip.
@@ -100,7 +100,7 @@
         /// </summary>
         [DataMember(Name = "musicBy", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The episode to which this clip belongs.

--- a/Source/Schema.NET/core/CommunicateAction.cs
+++ b/Source/Schema.NET/core/CommunicateAction.cs
@@ -17,12 +17,12 @@
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? InLanguage { get; set; }
+        Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -49,13 +49,13 @@
         /// </summary>
         [DataMember(Name = "inLanguage", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
         [DataMember(Name = "recipient", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ContactPoint.cs
+++ b/Source/Schema.NET/core/ContactPoint.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// The geographic area where a service or offered item is provided.
         /// </summary>
-        Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// A language someone may use with or at the item, service or place. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/inLanguage"&gt;inLanguage&lt;/a&gt;
         /// </summary>
-        Values<ILanguage, string>? AvailableLanguage { get; set; }
+        Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// An option available on this contact point (e.g. a toll-free number or support for hearing-impaired callers).
@@ -47,7 +47,7 @@
         /// <summary>
         /// The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. "iPhone") or a general category of products or services (e.g. "smartphones").
         /// </summary>
-        Values<IProduct, string>? ProductSupported { get; set; }
+        Values<IProduct, string> ProductSupported { get; set; }
 
         /// <summary>
         /// The telephone number.
@@ -72,14 +72,14 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// A language someone may use with or at the item, service or place. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/inLanguage"&gt;inLanguage&lt;/a&gt;
         /// </summary>
         [DataMember(Name = "availableLanguage", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? AvailableLanguage { get; set; }
+        public Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// An option available on this contact point (e.g. a toll-free number or support for hearing-impaired callers).
@@ -121,7 +121,7 @@
         /// </summary>
         [DataMember(Name = "productSupported", Order = 313)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string>? ProductSupported { get; set; }
+        public Values<IProduct, string> ProductSupported { get; set; }
 
         /// <summary>
         /// The telephone number.

--- a/Source/Schema.NET/core/CookAction.cs
+++ b/Source/Schema.NET/core/CookAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of location. The specific food establishment where the action occurred.
         /// </summary>
-        Values<IFoodEstablishment, IPlace>? FoodEstablishment { get; set; }
+        Values<IFoodEstablishment, IPlace> FoodEstablishment { get; set; }
 
         /// <summary>
         /// A sub property of location. The specific food event where the action occurred.
@@ -42,7 +42,7 @@
         /// </summary>
         [DataMember(Name = "foodEstablishment", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IFoodEstablishment, IPlace>? FoodEstablishment { get; set; }
+        public Values<IFoodEstablishment, IPlace> FoodEstablishment { get; set; }
 
         /// <summary>
         /// A sub property of location. The specific food event where the action occurred.

--- a/Source/Schema.NET/core/Course.cs
+++ b/Source/Schema.NET/core/Course.cs
@@ -17,17 +17,22 @@
         /// <summary>
         /// Requirements for taking the Course. May be completion of another &lt;a class="localLink" href="http://schema.org/Course"&gt;Course&lt;/a&gt; or a textual description like "permission of instructor". Requirements may be a pre-requisite competency, referenced using &lt;a class="localLink" href="http://schema.org/AlignmentObject"&gt;AlignmentObject&lt;/a&gt;.
         /// </summary>
-        Values<IAlignmentObject, ICourse, string>? CoursePrerequisites { get; set; }
+        Values<IAlignmentObject, ICourse, string> CoursePrerequisites { get; set; }
 
         /// <summary>
-        /// A description of the qualification, award, certificate, diploma or other educational credential awarded as a consequence of successful completion of this course.
+        /// A description of the qualification, award, certificate, diploma or other educational credential awarded as a consequence of successful completion of this course or program.
         /// </summary>
-        Values<string, Uri>? EducationalCredentialAwarded { get; set; }
+        Values<string, Uri> EducationalCredentialAwarded { get; set; }
 
         /// <summary>
         /// An offering of the course at a specific time and place or through specific media or mode of study or to a specific section of students.
         /// </summary>
         OneOrMany<ICourseInstance> HasCourseInstance { get; set; }
+
+        /// <summary>
+        /// A description of the qualification, award, certificate, diploma or other occupational credential awarded as a consequence of successful completion of this course or program.
+        /// </summary>
+        Values<string, Uri> OccupationalCredentialAwarded { get; set; }
     }
 
     /// <summary>
@@ -54,14 +59,14 @@
         /// </summary>
         [DataMember(Name = "coursePrerequisites", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAlignmentObject, ICourse, string>? CoursePrerequisites { get; set; }
+        public Values<IAlignmentObject, ICourse, string> CoursePrerequisites { get; set; }
 
         /// <summary>
-        /// A description of the qualification, award, certificate, diploma or other educational credential awarded as a consequence of successful completion of this course.
+        /// A description of the qualification, award, certificate, diploma or other educational credential awarded as a consequence of successful completion of this course or program.
         /// </summary>
         [DataMember(Name = "educationalCredentialAwarded", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? EducationalCredentialAwarded { get; set; }
+        public Values<string, Uri> EducationalCredentialAwarded { get; set; }
 
         /// <summary>
         /// An offering of the course at a specific time and place or through specific media or mode of study or to a specific section of students.
@@ -69,5 +74,12 @@
         [DataMember(Name = "hasCourseInstance", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICourseInstance> HasCourseInstance { get; set; }
+
+        /// <summary>
+        /// A description of the qualification, award, certificate, diploma or other occupational credential awarded as a consequence of successful completion of this course or program.
+        /// </summary>
+        [DataMember(Name = "occupationalCredentialAwarded", Order = 210)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> OccupationalCredentialAwarded { get; set; }
     }
 }

--- a/Source/Schema.NET/core/CourseInstance.cs
+++ b/Source/Schema.NET/core/CourseInstance.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The medium or means of delivery of the course instance or the mode of study, either as a text label (e.g. "online", "onsite" or "blended"; "synchronous" or "asynchronous"; "full-time" or "part-time") or as a URL reference to a term from a controlled vocabulary (e.g. https://ceds.ed.gov/element/001311#Asynchronous ).
         /// </summary>
-        Values<string, Uri>? CourseMode { get; set; }
+        Values<string, Uri> CourseMode { get; set; }
 
         /// <summary>
         /// The amount of work expected of students taking the course, often provided as a figure per week or per month, and may be broken down by type. For example, "2 hours of lectures, 1 hour of lab work and 3 hours of independent study per week".
@@ -42,7 +42,7 @@
         /// </summary>
         [DataMember(Name = "courseMode", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? CourseMode { get; set; }
+        public Values<string, Uri> CourseMode { get; set; }
 
         /// <summary>
         /// The amount of work expected of students taking the course, often provided as a figure per week or per month, and may be broken down by type. For example, "2 hours of lectures, 1 hour of lab work and 3 hours of independent study per week".

--- a/Source/Schema.NET/core/CreativeWork.cs
+++ b/Source/Schema.NET/core/CreativeWork.cs
@@ -47,7 +47,7 @@
         /// <summary>
         /// A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include:  auditory, tactile, textual, visual.
         /// </summary>
-        OneOrMany<string> AccessModeSufficient { get; set; }
+        OneOrMany<IItemList> AccessModeSufficient { get; set; }
 
         /// <summary>
         /// Specifies the Person that is legally accountable for the CreativeWork.
@@ -77,12 +77,12 @@
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        Values<IAudioObject, IClip>? Audio { get; set; }
+        Values<IAudioObject, IClip> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        Values<IOrganization, IPerson>? Author { get; set; }
+        Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -97,7 +97,7 @@
         /// <summary>
         /// A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
         /// </summary>
-        Values<ICreativeWork, string>? Citation { get; set; }
+        Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
@@ -110,6 +110,12 @@
         OneOrMany<int?> CommentCount { get; set; }
 
         /// <summary>
+        /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
+        /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+        /// </summary>
+        OneOrMany<string> ConditionsOfAccess { get; set; }
+
+        /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
         OneOrMany<IPlace> ContentLocation { get; set; }
@@ -117,7 +123,7 @@
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        Values<IRating, string>? ContentRating { get; set; }
+        Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
@@ -127,12 +133,12 @@
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        Values<IOrganization, IPerson>? Contributor { get; set; }
+        Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        Values<IOrganization, IPerson>? CopyrightHolder { get; set; }
+        Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
@@ -142,27 +148,32 @@
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        Values<string, Uri>? Correction { get; set; }
+        Values<string, Uri> Correction { get; set; }
+
+        /// <summary>
+        /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
+        /// </summary>
+        OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        Values<IOrganization, IPerson>? Creator { get; set; }
+        Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        Values<int?, DateTime?>? DatePublished { get; set; }
+        Values<int?, DateTime?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -194,7 +205,7 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        Values<string, Uri>? EncodingFormat { get; set; }
+        Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
@@ -204,17 +215,17 @@
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        Values<int?, DateTime?>? Expires { get; set; }
+        Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        Values<IOrganization, IPerson>? Funder { get; set; }
+        Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        Values<string, Uri>? Genre { get; set; }
+        Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
@@ -229,7 +240,7 @@
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? InLanguage { get; set; }
+        Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
@@ -249,7 +260,7 @@
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        Values<ICreativeWork, IProduct, Uri>? IsBasedOn { get; set; }
+        Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
@@ -274,7 +285,7 @@
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        Values<ICreativeWork, Uri>? License { get; set; }
+        Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
@@ -289,12 +300,12 @@
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        Values<IProduct, string, Uri>? Material { get; set; }
+        Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        Values<IQuantitativeValue, string>? MaterialExtent { get; set; }
+        Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
@@ -309,17 +320,17 @@
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        Values<int?, string>? Position { get; set; }
+        Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        Values<IOrganization, IPerson>? Producer { get; set; }
+        Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        Values<IOrganization, IPerson>? Provider { get; set; }
+        Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
@@ -329,7 +340,7 @@
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        Values<IOrganization, IPerson>? Publisher { get; set; }
+        Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
@@ -340,7 +351,7 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
@@ -360,23 +371,23 @@
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        Values<string, Uri>? SchemaVersion { get; set; }
+        Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        Values<int?, DateTime?>? SdDatePublished { get; set; }
+        Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        Values<ICreativeWork, Uri>? SdLicense { get; set; }
+        Values<ICreativeWork, Uri> SdLicense { get; set; }
 
         /// <summary>
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        Values<IOrganization, IPerson>? SdPublisher { get; set; }
+        Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
@@ -399,13 +410,13 @@
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        Values<IOrganization, IPerson>? Sponsor { get; set; }
+        Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        Values<DateTimeOffset?, string>? Temporal { get; set; }
+        Values<DateTimeOffset?, string> Temporal { get; set; }
 
         /// <summary>
         /// The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in &lt;a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals"&gt;ISO 8601 time interval format&lt;/a&gt;. In
@@ -413,7 +424,7 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        Values<DateTimeOffset?, string, Uri>? TemporalCoverage { get; set; }
+        Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
@@ -438,7 +449,7 @@
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        Values<IOrganization, IPerson>? Translator { get; set; }
+        Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
@@ -448,12 +459,12 @@
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        Values<double?, string>? Version { get; set; }
+        Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        Values<IClip, IVideoObject>? Video { get; set; }
+        Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
@@ -532,7 +543,7 @@
         /// </summary>
         [DataMember(Name = "accessModeSufficient", Order = 113)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> AccessModeSufficient { get; set; }
+        public OneOrMany<IItemList> AccessModeSufficient { get; set; }
 
         /// <summary>
         /// Specifies the Person that is legally accountable for the CreativeWork.
@@ -574,14 +585,14 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 119)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip>? Audio { get; set; }
+        public Values<IAudioObject, IClip> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
         [DataMember(Name = "author", Order = 120)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Author { get; set; }
+        public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -602,7 +613,7 @@
         /// </summary>
         [DataMember(Name = "citation", Order = 123)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, string>? Citation { get; set; }
+        public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
@@ -619,114 +630,129 @@
         public OneOrMany<int?> CommentCount { get; set; }
 
         /// <summary>
+        /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
+        /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+        /// </summary>
+        [DataMember(Name = "conditionsOfAccess", Order = 126)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> ConditionsOfAccess { get; set; }
+
+        /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 126)]
+        [DataMember(Name = "contentLocation", Order = 127)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 127)]
+        [DataMember(Name = "contentRating", Order = 128)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IRating, string>? ContentRating { get; set; }
+        public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 128)]
+        [DataMember(Name = "contentReferenceTime", Order = 129)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 129)]
+        [DataMember(Name = "contributor", Order = 130)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Contributor { get; set; }
+        public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 130)]
+        [DataMember(Name = "copyrightHolder", Order = 131)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? CopyrightHolder { get; set; }
+        public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 131)]
+        [DataMember(Name = "copyrightYear", Order = 132)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 132)]
+        [DataMember(Name = "correction", Order = 133)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Correction { get; set; }
+        public Values<string, Uri> Correction { get; set; }
+
+        /// <summary>
+        /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
+        /// </summary>
+        [DataMember(Name = "creativeWorkStatus", Order = 134)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 133)]
+        [DataMember(Name = "creator", Order = 135)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Creator { get; set; }
+        public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 134)]
+        [DataMember(Name = "dateCreated", Order = 136)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 135)]
+        [DataMember(Name = "dateModified", Order = 137)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 136)]
+        [DataMember(Name = "datePublished", Order = 138)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DatePublished { get; set; }
+        public Values<int?, DateTime?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 137)]
+        [DataMember(Name = "discussionUrl", Order = 139)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 138)]
+        [DataMember(Name = "editor", Order = 140)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 139)]
+        [DataMember(Name = "educationalAlignment", Order = 141)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 140)]
+        [DataMember(Name = "educationalUse", Order = 142)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 141)]
+        [DataMember(Name = "encoding", Order = 143)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -735,203 +761,203 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 142)]
+        [DataMember(Name = "encodingFormat", Order = 144)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<string, Uri>? EncodingFormat { get; set; }
+        public virtual Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 143)]
+        [DataMember(Name = "exampleOfWork", Order = 145)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 144)]
+        [DataMember(Name = "expires", Order = 146)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? Expires { get; set; }
+        public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 145)]
+        [DataMember(Name = "funder", Order = 147)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 146)]
+        [DataMember(Name = "genre", Order = 148)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 147)]
+        [DataMember(Name = "hasPart", Order = 149)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 148)]
+        [DataMember(Name = "headline", Order = 150)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 149)]
+        [DataMember(Name = "inLanguage", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 150)]
+        [DataMember(Name = "interactionStatistic", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 151)]
+        [DataMember(Name = "interactivityType", Order = 153)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 152)]
+        [DataMember(Name = "isAccessibleForFree", Order = 154)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 153)]
+        [DataMember(Name = "isBasedOn", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IProduct, Uri>? IsBasedOn { get; set; }
+        public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 154)]
+        [DataMember(Name = "isFamilyFriendly", Order = 156)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 155)]
+        [DataMember(Name = "isPartOf", Order = 157)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 156)]
+        [DataMember(Name = "keywords", Order = 158)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 157)]
+        [DataMember(Name = "learningResourceType", Order = 159)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 158)]
+        [DataMember(Name = "license", Order = 160)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? License { get; set; }
+        public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 159)]
+        [DataMember(Name = "locationCreated", Order = 161)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 160)]
+        [DataMember(Name = "mainEntity", Order = 162)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 161)]
+        [DataMember(Name = "material", Order = 163)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string, Uri>? Material { get; set; }
+        public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 162)]
+        [DataMember(Name = "materialExtent", Order = 164)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? MaterialExtent { get; set; }
+        public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 163)]
+        [DataMember(Name = "mentions", Order = 165)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
         /// </summary>
-        [DataMember(Name = "offers", Order = 164)]
+        [DataMember(Name = "offers", Order = 166)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 165)]
+        [DataMember(Name = "position", Order = 167)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? Position { get; set; }
+        public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 166)]
+        [DataMember(Name = "producer", Order = 168)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Producer { get; set; }
+        public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 167)]
+        [DataMember(Name = "provider", Order = 169)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 168)]
+        [DataMember(Name = "publication", Order = 170)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 169)]
+        [DataMember(Name = "publisher", Order = 171)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Publisher { get; set; }
+        public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 170)]
+        [DataMember(Name = "publisherImprint", Order = 172)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -939,64 +965,64 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 171)]
+        [DataMember(Name = "publishingPrinciples", Order = 173)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 172)]
+        [DataMember(Name = "recordedAt", Order = 174)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 173)]
+        [DataMember(Name = "releasedEvent", Order = 175)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 174)]
+        [DataMember(Name = "review", Order = 176)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 175)]
+        [DataMember(Name = "schemaVersion", Order = 177)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SchemaVersion { get; set; }
+        public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 176)]
+        [DataMember(Name = "sdDatePublished", Order = 178)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? SdDatePublished { get; set; }
+        public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 177)]
+        [DataMember(Name = "sdLicense", Order = 179)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? SdLicense { get; set; }
+        public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
         /// <summary>
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 178)]
+        [DataMember(Name = "sdPublisher", Order = 180)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? SdPublisher { get; set; }
+        public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 179)]
+        [DataMember(Name = "sourceOrganization", Order = 181)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -1004,7 +1030,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 180)]
+        [DataMember(Name = "spatial", Order = 182)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -1013,24 +1039,24 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 181)]
+        [DataMember(Name = "spatialCoverage", Order = 183)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 182)]
+        [DataMember(Name = "sponsor", Order = 184)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 183)]
+        [DataMember(Name = "temporal", Order = 185)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string>? Temporal { get; set; }
+        public Values<DateTimeOffset?, string> Temporal { get; set; }
 
         /// <summary>
         /// The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in &lt;a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals"&gt;ISO 8601 time interval format&lt;/a&gt;. In
@@ -1038,77 +1064,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 184)]
+        [DataMember(Name = "temporalCoverage", Order = 186)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string, Uri>? TemporalCoverage { get; set; }
+        public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 185)]
+        [DataMember(Name = "text", Order = 187)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 186)]
+        [DataMember(Name = "thumbnailUrl", Order = 188)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 187)]
+        [DataMember(Name = "timeRequired", Order = 189)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 188)]
+        [DataMember(Name = "translationOfWork", Order = 190)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 189)]
+        [DataMember(Name = "translator", Order = 191)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Translator { get; set; }
+        public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 190)]
+        [DataMember(Name = "typicalAgeRange", Order = 192)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 191)]
+        [DataMember(Name = "version", Order = 193)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Version { get; set; }
+        public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 192)]
+        [DataMember(Name = "video", Order = 194)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IClip, IVideoObject>? Video { get; set; }
+        public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 193)]
+        [DataMember(Name = "workExample", Order = 195)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 194)]
+        [DataMember(Name = "workTranslation", Order = 196)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
     }

--- a/Source/Schema.NET/core/CreativeWorkSeason.cs
+++ b/Source/Schema.NET/core/CreativeWorkSeason.cs
@@ -42,17 +42,17 @@
         /// <summary>
         /// Position of the season within an ordered group of seasons.
         /// </summary>
-        Values<int?, string>? SeasonNumber { get; set; }
+        Values<int?, string> SeasonNumber { get; set; }
 
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
 
         /// <summary>
         /// The trailer of a movie or tv/radio series, season, episode, etc.
@@ -119,21 +119,21 @@
         /// </summary>
         [DataMember(Name = "seasonNumber", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? SeasonNumber { get; set; }
+        public Values<int?, string> SeasonNumber { get; set; }
 
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "startDate", Order = 213)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "endDate", Order = 214)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
 
         /// <summary>
         /// The trailer of a movie or tv/radio series, season, episode, etc.

--- a/Source/Schema.NET/core/CreativeWorkSeries.cs
+++ b/Source/Schema.NET/core/CreativeWorkSeries.cs
@@ -19,12 +19,12 @@
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
     }
 
     /// <summary>
@@ -53,13 +53,13 @@
         /// </summary>
         [DataMember(Name = "startDate", Order = 307)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "endDate", Order = 308)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
     }
 }

--- a/Source/Schema.NET/core/DataCatalog.cs
+++ b/Source/Schema.NET/core/DataCatalog.cs
@@ -21,7 +21,7 @@
         /// If the &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; is "depression rating", the &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt; could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".&lt;br/&gt;&lt;br/&gt;
         /// If there are several &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; properties recorded for some given data object, use a &lt;a class="localLink" href="http://schema.org/PropertyValue"&gt;PropertyValue&lt;/a&gt; for each &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; and attach the corresponding &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt;.
         /// </summary>
-        Values<string, Uri>? MeasurementTechnique { get; set; }
+        Values<string, Uri> MeasurementTechnique { get; set; }
     }
 
     /// <summary>
@@ -52,6 +52,6 @@
         /// </summary>
         [DataMember(Name = "measurementTechnique", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? MeasurementTechnique { get; set; }
+        public Values<string, Uri> MeasurementTechnique { get; set; }
     }
 }

--- a/Source/Schema.NET/core/DataDownload.cs
+++ b/Source/Schema.NET/core/DataDownload.cs
@@ -16,7 +16,7 @@
         /// If the &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; is "depression rating", the &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt; could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".&lt;br/&gt;&lt;br/&gt;
         /// If there are several &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; properties recorded for some given data object, use a &lt;a class="localLink" href="http://schema.org/PropertyValue"&gt;PropertyValue&lt;/a&gt; for each &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; and attach the corresponding &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt;.
         /// </summary>
-        Values<string, Uri>? MeasurementTechnique { get; set; }
+        Values<string, Uri> MeasurementTechnique { get; set; }
     }
 
     /// <summary>
@@ -40,6 +40,6 @@
         /// </summary>
         [DataMember(Name = "measurementTechnique", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? MeasurementTechnique { get; set; }
+        public Values<string, Uri> MeasurementTechnique { get; set; }
     }
 }

--- a/Source/Schema.NET/core/DataFeed.cs
+++ b/Source/Schema.NET/core/DataFeed.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// An item within in a data feed. Data feeds may have many elements.
         /// </summary>
-        Values<IDataFeedItem, string, IThing>? DataFeedElement { get; set; }
+        Values<IDataFeedItem, string, IThing> DataFeedElement { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "dataFeedElement", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IDataFeedItem, string, IThing>? DataFeedElement { get; set; }
+        public Values<IDataFeedItem, string, IThing> DataFeedElement { get; set; }
     }
 }

--- a/Source/Schema.NET/core/DataFeedItem.cs
+++ b/Source/Schema.NET/core/DataFeedItem.cs
@@ -12,17 +12,17 @@
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The datetime the item was removed from the DataFeed.
         /// </summary>
-        OneOrMany<DateTimeOffset?> DateDeleted { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DateDeleted { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.
@@ -47,21 +47,21 @@
         /// </summary>
         [DataMember(Name = "dateCreated", Order = 206)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The datetime the item was removed from the DataFeed.
         /// </summary>
         [DataMember(Name = "dateDeleted", Order = 207)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> DateDeleted { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> DateDeleted { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
         [DataMember(Name = "dateModified", Order = 208)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.

--- a/Source/Schema.NET/core/Dataset.cs
+++ b/Source/Schema.NET/core/Dataset.cs
@@ -31,17 +31,17 @@
         /// If the &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; is "depression rating", the &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt; could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".&lt;br/&gt;&lt;br/&gt;
         /// If there are several &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; properties recorded for some given data object, use a &lt;a class="localLink" href="http://schema.org/PropertyValue"&gt;PropertyValue&lt;/a&gt; for each &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; and attach the corresponding &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt;.
         /// </summary>
-        Values<string, Uri>? MeasurementTechnique { get; set; }
+        Values<string, Uri> MeasurementTechnique { get; set; }
 
         /// <summary>
         /// The variableMeasured property can indicate (repeated as necessary) the  variables that are measured in some dataset, either described as text or as pairs of identifier and description using PropertyValue.
         /// </summary>
-        Values<IPropertyValue, string>? VariableMeasured { get; set; }
+        Values<IPropertyValue, string> VariableMeasured { get; set; }
 
         /// <summary>
         /// Originally named &lt;a class="localLink" href="http://schema.org/variablesMeasured"&gt;variablesMeasured&lt;/a&gt;, The &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; property can indicate (repeated as necessary) the  variables that are measured in some dataset, either described as text or as pairs of identifier and description using PropertyValue.
         /// </summary>
-        Values<IPropertyValue, string>? VariablesMeasured { get; set; }
+        Values<IPropertyValue, string> VariablesMeasured { get; set; }
     }
 
     /// <summary>
@@ -86,20 +86,20 @@
         /// </summary>
         [DataMember(Name = "measurementTechnique", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? MeasurementTechnique { get; set; }
+        public Values<string, Uri> MeasurementTechnique { get; set; }
 
         /// <summary>
         /// The variableMeasured property can indicate (repeated as necessary) the  variables that are measured in some dataset, either described as text or as pairs of identifier and description using PropertyValue.
         /// </summary>
         [DataMember(Name = "variableMeasured", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPropertyValue, string>? VariableMeasured { get; set; }
+        public Values<IPropertyValue, string> VariableMeasured { get; set; }
 
         /// <summary>
         /// Originally named &lt;a class="localLink" href="http://schema.org/variablesMeasured"&gt;variablesMeasured&lt;/a&gt;, The &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; property can indicate (repeated as necessary) the  variables that are measured in some dataset, either described as text or as pairs of identifier and description using PropertyValue.
         /// </summary>
         [DataMember(Name = "variablesMeasured", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPropertyValue, string>? VariablesMeasured { get; set; }
+        public Values<IPropertyValue, string> VariablesMeasured { get; set; }
     }
 }

--- a/Source/Schema.NET/core/DeliveryChargeSpecification.cs
+++ b/Source/Schema.NET/core/DeliveryChargeSpecification.cs
@@ -17,19 +17,19 @@
         /// <summary>
         /// The geographic area where a service or offered item is provided.
         /// </summary>
-        Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/ineligibleRegion"&gt;ineligibleRegion&lt;/a&gt;.
         /// </summary>
-        Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/eligibleRegion"&gt;eligibleRegion&lt;/a&gt;.
         /// </summary>
-        Values<IGeoShape, IPlace, string>? IneligibleRegion { get; set; }
+        Values<IGeoShape, IPlace, string> IneligibleRegion { get; set; }
     }
 
     /// <summary>
@@ -56,7 +56,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 407)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.&lt;br/&gt;&lt;br/&gt;
@@ -64,7 +64,7 @@
         /// </summary>
         [DataMember(Name = "eligibleRegion", Order = 408)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        public Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.&lt;br/&gt;&lt;br/&gt;
@@ -72,6 +72,6 @@
         /// </summary>
         [DataMember(Name = "ineligibleRegion", Order = 409)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoShape, IPlace, string>? IneligibleRegion { get; set; }
+        public Values<IGeoShape, IPlace, string> IneligibleRegion { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Demand.cs
+++ b/Source/Schema.NET/core/Demand.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The payment method(s) accepted by seller for this offer.
         /// </summary>
-        Values<ILoanOrCredit, PaymentMethod?>? AcceptedPaymentMethod { get; set; }
+        Values<ILoanOrCredit, PaymentMethod?> AcceptedPaymentMethod { get; set; }
 
         /// <summary>
         /// The amount of time that is required between accepting the offer and the actual usage of the resource or service.
@@ -22,7 +22,7 @@
         /// <summary>
         /// The geographic area where a service or offered item is provided.
         /// </summary>
-        Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// The availability of this item&amp;#x2014;for example In stock, Out of stock, Pre-order, etc.
@@ -32,12 +32,12 @@
         /// <summary>
         /// The end of the availability of the product or service included in the offer.
         /// </summary>
-        OneOrMany<DateTimeOffset?> AvailabilityEnds { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityEnds { get; set; }
 
         /// <summary>
         /// The beginning of the availability of the product or service included in the offer.
         /// </summary>
-        OneOrMany<DateTimeOffset?> AvailabilityStarts { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityStarts { get; set; }
 
         /// <summary>
         /// The place(s) from which the offer can be obtained (e.g. store locations).
@@ -78,12 +78,17 @@
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/ineligibleRegion"&gt;ineligibleRegion&lt;/a&gt;.
         /// </summary>
-        Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount.
         /// </summary>
         OneOrMany<IPriceSpecification> EligibleTransactionVolume { get; set; }
+
+        /// <summary>
+        /// A Global Trade Item Number (&lt;a href="https://www.gs1.org/standards/id-keys/gtin"&gt;GTIN&lt;/a&gt;). GTINs identify trade items, including products and services, using numeric identification codes. The &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; property generalizes the earlier &lt;a class="localLink" href="http://schema.org/gtin8"&gt;gtin8&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin12"&gt;gtin12&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin13"&gt;gtin13&lt;/a&gt;, and &lt;a class="localLink" href="http://schema.org/gtin14"&gt;gtin14&lt;/a&gt; properties. The GS1 &lt;a href="https://www.gs1.org/standards/Digital-Link/"&gt;digital link specifications&lt;/a&gt; express GTINs as URLs. A correct &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a &lt;a href="https://www.gs1.org/services/check-digit-calculator"&gt;valid GS1 check digit&lt;/a&gt; and meet the other rules for valid GTINs. See also &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1's GTIN Summary&lt;/a&gt; and &lt;a href="https://en.wikipedia.org/wiki/Global_Trade_Item_Number"&gt;Wikipedia&lt;/a&gt; for more details. Left-padding of the gtin values is not required or encouraged.
+        /// </summary>
+        OneOrMany<string> Gtin { get; set; }
 
         /// <summary>
         /// The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
@@ -114,7 +119,7 @@
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/eligibleRegion"&gt;eligibleRegion&lt;/a&gt;.
         /// </summary>
-        Values<IGeoShape, IPlace, string>? IneligibleRegion { get; set; }
+        Values<IGeoShape, IPlace, string> IneligibleRegion { get; set; }
 
         /// <summary>
         /// The current approximate inventory level for the item or items.
@@ -129,7 +134,7 @@
         /// <summary>
         /// The item being offered.
         /// </summary>
-        Values<IProduct, IService>? ItemOffered { get; set; }
+        Values<IProduct, IService> ItemOffered { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
@@ -144,7 +149,7 @@
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        Values<IOrganization, IPerson>? Seller { get; set; }
+        Values<IOrganization, IPerson> Seller { get; set; }
 
         /// <summary>
         /// The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer.
@@ -159,12 +164,12 @@
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The warranty promise(s) included in the offer.
@@ -189,7 +194,7 @@
         /// </summary>
         [DataMember(Name = "acceptedPaymentMethod", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILoanOrCredit, PaymentMethod?>? AcceptedPaymentMethod { get; set; }
+        public Values<ILoanOrCredit, PaymentMethod?> AcceptedPaymentMethod { get; set; }
 
         /// <summary>
         /// The amount of time that is required between accepting the offer and the actual usage of the resource or service.
@@ -203,7 +208,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// The availability of this item&amp;#x2014;for example In stock, Out of stock, Pre-order, etc.
@@ -216,15 +221,15 @@
         /// The end of the availability of the product or service included in the offer.
         /// </summary>
         [DataMember(Name = "availabilityEnds", Order = 210)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> AvailabilityEnds { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityEnds { get; set; }
 
         /// <summary>
         /// The beginning of the availability of the product or service included in the offer.
         /// </summary>
         [DataMember(Name = "availabilityStarts", Order = 211)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> AvailabilityStarts { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityStarts { get; set; }
 
         /// <summary>
         /// The place(s) from which the offer can be obtained (e.g. store locations).
@@ -281,7 +286,7 @@
         /// </summary>
         [DataMember(Name = "eligibleRegion", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        public Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount.
@@ -291,37 +296,44 @@
         public OneOrMany<IPriceSpecification> EligibleTransactionVolume { get; set; }
 
         /// <summary>
+        /// A Global Trade Item Number (&lt;a href="https://www.gs1.org/standards/id-keys/gtin"&gt;GTIN&lt;/a&gt;). GTINs identify trade items, including products and services, using numeric identification codes. The &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; property generalizes the earlier &lt;a class="localLink" href="http://schema.org/gtin8"&gt;gtin8&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin12"&gt;gtin12&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin13"&gt;gtin13&lt;/a&gt;, and &lt;a class="localLink" href="http://schema.org/gtin14"&gt;gtin14&lt;/a&gt; properties. The GS1 &lt;a href="https://www.gs1.org/standards/Digital-Link/"&gt;digital link specifications&lt;/a&gt; express GTINs as URLs. A correct &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a &lt;a href="https://www.gs1.org/services/check-digit-calculator"&gt;valid GS1 check digit&lt;/a&gt; and meet the other rules for valid GTINs. See also &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1's GTIN Summary&lt;/a&gt; and &lt;a href="https://en.wikipedia.org/wiki/Global_Trade_Item_Number"&gt;Wikipedia&lt;/a&gt; for more details. Left-padding of the gtin values is not required or encouraged.
+        /// </summary>
+        [DataMember(Name = "gtin", Order = 221)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> Gtin { get; set; }
+
+        /// <summary>
         /// The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin12", Order = 221)]
+        [DataMember(Name = "gtin12", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin12 { get; set; }
 
         /// <summary>
         /// The GTIN-13 code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceeding zero. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin13", Order = 222)]
+        [DataMember(Name = "gtin13", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin13 { get; set; }
 
         /// <summary>
         /// The GTIN-14 code of the product, or the product to which the offer refers. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin14", Order = 223)]
+        [DataMember(Name = "gtin14", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin14 { get; set; }
 
         /// <summary>
         /// The &lt;a href="http://apps.gs1.org/GDD/glossary/Pages/GTIN-8.aspx"&gt;GTIN-8&lt;/a&gt; code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin8", Order = 224)]
+        [DataMember(Name = "gtin8", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin8 { get; set; }
 
         /// <summary>
         /// This links to a node or nodes indicating the exact quantity of the products included in the offer.
         /// </summary>
-        [DataMember(Name = "includesObject", Order = 225)]
+        [DataMember(Name = "includesObject", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ITypeAndQuantityNode> IncludesObject { get; set; }
 
@@ -329,84 +341,84 @@
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/eligibleRegion"&gt;eligibleRegion&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "ineligibleRegion", Order = 226)]
+        [DataMember(Name = "ineligibleRegion", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoShape, IPlace, string>? IneligibleRegion { get; set; }
+        public Values<IGeoShape, IPlace, string> IneligibleRegion { get; set; }
 
         /// <summary>
         /// The current approximate inventory level for the item or items.
         /// </summary>
-        [DataMember(Name = "inventoryLevel", Order = 227)]
+        [DataMember(Name = "inventoryLevel", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IQuantitativeValue> InventoryLevel { get; set; }
 
         /// <summary>
         /// A predefined value from OfferItemCondition or a textual description of the condition of the product or service, or the products or services included in the offer.
         /// </summary>
-        [DataMember(Name = "itemCondition", Order = 228)]
+        [DataMember(Name = "itemCondition", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<OfferItemCondition?> ItemCondition { get; set; }
 
         /// <summary>
         /// The item being offered.
         /// </summary>
-        [DataMember(Name = "itemOffered", Order = 229)]
+        [DataMember(Name = "itemOffered", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? ItemOffered { get; set; }
+        public Values<IProduct, IService> ItemOffered { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "mpn", Order = 230)]
+        [DataMember(Name = "mpn", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Mpn { get; set; }
 
         /// <summary>
         /// One or more detailed price specifications, indicating the unit price and delivery or payment charges.
         /// </summary>
-        [DataMember(Name = "priceSpecification", Order = 231)]
+        [DataMember(Name = "priceSpecification", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPriceSpecification> PriceSpecification { get; set; }
 
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        [DataMember(Name = "seller", Order = 232)]
+        [DataMember(Name = "seller", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Seller { get; set; }
+        public Values<IOrganization, IPerson> Seller { get; set; }
 
         /// <summary>
         /// The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer.
         /// </summary>
-        [DataMember(Name = "serialNumber", Order = 233)]
+        [DataMember(Name = "serialNumber", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SerialNumber { get; set; }
 
         /// <summary>
         /// The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "sku", Order = 234)]
+        [DataMember(Name = "sku", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Sku { get; set; }
 
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        [DataMember(Name = "validFrom", Order = 235)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        [DataMember(Name = "validFrom", Order = 236)]
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        [DataMember(Name = "validThrough", Order = 236)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        [DataMember(Name = "validThrough", Order = 237)]
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The warranty promise(s) included in the offer.
         /// </summary>
-        [DataMember(Name = "warranty", Order = 237)]
+        [DataMember(Name = "warranty", Order = 238)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IWarrantyPromise> Warranty { get; set; }
     }

--- a/Source/Schema.NET/core/Diet.cs
+++ b/Source/Schema.NET/core/Diet.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// People or organizations that endorse the plan.
         /// </summary>
-        Values<IOrganization, IPerson>? Endorsers { get; set; }
+        Values<IOrganization, IPerson> Endorsers { get; set; }
 
         /// <summary>
         /// Medical expert advice related to the plan.
@@ -64,7 +64,7 @@
         /// </summary>
         [DataMember(Name = "endorsers", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Endorsers { get; set; }
+        public Values<IOrganization, IPerson> Endorsers { get; set; }
 
         /// <summary>
         /// Medical expert advice related to the plan.

--- a/Source/Schema.NET/core/DietarySupplement.cs
+++ b/Source/Schema.NET/core/DietarySupplement.cs
@@ -93,7 +93,7 @@
         /// </summary>
         [DataMember(Name = "legalStatus", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IDrugLegalStatus, MedicalEnumeration?, string>? LegalStatus { get; set; }
+        public override Values<IDrugLegalStatus, MedicalEnumeration?, string> LegalStatus { get; set; }
 
         /// <summary>
         /// The manufacturer of the product.

--- a/Source/Schema.NET/core/DigitalDocumentPermission.cs
+++ b/Source/Schema.NET/core/DigitalDocumentPermission.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The person, organization, contact point, or audience that has been granted this permission.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Grantee { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Grantee { get; set; }
 
         /// <summary>
         /// The type of permission granted the person, organization, or audience.
@@ -37,7 +37,7 @@
         /// </summary>
         [DataMember(Name = "grantee", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Grantee { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Grantee { get; set; }
 
         /// <summary>
         /// The type of permission granted the person, organization, or audience.

--- a/Source/Schema.NET/core/DonateAction.cs
+++ b/Source/Schema.NET/core/DonateAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "recipient", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Drug.cs
+++ b/Source/Schema.NET/core/Drug.cs
@@ -122,7 +122,7 @@
         /// <summary>
         /// Indicates the status of drug prescription eg. local catalogs classifications or whether the drug is available by prescription or over-the-counter, etc.
         /// </summary>
-        Values<DrugPrescriptionStatus?, string>? PrescriptionStatus { get; set; }
+        Values<DrugPrescriptionStatus?, string> PrescriptionStatus { get; set; }
 
         /// <summary>
         /// Proprietary name given to the diet plan, typically by its originator or creator.
@@ -142,7 +142,7 @@
         /// <summary>
         /// Any FDA or other warnings about the drug (text or URL).
         /// </summary>
-        Values<string, Uri>? Warning { get; set; }
+        Values<string, Uri> Warning { get; set; }
     }
 
     /// <summary>
@@ -274,7 +274,7 @@
         /// </summary>
         [DataMember(Name = "legalStatus", Order = 322)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IDrugLegalStatus, MedicalEnumeration?, string>? LegalStatus { get; set; }
+        public override Values<IDrugLegalStatus, MedicalEnumeration?, string> LegalStatus { get; set; }
 
         /// <summary>
         /// The manufacturer of the product.
@@ -337,7 +337,7 @@
         /// </summary>
         [DataMember(Name = "prescriptionStatus", Order = 331)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DrugPrescriptionStatus?, string>? PrescriptionStatus { get; set; }
+        public Values<DrugPrescriptionStatus?, string> PrescriptionStatus { get; set; }
 
         /// <summary>
         /// Proprietary name given to the diet plan, typically by its originator or creator.
@@ -365,6 +365,6 @@
         /// </summary>
         [DataMember(Name = "warning", Order = 335)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Warning { get; set; }
+        public Values<string, Uri> Warning { get; set; }
     }
 }

--- a/Source/Schema.NET/core/EmployeeRole.cs
+++ b/Source/Schema.NET/core/EmployeeRole.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The base salary of the job or of an employee in an EmployeeRole.
         /// </summary>
-        Values<IMonetaryAmount, decimal?, IPriceSpecification>? BaseSalary { get; set; }
+        Values<IMonetaryAmount, decimal?, IPriceSpecification> BaseSalary { get; set; }
 
         /// <summary>
         /// The currency (coded using &lt;a href="http://en.wikipedia.org/wiki/ISO_4217"&gt;ISO 4217&lt;/a&gt; ) used for the main salary information in this job posting or for this employee.
@@ -37,7 +37,7 @@
         /// </summary>
         [DataMember(Name = "baseSalary", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, decimal?, IPriceSpecification>? BaseSalary { get; set; }
+        public Values<IMonetaryAmount, decimal?, IPriceSpecification> BaseSalary { get; set; }
 
         /// <summary>
         /// The currency (coded using &lt;a href="http://en.wikipedia.org/wiki/ISO_4217"&gt;ISO 4217&lt;/a&gt; ) used for the main salary information in this job posting or for this employee.

--- a/Source/Schema.NET/core/EndorseAction.cs
+++ b/Source/Schema.NET/core/EndorseAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of participant. The person/organization being supported.
         /// </summary>
-        Values<IOrganization, IPerson>? Endorsee { get; set; }
+        Values<IOrganization, IPerson> Endorsee { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "endorsee", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Endorsee { get; set; }
+        public Values<IOrganization, IPerson> Endorsee { get; set; }
     }
 }

--- a/Source/Schema.NET/core/EngineSpecification.cs
+++ b/Source/Schema.NET/core/EngineSpecification.cs
@@ -31,12 +31,12 @@
         /// <summary>
         /// The type of engine or engines powering the vehicle.
         /// </summary>
-        Values<string, Uri>? EngineType { get; set; }
+        Values<string, Uri> EngineType { get; set; }
 
         /// <summary>
         /// The type of fuel suitable for the engine or engines of the vehicle. If the vehicle has only one engine, this property can be attached directly to the vehicle.
         /// </summary>
-        Values<string, Uri>? FuelType { get; set; }
+        Values<string, Uri> FuelType { get; set; }
 
         /// <summary>
         /// The torque (turning force) of the vehicle's engine.&lt;br/&gt;&lt;br/&gt;
@@ -89,14 +89,14 @@
         /// </summary>
         [DataMember(Name = "engineType", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? EngineType { get; set; }
+        public Values<string, Uri> EngineType { get; set; }
 
         /// <summary>
         /// The type of fuel suitable for the engine or engines of the vehicle. If the vehicle has only one engine, this property can be attached directly to the vehicle.
         /// </summary>
         [DataMember(Name = "fuelType", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? FuelType { get; set; }
+        public Values<string, Uri> FuelType { get; set; }
 
         /// <summary>
         /// The torque (turning force) of the vehicle's engine.&lt;br/&gt;&lt;br/&gt;

--- a/Source/Schema.NET/core/EntryPoint.cs
+++ b/Source/Schema.NET/core/EntryPoint.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The high level platform(s) where the Action can be performed for the given URL. To specify a specific application or operating system instance, use actionApplication.
         /// </summary>
-        Values<string, Uri>? ActionPlatform { get; set; }
+        Values<string, Uri> ActionPlatform { get; set; }
 
         /// <summary>
         /// The supported content type(s) for an EntryPoint response.
@@ -64,7 +64,7 @@
         /// </summary>
         [DataMember(Name = "actionPlatform", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ActionPlatform { get; set; }
+        public Values<string, Uri> ActionPlatform { get; set; }
 
         /// <summary>
         /// The supported content type(s) for an EntryPoint response.

--- a/Source/Schema.NET/core/Episode.cs
+++ b/Source/Schema.NET/core/Episode.cs
@@ -22,12 +22,12 @@
         /// <summary>
         /// Position of the episode within an ordered group of episodes.
         /// </summary>
-        Values<int?, string>? EpisodeNumber { get; set; }
+        Values<int?, string> EpisodeNumber { get; set; }
 
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The season to which this episode belongs.
@@ -81,14 +81,14 @@
         /// </summary>
         [DataMember(Name = "episodeNumber", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? EpisodeNumber { get; set; }
+        public Values<int?, string> EpisodeNumber { get; set; }
 
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
         [DataMember(Name = "musicBy", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The season to which this episode belongs.

--- a/Source/Schema.NET/core/Event.cs
+++ b/Source/Schema.NET/core/Event.cs
@@ -27,7 +27,7 @@
         /// <summary>
         /// A person or organization attending the event.
         /// </summary>
-        Values<IOrganization, IPerson>? Attendee { get; set; }
+        Values<IOrganization, IPerson> Attendee { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
@@ -37,12 +37,12 @@
         /// <summary>
         /// The person or organization who wrote a composition, or who is the composer of a work performed at some event.
         /// </summary>
-        Values<IOrganization, IPerson>? Composer { get; set; }
+        Values<IOrganization, IPerson> Composer { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        Values<IOrganization, IPerson>? Contributor { get; set; }
+        Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// A director of e.g. tv, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip.
@@ -52,7 +52,7 @@
         /// <summary>
         /// The time admission will commence.
         /// </summary>
-        OneOrMany<DateTimeOffset?> DoorTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> DoorTime { get; set; }
 
         /// <summary>
         /// The duration of the item (movie, audio recording, event, etc.) in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;.
@@ -67,12 +67,12 @@
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        Values<IOrganization, IPerson>? Funder { get; set; }
+        Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? InLanguage { get; set; }
+        Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
@@ -82,7 +82,7 @@
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
@@ -97,17 +97,17 @@
         /// <summary>
         /// An organizer of an Event.
         /// </summary>
-        Values<IOrganization, IPerson>? Organizer { get; set; }
+        Values<IOrganization, IPerson> Organizer { get; set; }
 
         /// <summary>
         /// A performer at the event&amp;#x2014;for example, a presenter, musician, musical group or actor.
         /// </summary>
-        Values<IOrganization, IPerson>? Performer { get; set; }
+        Values<IOrganization, IPerson> Performer { get; set; }
 
         /// <summary>
         /// Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated.
         /// </summary>
-        Values<int?, DateTime?>? PreviousStartDate { get; set; }
+        Values<int?, DateTime?> PreviousStartDate { get; set; }
 
         /// <summary>
         /// The CreativeWork that captured all or part of this Event.
@@ -127,17 +127,17 @@
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        Values<IOrganization, IPerson>? Sponsor { get; set; }
+        Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
 
         /// <summary>
         /// An Event that is part of this event. For example, a conference event includes many presentations, each of which is a subEvent of the conference.
@@ -152,7 +152,7 @@
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        Values<IOrganization, IPerson>? Translator { get; set; }
+        Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
@@ -209,7 +209,7 @@
         /// </summary>
         [DataMember(Name = "attendee", Order = 109)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Attendee { get; set; }
+        public Values<IOrganization, IPerson> Attendee { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
@@ -223,14 +223,14 @@
         /// </summary>
         [DataMember(Name = "composer", Order = 111)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Composer { get; set; }
+        public Values<IOrganization, IPerson> Composer { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
         [DataMember(Name = "contributor", Order = 112)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Contributor { get; set; }
+        public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// A director of e.g. tv, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip.
@@ -244,7 +244,7 @@
         /// </summary>
         [DataMember(Name = "doorTime", Order = 114)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> DoorTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> DoorTime { get; set; }
 
         /// <summary>
         /// The duration of the item (movie, audio recording, event, etc.) in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;.
@@ -265,14 +265,14 @@
         /// </summary>
         [DataMember(Name = "funder", Order = 117)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "inLanguage", Order = 118)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
@@ -286,7 +286,7 @@
         /// </summary>
         [DataMember(Name = "location", Order = 120)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        public Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
@@ -307,21 +307,21 @@
         /// </summary>
         [DataMember(Name = "organizer", Order = 123)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Organizer { get; set; }
+        public Values<IOrganization, IPerson> Organizer { get; set; }
 
         /// <summary>
         /// A performer at the event&amp;#x2014;for example, a presenter, musician, musical group or actor.
         /// </summary>
         [DataMember(Name = "performer", Order = 124)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Performer { get; set; }
+        public Values<IOrganization, IPerson> Performer { get; set; }
 
         /// <summary>
         /// Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated.
         /// </summary>
         [DataMember(Name = "previousStartDate", Order = 125)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? PreviousStartDate { get; set; }
+        public Values<int?, DateTime?> PreviousStartDate { get; set; }
 
         /// <summary>
         /// The CreativeWork that captured all or part of this Event.
@@ -349,21 +349,21 @@
         /// </summary>
         [DataMember(Name = "sponsor", Order = 129)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "startDate", Order = 130)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "endDate", Order = 131)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
 
         /// <summary>
         /// An Event that is part of this event. For example, a conference event includes many presentations, each of which is a subEvent of the conference.
@@ -384,7 +384,7 @@
         /// </summary>
         [DataMember(Name = "translator", Order = 134)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Translator { get; set; }
+        public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.

--- a/Source/Schema.NET/core/FinancialProduct.cs
+++ b/Source/Schema.NET/core/FinancialProduct.cs
@@ -12,17 +12,17 @@
         /// <summary>
         /// The annual rate that is charged for borrowing (or made by investing), expressed as a single percentage number that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction.
         /// </summary>
-        Values<double?, IQuantitativeValue>? AnnualPercentageRate { get; set; }
+        Values<double?, IQuantitativeValue> AnnualPercentageRate { get; set; }
 
         /// <summary>
         /// Description of fees, commissions, and other terms applied either to a class of financial product, or by a financial service organization.
         /// </summary>
-        Values<string, Uri>? FeesAndCommissionsSpecification { get; set; }
+        Values<string, Uri> FeesAndCommissionsSpecification { get; set; }
 
         /// <summary>
         /// The interest rate, charged or paid, applicable to the financial product. Note: This is different from the calculated annualPercentageRate.
         /// </summary>
-        Values<double?, IQuantitativeValue>? InterestRate { get; set; }
+        Values<double?, IQuantitativeValue> InterestRate { get; set; }
     }
 
     /// <summary>
@@ -42,20 +42,20 @@
         /// </summary>
         [DataMember(Name = "annualPercentageRate", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, IQuantitativeValue>? AnnualPercentageRate { get; set; }
+        public Values<double?, IQuantitativeValue> AnnualPercentageRate { get; set; }
 
         /// <summary>
         /// Description of fees, commissions, and other terms applied either to a class of financial product, or by a financial service organization.
         /// </summary>
         [DataMember(Name = "feesAndCommissionsSpecification", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? FeesAndCommissionsSpecification { get; set; }
+        public Values<string, Uri> FeesAndCommissionsSpecification { get; set; }
 
         /// <summary>
         /// The interest rate, charged or paid, applicable to the financial product. Note: This is different from the calculated annualPercentageRate.
         /// </summary>
         [DataMember(Name = "interestRate", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, IQuantitativeValue>? InterestRate { get; set; }
+        public Values<double?, IQuantitativeValue> InterestRate { get; set; }
     }
 }

--- a/Source/Schema.NET/core/FinancialService.cs
+++ b/Source/Schema.NET/core/FinancialService.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// Description of fees, commissions, and other terms applied either to a class of financial product, or by a financial service organization.
         /// </summary>
-        Values<string, Uri>? FeesAndCommissionsSpecification { get; set; }
+        Values<string, Uri> FeesAndCommissionsSpecification { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "feesAndCommissionsSpecification", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? FeesAndCommissionsSpecification { get; set; }
+        public Values<string, Uri> FeesAndCommissionsSpecification { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Flight.cs
+++ b/Source/Schema.NET/core/Flight.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The kind of aircraft (e.g., "Boeing 747").
         /// </summary>
-        Values<string, IVehicle>? Aircraft { get; set; }
+        Values<string, IVehicle> Aircraft { get; set; }
 
         /// <summary>
         /// The airport where the flight terminates.
@@ -52,12 +52,12 @@
         /// <summary>
         /// The estimated time the flight will take.
         /// </summary>
-        Values<TimeSpan?, string>? EstimatedFlightDuration { get; set; }
+        Values<TimeSpan?, string> EstimatedFlightDuration { get; set; }
 
         /// <summary>
         /// The distance of the flight.
         /// </summary>
-        Values<string, string>? FlightDistance { get; set; }
+        Values<string, string> FlightDistance { get; set; }
 
         /// <summary>
         /// The unique identifier for a flight including the airline IATA code. For example, if describing United flight 110, where the IATA code for United is 'UA', the flightNumber is 'UA110'.
@@ -72,7 +72,7 @@
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        Values<IOrganization, IPerson>? Seller { get; set; }
+        Values<IOrganization, IPerson> Seller { get; set; }
 
         /// <summary>
         /// The time when a passenger can check into the flight online.
@@ -97,7 +97,7 @@
         /// </summary>
         [DataMember(Name = "aircraft", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IVehicle>? Aircraft { get; set; }
+        public Values<string, IVehicle> Aircraft { get; set; }
 
         /// <summary>
         /// The airport where the flight terminates.
@@ -153,14 +153,14 @@
         /// </summary>
         [DataMember(Name = "estimatedFlightDuration", Order = 314)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
-        public Values<TimeSpan?, string>? EstimatedFlightDuration { get; set; }
+        public Values<TimeSpan?, string> EstimatedFlightDuration { get; set; }
 
         /// <summary>
         /// The distance of the flight.
         /// </summary>
         [DataMember(Name = "flightDistance", Order = 315)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, string>? FlightDistance { get; set; }
+        public Values<string, string> FlightDistance { get; set; }
 
         /// <summary>
         /// The unique identifier for a flight including the airline IATA code. For example, if describing United flight 110, where the IATA code for United is 'UA', the flightNumber is 'UA110'.
@@ -181,7 +181,7 @@
         /// </summary>
         [DataMember(Name = "seller", Order = 318)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Seller { get; set; }
+        public Values<IOrganization, IPerson> Seller { get; set; }
 
         /// <summary>
         /// The time when a passenger can check into the flight online.

--- a/Source/Schema.NET/core/FollowAction.cs
+++ b/Source/Schema.NET/core/FollowAction.cs
@@ -20,7 +20,7 @@
         /// <summary>
         /// A sub property of object. The person or organization being followed.
         /// </summary>
-        Values<IOrganization, IPerson>? Followee { get; set; }
+        Values<IOrganization, IPerson> Followee { get; set; }
     }
 
     /// <summary>
@@ -48,6 +48,6 @@
         /// </summary>
         [DataMember(Name = "followee", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Followee { get; set; }
+        public Values<IOrganization, IPerson> Followee { get; set; }
     }
 }

--- a/Source/Schema.NET/core/FoodEstablishment.cs
+++ b/Source/Schema.NET/core/FoodEstablishment.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// Indicates whether a FoodEstablishment accepts reservations. Values can be Boolean, an URL at which reservations can be made or (for backwards compatibility) the strings &lt;code&gt;Yes&lt;/code&gt; or &lt;code&gt;No&lt;/code&gt;.
         /// </summary>
-        Values<bool?, string, Uri>? AcceptsReservations { get; set; }
+        Values<bool?, string, Uri> AcceptsReservations { get; set; }
 
         /// <summary>
         /// Either the actual menu as a structured representation, as text, or a URL of the menu.
         /// </summary>
-        Values<IMenu, string, Uri>? HasMenu { get; set; }
+        Values<IMenu, string, Uri> HasMenu { get; set; }
 
         /// <summary>
         /// The cuisine of the restaurant.
@@ -47,14 +47,14 @@
         /// </summary>
         [DataMember(Name = "acceptsReservations", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, string, Uri>? AcceptsReservations { get; set; }
+        public Values<bool?, string, Uri> AcceptsReservations { get; set; }
 
         /// <summary>
         /// Either the actual menu as a structured representation, as text, or a URL of the menu.
         /// </summary>
         [DataMember(Name = "hasMenu", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMenu, string, Uri>? HasMenu { get; set; }
+        public Values<IMenu, string, Uri> HasMenu { get; set; }
 
         /// <summary>
         /// The cuisine of the restaurant.

--- a/Source/Schema.NET/core/FoodEstablishmentReservation.cs
+++ b/Source/Schema.NET/core/FoodEstablishmentReservation.cs
@@ -14,18 +14,18 @@
         /// The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to &lt;em&gt;December&lt;/em&gt;. For media, including audio and video, it's the time offset of the end of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
         /// Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
         /// </summary>
-        OneOrMany<DateTimeOffset?> EndTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> EndTime { get; set; }
 
         /// <summary>
         /// Number of people the reservation should accommodate.
         /// </summary>
-        Values<int?, IQuantitativeValue>? PartySize { get; set; }
+        Values<int?, IQuantitativeValue> PartySize { get; set; }
 
         /// <summary>
         /// The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from &lt;em&gt;January&lt;/em&gt; to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
         /// Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
         /// </summary>
-        OneOrMany<DateTimeOffset?> StartTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> StartTime { get; set; }
     }
 
     /// <summary>
@@ -47,14 +47,14 @@
         /// </summary>
         [DataMember(Name = "endTime", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> EndTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> EndTime { get; set; }
 
         /// <summary>
         /// Number of people the reservation should accommodate.
         /// </summary>
         [DataMember(Name = "partySize", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? PartySize { get; set; }
+        public Values<int?, IQuantitativeValue> PartySize { get; set; }
 
         /// <summary>
         /// The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from &lt;em&gt;January&lt;/em&gt; to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
@@ -62,6 +62,6 @@
         /// </summary>
         [DataMember(Name = "startTime", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> StartTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> StartTime { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Game.cs
+++ b/Source/Schema.NET/core/Game.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// Real or fictional location of the game (or part of game).
         /// </summary>
-        Values<IPlace, IPostalAddress, Uri>? GameLocation { get; set; }
+        Values<IPlace, IPostalAddress, Uri> GameLocation { get; set; }
 
         /// <summary>
         /// Indicate how many people can play this game (minimum, maximum, or range).
@@ -66,7 +66,7 @@
         /// </summary>
         [DataMember(Name = "gameLocation", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPlace, IPostalAddress, Uri>? GameLocation { get; set; }
+        public Values<IPlace, IPostalAddress, Uri> GameLocation { get; set; }
 
         /// <summary>
         /// Indicate how many people can play this game (minimum, maximum, or range).

--- a/Source/Schema.NET/core/GeoCircle.cs
+++ b/Source/Schema.NET/core/GeoCircle.cs
@@ -19,7 +19,7 @@
         /// <summary>
         /// Indicates the approximate radius of a GeoCircle (metres unless indicated otherwise via Distance notation).
         /// </summary>
-        Values<string, double?, string>? GeoRadius { get; set; }
+        Values<string, double?, string> GeoRadius { get; set; }
     }
 
     /// <summary>
@@ -48,6 +48,6 @@
         /// </summary>
         [DataMember(Name = "geoRadius", Order = 407)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, double?, string>? GeoRadius { get; set; }
+        public Values<string, double?, string> GeoRadius { get; set; }
     }
 }

--- a/Source/Schema.NET/core/GeoCoordinates.cs
+++ b/Source/Schema.NET/core/GeoCoordinates.cs
@@ -12,27 +12,27 @@
         /// <summary>
         /// Physical address of the item.
         /// </summary>
-        Values<IPostalAddress, string>? Address { get; set; }
+        Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The country. For example, USA. You can also provide the two-letter &lt;a href="http://en.wikipedia.org/wiki/ISO_3166-1"&gt;ISO 3166-1 alpha-2 country code&lt;/a&gt;.
         /// </summary>
-        Values<ICountry, string>? AddressCountry { get; set; }
+        Values<ICountry, string> AddressCountry { get; set; }
 
         /// <summary>
         /// The elevation of a location (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;). Values may be of the form 'NUMBER UNIT&lt;em&gt;OF&lt;/em&gt;MEASUREMENT' (e.g., '1,000 m', '3,200 ft') while numbers alone should be assumed to be a value in meters.
         /// </summary>
-        Values<double?, string>? Elevation { get; set; }
+        Values<double?, string> Elevation { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        Values<double?, string>? Latitude { get; set; }
+        Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        Values<double?, string>? Longitude { get; set; }
+        Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// The postal code. For example, 94043.
@@ -57,35 +57,35 @@
         /// </summary>
         [DataMember(Name = "address", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPostalAddress, string>? Address { get; set; }
+        public Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The country. For example, USA. You can also provide the two-letter &lt;a href="http://en.wikipedia.org/wiki/ISO_3166-1"&gt;ISO 3166-1 alpha-2 country code&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "addressCountry", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICountry, string>? AddressCountry { get; set; }
+        public Values<ICountry, string> AddressCountry { get; set; }
 
         /// <summary>
         /// The elevation of a location (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;). Values may be of the form 'NUMBER UNIT&lt;em&gt;OF&lt;/em&gt;MEASUREMENT' (e.g., '1,000 m', '3,200 ft') while numbers alone should be assumed to be a value in meters.
         /// </summary>
         [DataMember(Name = "elevation", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Elevation { get; set; }
+        public Values<double?, string> Elevation { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "latitude", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Latitude { get; set; }
+        public Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "longitude", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Longitude { get; set; }
+        public Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// The postal code. For example, 94043.

--- a/Source/Schema.NET/core/GeoShape.cs
+++ b/Source/Schema.NET/core/GeoShape.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// Physical address of the item.
         /// </summary>
-        Values<IPostalAddress, string>? Address { get; set; }
+        Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The country. For example, USA. You can also provide the two-letter &lt;a href="http://en.wikipedia.org/wiki/ISO_3166-1"&gt;ISO 3166-1 alpha-2 country code&lt;/a&gt;.
         /// </summary>
-        Values<ICountry, string>? AddressCountry { get; set; }
+        Values<ICountry, string> AddressCountry { get; set; }
 
         /// <summary>
         /// A box is the area enclosed by the rectangle formed by two points. The first point is the lower corner, the second point is the upper corner. A box is expressed as two points separated by a space character.
@@ -32,7 +32,7 @@
         /// <summary>
         /// The elevation of a location (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;). Values may be of the form 'NUMBER UNIT&lt;em&gt;OF&lt;/em&gt;MEASUREMENT' (e.g., '1,000 m', '3,200 ft') while numbers alone should be assumed to be a value in meters.
         /// </summary>
-        Values<double?, string>? Elevation { get; set; }
+        Values<double?, string> Elevation { get; set; }
 
         /// <summary>
         /// A line is a point-to-point path consisting of two or more points. A line is expressed as a series of two or more point objects separated by space.
@@ -67,14 +67,14 @@
         /// </summary>
         [DataMember(Name = "address", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPostalAddress, string>? Address { get; set; }
+        public Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The country. For example, USA. You can also provide the two-letter &lt;a href="http://en.wikipedia.org/wiki/ISO_3166-1"&gt;ISO 3166-1 alpha-2 country code&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "addressCountry", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICountry, string>? AddressCountry { get; set; }
+        public Values<ICountry, string> AddressCountry { get; set; }
 
         /// <summary>
         /// A box is the area enclosed by the rectangle formed by two points. The first point is the lower corner, the second point is the upper corner. A box is expressed as two points separated by a space character.
@@ -95,7 +95,7 @@
         /// </summary>
         [DataMember(Name = "elevation", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Elevation { get; set; }
+        public Values<double?, string> Elevation { get; set; }
 
         /// <summary>
         /// A line is a point-to-point path consisting of two or more points. A line is expressed as a series of two or more point objects separated by space.

--- a/Source/Schema.NET/core/GiveAction.cs
+++ b/Source/Schema.NET/core/GiveAction.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -42,6 +42,6 @@
         /// </summary>
         [DataMember(Name = "recipient", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Hospital.cs
+++ b/Source/Schema.NET/core/Hospital.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A medical service available from this provider.
         /// </summary>
-        Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy>? AvailableService { get; set; }
+        Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy> AvailableService { get; set; }
     }
 
     /// <summary>
@@ -32,7 +32,7 @@
         /// </summary>
         [DataMember(Name = "availableService", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy>? AvailableService { get; set; }
+        public Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy> AvailableService { get; set; }
 
         /// <summary>
         /// A medical specialty of the provider.

--- a/Source/Schema.NET/core/HotelRoom.cs
+++ b/Source/Schema.NET/core/HotelRoom.cs
@@ -15,7 +15,7 @@
         /// The type of bed or beds included in the accommodation. For the single case of just one bed of a certain type, you use bed directly with a text.
         ///       If you want to indicate the quantity of a certain kind of bed, use an instance of BedDetails. For more detailed information, use the amenityFeature property.
         /// </summary>
-        Values<IBedDetails, BedType?, string>? Bed { get; set; }
+        Values<IBedDetails, BedType?, string> Bed { get; set; }
 
         /// <summary>
         /// The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).
@@ -44,7 +44,7 @@
         /// </summary>
         [DataMember(Name = "bed", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBedDetails, BedType?, string>? Bed { get; set; }
+        public Values<IBedDetails, BedType?, string> Bed { get; set; }
 
         /// <summary>
         /// The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).

--- a/Source/Schema.NET/core/House.cs
+++ b/Source/Schema.NET/core/House.cs
@@ -29,6 +29,6 @@
         /// </summary>
         [DataMember(Name = "numberOfRooms", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        public override Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
     }
 }

--- a/Source/Schema.NET/core/HowTo.cs
+++ b/Source/Schema.NET/core/HowTo.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The estimated cost of the supply or supplies consumed when performing instructions.
         /// </summary>
-        Values<IMonetaryAmount, string>? EstimatedCost { get; set; }
+        Values<IMonetaryAmount, string> EstimatedCost { get; set; }
 
         /// <summary>
         /// The length of time it takes to perform instructions or a direction (not including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.
@@ -27,17 +27,17 @@
         /// <summary>
         /// A single step item (as HowToStep, text, document, video, etc.) or a HowToSection.
         /// </summary>
-        Values<ICreativeWork, IHowToSection, IHowToStep, string>? Step { get; set; }
+        Values<ICreativeWork, IHowToSection, IHowToStep, string> Step { get; set; }
 
         /// <summary>
         /// A sub-property of instrument. A supply consumed when performing instructions or a direction.
         /// </summary>
-        Values<IHowToSupply, string>? Supply { get; set; }
+        Values<IHowToSupply, string> Supply { get; set; }
 
         /// <summary>
         /// A sub property of instrument. An object used (but not consumed) when performing instructions or a direction.
         /// </summary>
-        Values<IHowToTool, string>? Tool { get; set; }
+        Values<IHowToTool, string> Tool { get; set; }
 
         /// <summary>
         /// The total time required to perform instructions or a direction (including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.
@@ -47,7 +47,7 @@
         /// <summary>
         /// The quantity that results by performing instructions. For example, a paper airplane, 10 personalized candles.
         /// </summary>
-        Values<IQuantitativeValue, string>? Yield { get; set; }
+        Values<IQuantitativeValue, string> Yield { get; set; }
     }
 
     /// <summary>
@@ -67,7 +67,7 @@
         /// </summary>
         [DataMember(Name = "estimatedCost", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, string>? EstimatedCost { get; set; }
+        public Values<IMonetaryAmount, string> EstimatedCost { get; set; }
 
         /// <summary>
         /// The length of time it takes to perform instructions or a direction (not including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.
@@ -88,21 +88,21 @@
         /// </summary>
         [DataMember(Name = "step", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IHowToSection, IHowToStep, string>? Step { get; set; }
+        public Values<ICreativeWork, IHowToSection, IHowToStep, string> Step { get; set; }
 
         /// <summary>
         /// A sub-property of instrument. A supply consumed when performing instructions or a direction.
         /// </summary>
         [DataMember(Name = "supply", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IHowToSupply, string>? Supply { get; set; }
+        public Values<IHowToSupply, string> Supply { get; set; }
 
         /// <summary>
         /// A sub property of instrument. An object used (but not consumed) when performing instructions or a direction.
         /// </summary>
         [DataMember(Name = "tool", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IHowToTool, string>? Tool { get; set; }
+        public Values<IHowToTool, string> Tool { get; set; }
 
         /// <summary>
         /// The total time required to perform instructions or a direction (including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.
@@ -116,6 +116,6 @@
         /// </summary>
         [DataMember(Name = "yield", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? Yield { get; set; }
+        public Values<IQuantitativeValue, string> Yield { get; set; }
     }
 }

--- a/Source/Schema.NET/core/HowToDirection.cs
+++ b/Source/Schema.NET/core/HowToDirection.cs
@@ -12,17 +12,17 @@
         /// <summary>
         /// A media object representing the circumstances after performing this direction.
         /// </summary>
-        Values<IMediaObject, Uri>? AfterMedia { get; set; }
+        Values<IMediaObject, Uri> AfterMedia { get; set; }
 
         /// <summary>
         /// A media object representing the circumstances before performing this direction.
         /// </summary>
-        Values<IMediaObject, Uri>? BeforeMedia { get; set; }
+        Values<IMediaObject, Uri> BeforeMedia { get; set; }
 
         /// <summary>
         /// A media object representing the circumstances while performing this direction.
         /// </summary>
-        Values<IMediaObject, Uri>? DuringMedia { get; set; }
+        Values<IMediaObject, Uri> DuringMedia { get; set; }
 
         /// <summary>
         /// The length of time it takes to perform instructions or a direction (not including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.
@@ -37,12 +37,12 @@
         /// <summary>
         /// A sub-property of instrument. A supply consumed when performing instructions or a direction.
         /// </summary>
-        Values<IHowToSupply, string>? Supply { get; set; }
+        Values<IHowToSupply, string> Supply { get; set; }
 
         /// <summary>
         /// A sub property of instrument. An object used (but not consumed) when performing instructions or a direction.
         /// </summary>
-        Values<IHowToTool, string>? Tool { get; set; }
+        Values<IHowToTool, string> Tool { get; set; }
 
         /// <summary>
         /// The total time required to perform instructions or a direction (including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.
@@ -67,21 +67,21 @@
         /// </summary>
         [DataMember(Name = "afterMedia", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMediaObject, Uri>? AfterMedia { get; set; }
+        public Values<IMediaObject, Uri> AfterMedia { get; set; }
 
         /// <summary>
         /// A media object representing the circumstances before performing this direction.
         /// </summary>
         [DataMember(Name = "beforeMedia", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMediaObject, Uri>? BeforeMedia { get; set; }
+        public Values<IMediaObject, Uri> BeforeMedia { get; set; }
 
         /// <summary>
         /// A media object representing the circumstances while performing this direction.
         /// </summary>
         [DataMember(Name = "duringMedia", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMediaObject, Uri>? DuringMedia { get; set; }
+        public Values<IMediaObject, Uri> DuringMedia { get; set; }
 
         /// <summary>
         /// The length of time it takes to perform instructions or a direction (not including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.
@@ -102,14 +102,14 @@
         /// </summary>
         [DataMember(Name = "supply", Order = 311)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IHowToSupply, string>? Supply { get; set; }
+        public Values<IHowToSupply, string> Supply { get; set; }
 
         /// <summary>
         /// A sub property of instrument. An object used (but not consumed) when performing instructions or a direction.
         /// </summary>
         [DataMember(Name = "tool", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IHowToTool, string>? Tool { get; set; }
+        public Values<IHowToTool, string> Tool { get; set; }
 
         /// <summary>
         /// The total time required to perform instructions or a direction (including time to prepare the supplies), in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 duration format&lt;/a&gt;.

--- a/Source/Schema.NET/core/HowToItem.cs
+++ b/Source/Schema.NET/core/HowToItem.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The required quantity of the item(s).
         /// </summary>
-        Values<double?, IQuantitativeValue, string>? RequiredQuantity { get; set; }
+        Values<double?, IQuantitativeValue, string> RequiredQuantity { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "requiredQuantity", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, IQuantitativeValue, string>? RequiredQuantity { get; set; }
+        public Values<double?, IQuantitativeValue, string> RequiredQuantity { get; set; }
     }
 }

--- a/Source/Schema.NET/core/HowToSupply.cs
+++ b/Source/Schema.NET/core/HowToSupply.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The estimated cost of the supply or supplies consumed when performing instructions.
         /// </summary>
-        Values<IMonetaryAmount, string>? EstimatedCost { get; set; }
+        Values<IMonetaryAmount, string> EstimatedCost { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "estimatedCost", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, string>? EstimatedCost { get; set; }
+        public Values<IMonetaryAmount, string> EstimatedCost { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ImageObject.cs
+++ b/Source/Schema.NET/core/ImageObject.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// The caption for this object. For downloadable machine formats (closed caption, subtitles etc.) use MediaObject and indicate the &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt;.
         /// </summary>
-        Values<IMediaObject, string>? Caption { get; set; }
+        Values<IMediaObject, string> Caption { get; set; }
 
         /// <summary>
         /// exif data for this object.
         /// </summary>
-        Values<IPropertyValue, string>? ExifData { get; set; }
+        Values<IPropertyValue, string> ExifData { get; set; }
 
         /// <summary>
         /// Indicates whether this image is representative of the content of the page.
@@ -47,14 +47,14 @@
         /// </summary>
         [DataMember(Name = "caption", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMediaObject, string>? Caption { get; set; }
+        public Values<IMediaObject, string> Caption { get; set; }
 
         /// <summary>
         /// exif data for this object.
         /// </summary>
         [DataMember(Name = "exifData", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPropertyValue, string>? ExifData { get; set; }
+        public Values<IPropertyValue, string> ExifData { get; set; }
 
         /// <summary>
         /// Indicates whether this image is representative of the content of the page.

--- a/Source/Schema.NET/core/InteractionCounter.cs
+++ b/Source/Schema.NET/core/InteractionCounter.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The WebSite or SoftwareApplication where the interactions took place.
         /// </summary>
-        Values<ISoftwareApplication, IWebSite>? InteractionService { get; set; }
+        Values<ISoftwareApplication, IWebSite> InteractionService { get; set; }
 
         /// <summary>
         /// The Action representing the type of interaction. For up votes, +1s, etc. use &lt;a class="localLink" href="http://schema.org/LikeAction"&gt;LikeAction&lt;/a&gt;. For down votes use &lt;a class="localLink" href="http://schema.org/DislikeAction"&gt;DislikeAction&lt;/a&gt;. Otherwise, use the most specific Action.
@@ -42,7 +42,7 @@
         /// </summary>
         [DataMember(Name = "interactionService", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ISoftwareApplication, IWebSite>? InteractionService { get; set; }
+        public Values<ISoftwareApplication, IWebSite> InteractionService { get; set; }
 
         /// <summary>
         /// The Action representing the type of interaction. For up votes, +1s, etc. use &lt;a class="localLink" href="http://schema.org/LikeAction"&gt;LikeAction&lt;/a&gt;. For down votes use &lt;a class="localLink" href="http://schema.org/DislikeAction"&gt;DislikeAction&lt;/a&gt;. Otherwise, use the most specific Action.

--- a/Source/Schema.NET/core/InvestmentOrDeposit.cs
+++ b/Source/Schema.NET/core/InvestmentOrDeposit.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The amount of money.
         /// </summary>
-        Values<IMonetaryAmount, decimal?>? Amount { get; set; }
+        Values<IMonetaryAmount, decimal?> Amount { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "amount", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, decimal?>? Amount { get; set; }
+        public Values<IMonetaryAmount, decimal?> Amount { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Invoice.cs
+++ b/Source/Schema.NET/core/Invoice.cs
@@ -22,12 +22,12 @@
         /// <summary>
         /// An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred.
         /// </summary>
-        Values<IOrganization, IPerson>? Broker { get; set; }
+        Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
-        Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// A number that confirms the given order or payment has been received.
@@ -37,17 +37,17 @@
         /// <summary>
         /// Party placing the order or paying the invoice.
         /// </summary>
-        Values<IOrganization, IPerson>? Customer { get; set; }
+        Values<IOrganization, IPerson> Customer { get; set; }
 
         /// <summary>
         /// The minimum payment required at this time.
         /// </summary>
-        Values<IMonetaryAmount, IPriceSpecification>? MinimumPaymentDue { get; set; }
+        Values<IMonetaryAmount, IPriceSpecification> MinimumPaymentDue { get; set; }
 
         /// <summary>
         /// The date that payment is due.
         /// </summary>
-        OneOrMany<DateTimeOffset?> PaymentDueDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> PaymentDueDate { get; set; }
 
         /// <summary>
         /// The name of the credit card or other method of payment for the order.
@@ -62,12 +62,12 @@
         /// <summary>
         /// The status of payment; whether the invoice has been paid or not.
         /// </summary>
-        Values<PaymentStatusType?, string>? PaymentStatus { get; set; }
+        Values<PaymentStatusType?, string> PaymentStatus { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        Values<IOrganization, IPerson>? Provider { get; set; }
+        Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice.
@@ -77,12 +77,12 @@
         /// <summary>
         /// The date the invoice is scheduled to be paid.
         /// </summary>
-        Values<int?, DateTime?>? ScheduledPaymentDate { get; set; }
+        Values<int?, DateTime?> ScheduledPaymentDate { get; set; }
 
         /// <summary>
         /// The total amount due.
         /// </summary>
-        Values<IMonetaryAmount, IPriceSpecification>? TotalPaymentDue { get; set; }
+        Values<IMonetaryAmount, IPriceSpecification> TotalPaymentDue { get; set; }
     }
 
     /// <summary>
@@ -116,14 +116,14 @@
         /// </summary>
         [DataMember(Name = "broker", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Broker { get; set; }
+        public Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
         [DataMember(Name = "category", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// A number that confirms the given order or payment has been received.
@@ -137,21 +137,21 @@
         /// </summary>
         [DataMember(Name = "customer", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Customer { get; set; }
+        public Values<IOrganization, IPerson> Customer { get; set; }
 
         /// <summary>
         /// The minimum payment required at this time.
         /// </summary>
         [DataMember(Name = "minimumPaymentDue", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, IPriceSpecification>? MinimumPaymentDue { get; set; }
+        public Values<IMonetaryAmount, IPriceSpecification> MinimumPaymentDue { get; set; }
 
         /// <summary>
         /// The date that payment is due.
         /// </summary>
         [DataMember(Name = "paymentDueDate", Order = 213)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> PaymentDueDate { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> PaymentDueDate { get; set; }
 
         /// <summary>
         /// The name of the credit card or other method of payment for the order.
@@ -172,14 +172,14 @@
         /// </summary>
         [DataMember(Name = "paymentStatus", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PaymentStatusType?, string>? PaymentStatus { get; set; }
+        public Values<PaymentStatusType?, string> PaymentStatus { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
         [DataMember(Name = "provider", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice.
@@ -193,13 +193,13 @@
         /// </summary>
         [DataMember(Name = "scheduledPaymentDate", Order = 219)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? ScheduledPaymentDate { get; set; }
+        public Values<int?, DateTime?> ScheduledPaymentDate { get; set; }
 
         /// <summary>
         /// The total amount due.
         /// </summary>
         [DataMember(Name = "totalPaymentDue", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, IPriceSpecification>? TotalPaymentDue { get; set; }
+        public Values<IMonetaryAmount, IPriceSpecification> TotalPaymentDue { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ItemList.cs
+++ b/Source/Schema.NET/core/ItemList.cs
@@ -14,12 +14,12 @@
         /// Text values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.&lt;br/&gt;&lt;br/&gt;
         /// Note: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases.
         /// </summary>
-        Values<IListItem, string, IThing>? ItemListElement { get; set; }
+        Values<IListItem, string, IThing> ItemListElement { get; set; }
 
         /// <summary>
         /// Type of ordering (e.g. Ascending, Descending, Unordered).
         /// </summary>
-        Values<ItemListOrderType?, string>? ItemListOrder { get; set; }
+        Values<ItemListOrderType?, string> ItemListOrder { get; set; }
 
         /// <summary>
         /// The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list.
@@ -46,14 +46,14 @@
         /// </summary>
         [DataMember(Name = "itemListElement", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IListItem, string, IThing>? ItemListElement { get; set; }
+        public Values<IListItem, string, IThing> ItemListElement { get; set; }
 
         /// <summary>
         /// Type of ordering (e.g. Ascending, Descending, Unordered).
         /// </summary>
         [DataMember(Name = "itemListOrder", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ItemListOrderType?, string>? ItemListOrder { get; set; }
+        public Values<ItemListOrderType?, string> ItemListOrder { get; set; }
 
         /// <summary>
         /// The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list.

--- a/Source/Schema.NET/core/JobPosting.cs
+++ b/Source/Schema.NET/core/JobPosting.cs
@@ -22,12 +22,12 @@
         /// <summary>
         /// The base salary of the job or of an employee in an EmployeeRole.
         /// </summary>
-        Values<IMonetaryAmount, decimal?, IPriceSpecification>? BaseSalary { get; set; }
+        Values<IMonetaryAmount, decimal?, IPriceSpecification> BaseSalary { get; set; }
 
         /// <summary>
         /// Publication date for the job posting.
         /// </summary>
-        Values<int?, DateTime?>? DatePosted { get; set; }
+        Values<int?, DateTime?> DatePosted { get; set; }
 
         /// <summary>
         /// Educational background needed for the position or Occupation.
@@ -42,7 +42,7 @@
         /// <summary>
         /// An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value.
         /// </summary>
-        Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?>? EstimatedSalary { get; set; }
+        Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?> EstimatedSalary { get; set; }
 
         /// <summary>
         /// Description of skills and experience needed for the position or Occupation.
@@ -70,6 +70,11 @@
         OneOrMany<string> JobBenefits { get; set; }
 
         /// <summary>
+        /// An indicator as to whether a position is available for an immediate start.
+        /// </summary>
+        OneOrMany<bool?> JobImmediateStart { get; set; }
+
+        /// <summary>
         /// A (typically single) geographic location associated with the job position.
         /// </summary>
         OneOrMany<IPlace> JobLocation { get; set; }
@@ -78,6 +83,11 @@
         /// A description of the job location (e.g TELECOMMUTE for telecommute jobs).
         /// </summary>
         OneOrMany<string> JobLocationType { get; set; }
+
+        /// <summary>
+        /// The date on which a successful applicant for this job would be expected to start work. Choose a specific date in the future or use the jobImmediateStart property to indicate the position is to be filled as soon as possible.
+        /// </summary>
+        Values<int?, DateTime?, string> JobStartDate { get; set; }
 
         /// <summary>
         /// A category describing the job, preferably using a term from a taxonomy such as &lt;a href="http://www.onetcenter.org/taxonomy.html"&gt;BLS O*NET-SOC&lt;/a&gt;, &lt;a href="https://www.ilo.org/public/english/bureau/stat/isco/isco08/"&gt;ISCO-08&lt;/a&gt; or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.&lt;br/&gt;&lt;br/&gt;
@@ -118,7 +128,7 @@
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The typical working hours for this job (e.g. 1st shift, night shift, 8am-5pm).
@@ -157,14 +167,14 @@
         /// </summary>
         [DataMember(Name = "baseSalary", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, decimal?, IPriceSpecification>? BaseSalary { get; set; }
+        public Values<IMonetaryAmount, decimal?, IPriceSpecification> BaseSalary { get; set; }
 
         /// <summary>
         /// Publication date for the job posting.
         /// </summary>
         [DataMember(Name = "datePosted", Order = 209)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DatePosted { get; set; }
+        public Values<int?, DateTime?> DatePosted { get; set; }
 
         /// <summary>
         /// Educational background needed for the position or Occupation.
@@ -185,7 +195,7 @@
         /// </summary>
         [DataMember(Name = "estimatedSalary", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?>? EstimatedSalary { get; set; }
+        public Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?> EstimatedSalary { get; set; }
 
         /// <summary>
         /// Description of skills and experience needed for the position or Occupation.
@@ -223,80 +233,94 @@
         public OneOrMany<string> JobBenefits { get; set; }
 
         /// <summary>
+        /// An indicator as to whether a position is available for an immediate start.
+        /// </summary>
+        [DataMember(Name = "jobImmediateStart", Order = 218)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<bool?> JobImmediateStart { get; set; }
+
+        /// <summary>
         /// A (typically single) geographic location associated with the job position.
         /// </summary>
-        [DataMember(Name = "jobLocation", Order = 218)]
+        [DataMember(Name = "jobLocation", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> JobLocation { get; set; }
 
         /// <summary>
         /// A description of the job location (e.g TELECOMMUTE for telecommute jobs).
         /// </summary>
-        [DataMember(Name = "jobLocationType", Order = 219)]
+        [DataMember(Name = "jobLocationType", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> JobLocationType { get; set; }
+
+        /// <summary>
+        /// The date on which a successful applicant for this job would be expected to start work. Choose a specific date in the future or use the jobImmediateStart property to indicate the position is to be filled as soon as possible.
+        /// </summary>
+        [DataMember(Name = "jobStartDate", Order = 221)]
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, string> JobStartDate { get; set; }
 
         /// <summary>
         /// A category describing the job, preferably using a term from a taxonomy such as &lt;a href="http://www.onetcenter.org/taxonomy.html"&gt;BLS O*NET-SOC&lt;/a&gt;, &lt;a href="https://www.ilo.org/public/english/bureau/stat/isco/isco08/"&gt;ISCO-08&lt;/a&gt; or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.&lt;br/&gt;&lt;br/&gt;
         /// Note: for historical reasons, any textual label and formal code provided as a literal may be assumed to be from O*NET-SOC.
         /// </summary>
-        [DataMember(Name = "occupationalCategory", Order = 220)]
+        [DataMember(Name = "occupationalCategory", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> OccupationalCategory { get; set; }
 
         /// <summary>
         /// Specific qualifications required for this role or Occupation.
         /// </summary>
-        [DataMember(Name = "qualifications", Order = 221)]
+        [DataMember(Name = "qualifications", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Qualifications { get; set; }
 
         /// <summary>
         /// The Occupation for the JobPosting.
         /// </summary>
-        [DataMember(Name = "relevantOccupation", Order = 222)]
+        [DataMember(Name = "relevantOccupation", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOccupation> RelevantOccupation { get; set; }
 
         /// <summary>
         /// Responsibilities associated with this role or Occupation.
         /// </summary>
-        [DataMember(Name = "responsibilities", Order = 223)]
+        [DataMember(Name = "responsibilities", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Responsibilities { get; set; }
 
         /// <summary>
         /// The currency (coded using &lt;a href="http://en.wikipedia.org/wiki/ISO_4217"&gt;ISO 4217&lt;/a&gt; ) used for the main salary information in this job posting or for this employee.
         /// </summary>
-        [DataMember(Name = "salaryCurrency", Order = 224)]
+        [DataMember(Name = "salaryCurrency", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SalaryCurrency { get; set; }
 
         /// <summary>
         /// Skills required to fulfill this role or in this Occupation.
         /// </summary>
-        [DataMember(Name = "skills", Order = 225)]
+        [DataMember(Name = "skills", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Skills { get; set; }
 
         /// <summary>
         /// Any special commitments associated with this job posting. Valid entries include VeteranCommit, MilitarySpouseCommit, etc.
         /// </summary>
-        [DataMember(Name = "specialCommitments", Order = 226)]
+        [DataMember(Name = "specialCommitments", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SpecialCommitments { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        [DataMember(Name = "validThrough", Order = 227)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        [DataMember(Name = "validThrough", Order = 229)]
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The typical working hours for this job (e.g. 1st shift, night shift, 8am-5pm).
         /// </summary>
-        [DataMember(Name = "workHours", Order = 228)]
+        [DataMember(Name = "workHours", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> WorkHours { get; set; }
     }

--- a/Source/Schema.NET/core/Joint.cs
+++ b/Source/Schema.NET/core/Joint.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The degree of mobility the joint allows.
         /// </summary>
-        Values<IMedicalEntity, string>? FunctionalClass { get; set; }
+        Values<IMedicalEntity, string> FunctionalClass { get; set; }
 
         /// <summary>
         /// The name given to how bone physically connects to each other.
@@ -49,7 +49,7 @@
         /// </summary>
         [DataMember(Name = "functionalClass", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalEntity, string>? FunctionalClass { get; set; }
+        public Values<IMedicalEntity, string> FunctionalClass { get; set; }
 
         /// <summary>
         /// The name given to how bone physically connects to each other.

--- a/Source/Schema.NET/core/ListItem.cs
+++ b/Source/Schema.NET/core/ListItem.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        Values<int?, string>? Position { get; set; }
+        Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.
@@ -61,7 +61,7 @@
         /// </summary>
         [DataMember(Name = "position", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? Position { get; set; }
+        public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.

--- a/Source/Schema.NET/core/LoanOrCredit.cs
+++ b/Source/Schema.NET/core/LoanOrCredit.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The amount of money.
         /// </summary>
-        Values<IMonetaryAmount, decimal?>? Amount { get; set; }
+        Values<IMonetaryAmount, decimal?> Amount { get; set; }
 
         /// <summary>
         /// The currency in which the monetary amount is expressed.&lt;br/&gt;&lt;br/&gt;
@@ -33,7 +33,7 @@
         /// <summary>
         /// The type of a loan or credit.
         /// </summary>
-        Values<string, Uri>? LoanType { get; set; }
+        Values<string, Uri> LoanType { get; set; }
 
         /// <summary>
         /// The only way you get the money back in the event of default is the security. Recourse is where you still have the opportunity to go back to the borrower for the rest of the money.
@@ -48,7 +48,7 @@
         /// <summary>
         /// Assets required to secure loan or credit repayments. It may take form of third party pledge, goods, financial instruments (cash, securities, etc.)
         /// </summary>
-        Values<string, IThing>? RequiredCollateral { get; set; }
+        Values<string, IThing> RequiredCollateral { get; set; }
     }
 
     /// <summary>
@@ -68,7 +68,7 @@
         /// </summary>
         [DataMember(Name = "amount", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, decimal?>? Amount { get; set; }
+        public Values<IMonetaryAmount, decimal?> Amount { get; set; }
 
         /// <summary>
         /// The currency in which the monetary amount is expressed.&lt;br/&gt;&lt;br/&gt;
@@ -97,7 +97,7 @@
         /// </summary>
         [DataMember(Name = "loanType", Order = 410)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? LoanType { get; set; }
+        public Values<string, Uri> LoanType { get; set; }
 
         /// <summary>
         /// The only way you get the money back in the event of default is the security. Recourse is where you still have the opportunity to go back to the borrower for the rest of the money.
@@ -118,6 +118,6 @@
         /// </summary>
         [DataMember(Name = "requiredCollateral", Order = 413)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IThing>? RequiredCollateral { get; set; }
+        public Values<string, IThing> RequiredCollateral { get; set; }
     }
 }

--- a/Source/Schema.NET/core/LocationFeatureSpecification.cs
+++ b/Source/Schema.NET/core/LocationFeatureSpecification.cs
@@ -17,12 +17,12 @@
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
     }
 
     /// <summary>
@@ -48,14 +48,14 @@
         /// The date when the item becomes valid.
         /// </summary>
         [DataMember(Name = "validFrom", Order = 407)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
         [DataMember(Name = "validThrough", Order = 408)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
     }
 }

--- a/Source/Schema.NET/core/LodgingBusiness.cs
+++ b/Source/Schema.NET/core/LodgingBusiness.cs
@@ -17,28 +17,28 @@
         /// <summary>
         /// A language someone may use with or at the item, service or place. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/inLanguage"&gt;inLanguage&lt;/a&gt;
         /// </summary>
-        Values<ILanguage, string>? AvailableLanguage { get; set; }
+        Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// The earliest someone may check into a lodging establishment.
         /// </summary>
-        OneOrMany<DateTimeOffset?> CheckinTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> CheckinTime { get; set; }
 
         /// <summary>
         /// The latest someone may check out of a lodging establishment.
         /// </summary>
-        OneOrMany<DateTimeOffset?> CheckoutTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> CheckoutTime { get; set; }
 
         /// <summary>
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
         /// Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
         /// </summary>
-        Values<bool?, string>? PetsAllowed { get; set; }
+        Values<bool?, string> PetsAllowed { get; set; }
 
         /// <summary>
         /// An official rating for a lodging business or food establishment, e.g. from national associations or standards bodies. Use the author property to indicate the rating organization, e.g. as an Organization with name such as (e.g. HOTREC, DEHOGA, WHR, or Hotelstars).
@@ -77,21 +77,21 @@
         /// </summary>
         [DataMember(Name = "availableLanguage", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? AvailableLanguage { get; set; }
+        public Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// The earliest someone may check into a lodging establishment.
         /// </summary>
         [DataMember(Name = "checkinTime", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> CheckinTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> CheckinTime { get; set; }
 
         /// <summary>
         /// The latest someone may check out of a lodging establishment.
         /// </summary>
         [DataMember(Name = "checkoutTime", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> CheckoutTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> CheckoutTime { get; set; }
 
         /// <summary>
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
@@ -99,14 +99,14 @@
         /// </summary>
         [DataMember(Name = "numberOfRooms", Order = 311)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        public Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
         /// </summary>
         [DataMember(Name = "petsAllowed", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, string>? PetsAllowed { get; set; }
+        public Values<bool?, string> PetsAllowed { get; set; }
 
         /// <summary>
         /// An official rating for a lodging business or food establishment, e.g. from national associations or standards bodies. Use the author property to indicate the rating organization, e.g. as an Organization with name such as (e.g. HOTREC, DEHOGA, WHR, or Hotelstars).

--- a/Source/Schema.NET/core/LodgingReservation.cs
+++ b/Source/Schema.NET/core/LodgingReservation.cs
@@ -13,12 +13,12 @@
         /// <summary>
         /// The earliest someone may check into a lodging establishment.
         /// </summary>
-        OneOrMany<DateTimeOffset?> CheckinTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> CheckinTime { get; set; }
 
         /// <summary>
         /// The latest someone may check out of a lodging establishment.
         /// </summary>
-        OneOrMany<DateTimeOffset?> CheckoutTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> CheckoutTime { get; set; }
 
         /// <summary>
         /// A full description of the lodging unit.
@@ -33,12 +33,12 @@
         /// <summary>
         /// The number of adults staying in the unit.
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumAdults { get; set; }
+        Values<int?, IQuantitativeValue> NumAdults { get; set; }
 
         /// <summary>
         /// The number of children staying in the unit.
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumChildren { get; set; }
+        Values<int?, IQuantitativeValue> NumChildren { get; set; }
     }
 
     /// <summary>
@@ -59,14 +59,14 @@
         /// </summary>
         [DataMember(Name = "checkinTime", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> CheckinTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> CheckinTime { get; set; }
 
         /// <summary>
         /// The latest someone may check out of a lodging establishment.
         /// </summary>
         [DataMember(Name = "checkoutTime", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> CheckoutTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> CheckoutTime { get; set; }
 
         /// <summary>
         /// A full description of the lodging unit.
@@ -87,13 +87,13 @@
         /// </summary>
         [DataMember(Name = "numAdults", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumAdults { get; set; }
+        public Values<int?, IQuantitativeValue> NumAdults { get; set; }
 
         /// <summary>
         /// The number of children staying in the unit.
         /// </summary>
         [DataMember(Name = "numChildren", Order = 311)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumChildren { get; set; }
+        public Values<int?, IQuantitativeValue> NumChildren { get; set; }
     }
 }

--- a/Source/Schema.NET/core/LymphaticVessel.cs
+++ b/Source/Schema.NET/core/LymphaticVessel.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The anatomical or organ system drained by this vessel; generally refers to a specific part of an organ.
         /// </summary>
-        Values<IAnatomicalStructure, IAnatomicalSystem>? RegionDrained { get; set; }
+        Values<IAnatomicalStructure, IAnatomicalSystem> RegionDrained { get; set; }
 
         /// <summary>
         /// The vasculature the lymphatic structure runs, or efferents, to.
@@ -49,7 +49,7 @@
         /// </summary>
         [DataMember(Name = "regionDrained", Order = 407)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, IAnatomicalSystem>? RegionDrained { get; set; }
+        public Values<IAnatomicalStructure, IAnatomicalSystem> RegionDrained { get; set; }
 
         /// <summary>
         /// The vasculature the lymphatic structure runs, or efferents, to.

--- a/Source/Schema.NET/core/MediaObject.cs
+++ b/Source/Schema.NET/core/MediaObject.cs
@@ -48,12 +48,12 @@
         /// The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to &lt;em&gt;December&lt;/em&gt;. For media, including audio and video, it's the time offset of the end of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
         /// Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
         /// </summary>
-        OneOrMany<DateTimeOffset?> EndTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> EndTime { get; set; }
 
         /// <summary>
         /// The height of the item.
         /// </summary>
-        Values<string, IQuantitativeValue, int>? Height { get; set; }
+        Values<string, IQuantitativeValue, int> Height { get; set; }
 
         /// <summary>
         /// Player type required&amp;#x2014;for example, Flash or Silverlight.
@@ -73,23 +73,23 @@
         /// <summary>
         /// Indicates if use of the media require a subscription  (either paid or free). Allowed values are &lt;code&gt;true&lt;/code&gt; or &lt;code&gt;false&lt;/code&gt; (note that an earlier version had 'yes', 'no').
         /// </summary>
-        Values<bool?, IMediaSubscription>? RequiresSubscription { get; set; }
+        Values<bool?, IMediaSubscription> RequiresSubscription { get; set; }
 
         /// <summary>
         /// The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from &lt;em&gt;January&lt;/em&gt; to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
         /// Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
         /// </summary>
-        OneOrMany<DateTimeOffset?> StartTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> StartTime { get; set; }
 
         /// <summary>
         /// Date when this media object was uploaded to this site.
         /// </summary>
-        Values<int?, DateTime?>? UploadDate { get; set; }
+        Values<int?, DateTime?> UploadDate { get; set; }
 
         /// <summary>
         /// The width of the item.
         /// </summary>
-        Values<string, IQuantitativeValue, int>? Width { get; set; }
+        Values<string, IQuantitativeValue, int> Width { get; set; }
     }
 
     /// <summary>
@@ -160,7 +160,7 @@
         /// </summary>
         [DataMember(Name = "encodingFormat", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<string, Uri>? EncodingFormat { get; set; }
+        public override Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to &lt;em&gt;December&lt;/em&gt;. For media, including audio and video, it's the time offset of the end of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
@@ -168,14 +168,14 @@
         /// </summary>
         [DataMember(Name = "endTime", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> EndTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> EndTime { get; set; }
 
         /// <summary>
         /// The height of the item.
         /// </summary>
         [DataMember(Name = "height", Order = 215)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue, int>? Height { get; set; }
+        public Values<string, IQuantitativeValue, int> Height { get; set; }
 
         /// <summary>
         /// Player type required&amp;#x2014;for example, Flash or Silverlight.
@@ -203,7 +203,7 @@
         /// </summary>
         [DataMember(Name = "requiresSubscription", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, IMediaSubscription>? RequiresSubscription { get; set; }
+        public Values<bool?, IMediaSubscription> RequiresSubscription { get; set; }
 
         /// <summary>
         /// The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from &lt;em&gt;January&lt;/em&gt; to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.&lt;br/&gt;&lt;br/&gt;
@@ -211,20 +211,20 @@
         /// </summary>
         [DataMember(Name = "startTime", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> StartTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> StartTime { get; set; }
 
         /// <summary>
         /// Date when this media object was uploaded to this site.
         /// </summary>
         [DataMember(Name = "uploadDate", Order = 221)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? UploadDate { get; set; }
+        public Values<int?, DateTime?> UploadDate { get; set; }
 
         /// <summary>
         /// The width of the item.
         /// </summary>
         [DataMember(Name = "width", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue, int>? Width { get; set; }
+        public Values<string, IQuantitativeValue, int> Width { get; set; }
     }
 }

--- a/Source/Schema.NET/core/MedicalClinic.cs
+++ b/Source/Schema.NET/core/MedicalClinic.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A medical service available from this provider.
         /// </summary>
-        Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy>? AvailableService { get; set; }
+        Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy> AvailableService { get; set; }
     }
 
     /// <summary>
@@ -32,7 +32,7 @@
         /// </summary>
         [DataMember(Name = "availableService", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy>? AvailableService { get; set; }
+        public Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy> AvailableService { get; set; }
 
         /// <summary>
         /// A medical specialty of the provider.

--- a/Source/Schema.NET/core/MedicalCondition.cs
+++ b/Source/Schema.NET/core/MedicalCondition.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The anatomy of the underlying organ system or structures associated with this entity.
         /// </summary>
-        Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy>? AssociatedAnatomy { get; set; }
+        Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
         /// Specifying a cause of something in general. e.g in medicine , one of the causative agent(s) that are most directly responsible for the pathophysiologic process that eventually results in the occurrence.
@@ -87,7 +87,7 @@
         /// <summary>
         /// The status of the study (enumerated).
         /// </summary>
-        Values<EventStatusType?, MedicalStudyStatus?, string>? Status { get; set; }
+        Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
         /// <summary>
         /// A more specific type of the condition, where applicable, for example 'Type 1 Diabetes', 'Type 2 Diabetes', or 'Gestational Diabetes' for Diabetes.
@@ -117,7 +117,7 @@
         /// </summary>
         [DataMember(Name = "associatedAnatomy", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy>? AssociatedAnatomy { get; set; }
+        public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
         /// Specifying a cause of something in general. e.g in medicine , one of the causative agent(s) that are most directly responsible for the pathophysiologic process that eventually results in the occurrence.
@@ -222,7 +222,7 @@
         /// </summary>
         [DataMember(Name = "status", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<EventStatusType?, MedicalStudyStatus?, string>? Status { get; set; }
+        public Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
         /// <summary>
         /// A more specific type of the condition, where applicable, for example 'Type 1 Diabetes', 'Type 2 Diabetes', or 'Gestational Diabetes' for Diabetes.

--- a/Source/Schema.NET/core/MedicalDevice.cs
+++ b/Source/Schema.NET/core/MedicalDevice.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// A contraindication for this therapy.
         /// </summary>
-        Values<IMedicalContraindication, string>? Contraindication { get; set; }
+        Values<IMedicalContraindication, string> Contraindication { get; set; }
 
         /// <summary>
         /// A factor that indicates use of this therapy for treatment and/or prevention of a condition, symptom, etc. For therapies such as drugs, indications can include both officially-approved indications as well as off-label uses. These can be distinguished by using the ApprovedIndication subtype of MedicalIndication.
@@ -42,7 +42,7 @@
         /// <summary>
         /// A goal towards an action is taken. Can be concrete or abstract.
         /// </summary>
-        Values<MedicalDevicePurpose?, IThing>? Purpose { get; set; }
+        Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
 
         /// <summary>
         /// A possible serious complication and/or serious side effect of this therapy. Serious adverse outcomes include those that are life-threatening; result in death, disability, or permanent damage; require hospitalization or prolong existing hospitalization; cause congenital anomalies or birth defects; or jeopardize the patient and may require medical or surgical intervention to prevent one of the outcomes in this definition.
@@ -74,7 +74,7 @@
         /// </summary>
         [DataMember(Name = "contraindication", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalContraindication, string>? Contraindication { get; set; }
+        public Values<IMedicalContraindication, string> Contraindication { get; set; }
 
         /// <summary>
         /// A factor that indicates use of this therapy for treatment and/or prevention of a condition, symptom, etc. For therapies such as drugs, indications can include both officially-approved indications as well as off-label uses. These can be distinguished by using the ApprovedIndication subtype of MedicalIndication.
@@ -109,7 +109,7 @@
         /// </summary>
         [DataMember(Name = "purpose", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<MedicalDevicePurpose?, IThing>? Purpose { get; set; }
+        public Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
 
         /// <summary>
         /// A possible serious complication and/or serious side effect of this therapy. Serious adverse outcomes include those that are life-threatening; result in death, disability, or permanent damage; require hospitalization or prolong existing hospitalization; cause congenital anomalies or birth defects; or jeopardize the patient and may require medical or surgical intervention to prevent one of the outcomes in this definition.

--- a/Source/Schema.NET/core/MedicalEntity.cs
+++ b/Source/Schema.NET/core/MedicalEntity.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The drug or supplement's legal status, including any controlled substance schedules that apply.
         /// </summary>
-        Values<IDrugLegalStatus, MedicalEnumeration?, string>? LegalStatus { get; set; }
+        Values<IDrugLegalStatus, MedicalEnumeration?, string> LegalStatus { get; set; }
 
         /// <summary>
         /// The system of medicine that includes this MedicalEntity, for example 'evidence-based', 'homeopathic', 'chiropractic', etc.
@@ -64,7 +64,7 @@
         /// </summary>
         [DataMember(Name = "legalStatus", Order = 107)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IDrugLegalStatus, MedicalEnumeration?, string>? LegalStatus { get; set; }
+        public virtual Values<IDrugLegalStatus, MedicalEnumeration?, string> LegalStatus { get; set; }
 
         /// <summary>
         /// The system of medicine that includes this MedicalEntity, for example 'evidence-based', 'homeopathic', 'chiropractic', etc.

--- a/Source/Schema.NET/core/MedicalGuideline.cs
+++ b/Source/Schema.NET/core/MedicalGuideline.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// Date on which this guideline's recommendation was made.
         /// </summary>
-        Values<int?, DateTime?>? GuidelineDate { get; set; }
+        Values<int?, DateTime?> GuidelineDate { get; set; }
 
         /// <summary>
         /// The medical conditions, treatments, etc. that are the subject of the guideline.
@@ -61,7 +61,7 @@
         /// </summary>
         [DataMember(Name = "guidelineDate", Order = 208)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? GuidelineDate { get; set; }
+        public Values<int?, DateTime?> GuidelineDate { get; set; }
 
         /// <summary>
         /// The medical conditions, treatments, etc. that are the subject of the guideline.

--- a/Source/Schema.NET/core/MedicalProcedure.cs
+++ b/Source/Schema.NET/core/MedicalProcedure.cs
@@ -32,12 +32,12 @@
         /// <summary>
         /// Expected or actual outcomes of the study.
         /// </summary>
-        Values<IMedicalEntity, string>? Outcome { get; set; }
+        Values<IMedicalEntity, string> Outcome { get; set; }
 
         /// <summary>
         /// Typical preparation that a patient must undergo before having the procedure performed.
         /// </summary>
-        Values<IMedicalEntity, string>? Preparation { get; set; }
+        Values<IMedicalEntity, string> Preparation { get; set; }
 
         /// <summary>
         /// The type of procedure, for example Surgical, Noninvasive, or Percutaneous.
@@ -47,7 +47,7 @@
         /// <summary>
         /// The status of the study (enumerated).
         /// </summary>
-        Values<EventStatusType?, MedicalStudyStatus?, string>? Status { get; set; }
+        Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
     }
 
     /// <summary>
@@ -95,14 +95,14 @@
         /// </summary>
         [DataMember(Name = "outcome", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalEntity, string>? Outcome { get; set; }
+        public Values<IMedicalEntity, string> Outcome { get; set; }
 
         /// <summary>
         /// Typical preparation that a patient must undergo before having the procedure performed.
         /// </summary>
         [DataMember(Name = "preparation", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalEntity, string>? Preparation { get; set; }
+        public Values<IMedicalEntity, string> Preparation { get; set; }
 
         /// <summary>
         /// The type of procedure, for example Surgical, Noninvasive, or Percutaneous.
@@ -116,6 +116,6 @@
         /// </summary>
         [DataMember(Name = "status", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<EventStatusType?, MedicalStudyStatus?, string>? Status { get; set; }
+        public Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
     }
 }

--- a/Source/Schema.NET/core/MedicalStudy.cs
+++ b/Source/Schema.NET/core/MedicalStudy.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// Expected or actual outcomes of the study.
         /// </summary>
-        Values<IMedicalEntity, string>? Outcome { get; set; }
+        Values<IMedicalEntity, string> Outcome { get; set; }
 
         /// <summary>
         /// Any characteristics of the population used in the study, e.g. 'males under 65'.
@@ -27,12 +27,12 @@
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        Values<IOrganization, IPerson>? Sponsor { get; set; }
+        Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The status of the study (enumerated).
         /// </summary>
-        Values<EventStatusType?, MedicalStudyStatus?, string>? Status { get; set; }
+        Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
         /// <summary>
         /// The location in which the study is taking/took place.
@@ -69,7 +69,7 @@
         /// </summary>
         [DataMember(Name = "outcome", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalEntity, string>? Outcome { get; set; }
+        public Values<IMedicalEntity, string> Outcome { get; set; }
 
         /// <summary>
         /// Any characteristics of the population used in the study, e.g. 'males under 65'.
@@ -83,14 +83,14 @@
         /// </summary>
         [DataMember(Name = "sponsor", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The status of the study (enumerated).
         /// </summary>
         [DataMember(Name = "status", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<EventStatusType?, MedicalStudyStatus?, string>? Status { get; set; }
+        public Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
         /// <summary>
         /// The location in which the study is taking/took place.

--- a/Source/Schema.NET/core/MedicalTest.cs
+++ b/Source/Schema.NET/core/MedicalTest.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// Range of acceptable values for a typical patient, when applicable.
         /// </summary>
-        Values<MedicalEnumeration?, string>? NormalRange { get; set; }
+        Values<MedicalEnumeration?, string> NormalRange { get; set; }
 
         /// <summary>
         /// A sign detected by the test.
@@ -59,7 +59,7 @@
         /// </summary>
         [DataMember(Name = "normalRange", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<MedicalEnumeration?, string>? NormalRange { get; set; }
+        public Values<MedicalEnumeration?, string> NormalRange { get; set; }
 
         /// <summary>
         /// A sign detected by the test.

--- a/Source/Schema.NET/core/MedicalTherapy.cs
+++ b/Source/Schema.NET/core/MedicalTherapy.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A contraindication for this therapy.
         /// </summary>
-        Values<IMedicalContraindication, string>? Contraindication { get; set; }
+        Values<IMedicalContraindication, string> Contraindication { get; set; }
 
         /// <summary>
         /// A therapy that duplicates or overlaps this one.
@@ -42,7 +42,7 @@
         /// </summary>
         [DataMember(Name = "contraindication", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalContraindication, string>? Contraindication { get; set; }
+        public Values<IMedicalContraindication, string> Contraindication { get; set; }
 
         /// <summary>
         /// A therapy that duplicates or overlaps this one.

--- a/Source/Schema.NET/core/MenuItem.cs
+++ b/Source/Schema.NET/core/MenuItem.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item.
         /// </summary>
-        Values<IMenuItem, IMenuSection>? MenuAddOn { get; set; }
+        Values<IMenuItem, IMenuSection> MenuAddOn { get; set; }
 
         /// <summary>
         /// Nutrition information about the recipe or menu item.
@@ -47,7 +47,7 @@
         /// </summary>
         [DataMember(Name = "menuAddOn", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMenuItem, IMenuSection>? MenuAddOn { get; set; }
+        public Values<IMenuItem, IMenuSection> MenuAddOn { get; set; }
 
         /// <summary>
         /// Nutrition information about the recipe or menu item.

--- a/Source/Schema.NET/core/Message.cs
+++ b/Source/Schema.NET/core/Message.cs
@@ -12,17 +12,17 @@
         /// <summary>
         /// A sub property of recipient. The recipient blind copied on a message.
         /// </summary>
-        Values<IContactPoint, IOrganization, IPerson>? BccRecipient { get; set; }
+        Values<IContactPoint, IOrganization, IPerson> BccRecipient { get; set; }
 
         /// <summary>
         /// A sub property of recipient. The recipient copied on a message.
         /// </summary>
-        Values<IContactPoint, IOrganization, IPerson>? CcRecipient { get; set; }
+        Values<IContactPoint, IOrganization, IPerson> CcRecipient { get; set; }
 
         /// <summary>
         /// The date/time at which the message has been read by the recipient if a single recipient exists.
         /// </summary>
-        OneOrMany<DateTimeOffset?> DateRead { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DateRead { get; set; }
 
         /// <summary>
         /// The date/time the message was received if a single recipient exists.
@@ -42,17 +42,17 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
 
         /// <summary>
         /// A sub property of participant. The participant who is at the sending end of the action.
         /// </summary>
-        Values<IAudience, IOrganization, IPerson>? Sender { get; set; }
+        Values<IAudience, IOrganization, IPerson> Sender { get; set; }
 
         /// <summary>
         /// A sub property of recipient. The recipient who was directly sent the message.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? ToRecipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> ToRecipient { get; set; }
     }
 
     /// <summary>
@@ -72,21 +72,21 @@
         /// </summary>
         [DataMember(Name = "bccRecipient", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IContactPoint, IOrganization, IPerson>? BccRecipient { get; set; }
+        public Values<IContactPoint, IOrganization, IPerson> BccRecipient { get; set; }
 
         /// <summary>
         /// A sub property of recipient. The recipient copied on a message.
         /// </summary>
         [DataMember(Name = "ccRecipient", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IContactPoint, IOrganization, IPerson>? CcRecipient { get; set; }
+        public Values<IContactPoint, IOrganization, IPerson> CcRecipient { get; set; }
 
         /// <summary>
         /// The date/time at which the message has been read by the recipient if a single recipient exists.
         /// </summary>
         [DataMember(Name = "dateRead", Order = 208)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> DateRead { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> DateRead { get; set; }
 
         /// <summary>
         /// The date/time the message was received if a single recipient exists.
@@ -114,20 +114,20 @@
         /// </summary>
         [DataMember(Name = "recipient", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
 
         /// <summary>
         /// A sub property of participant. The participant who is at the sending end of the action.
         /// </summary>
         [DataMember(Name = "sender", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IOrganization, IPerson>? Sender { get; set; }
+        public Values<IAudience, IOrganization, IPerson> Sender { get; set; }
 
         /// <summary>
         /// A sub property of recipient. The recipient who was directly sent the message.
         /// </summary>
         [DataMember(Name = "toRecipient", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? ToRecipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> ToRecipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/MonetaryAmount.cs
+++ b/Source/Schema.NET/core/MonetaryAmount.cs
@@ -28,12 +28,12 @@
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The value of the quantitative value or property value node.&lt;br/&gt;&lt;br/&gt;
@@ -44,7 +44,7 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<bool?, double?, IStructuredValue, string>? Value { get; set; }
+        Values<bool?, double?, IStructuredValue, string> Value { get; set; }
     }
 
     /// <summary>
@@ -85,15 +85,15 @@
         /// The date when the item becomes valid.
         /// </summary>
         [DataMember(Name = "validFrom", Order = 309)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
         [DataMember(Name = "validThrough", Order = 310)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The value of the quantitative value or property value node.&lt;br/&gt;&lt;br/&gt;
@@ -106,6 +106,6 @@
         /// </summary>
         [DataMember(Name = "value", Order = 311)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, double?, IStructuredValue, string>? Value { get; set; }
+        public Values<bool?, double?, IStructuredValue, string> Value { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Movie.cs
+++ b/Source/Schema.NET/core/Movie.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The production company or studio responsible for the item e.g. series, video game, episode etc.
@@ -42,7 +42,7 @@
         /// <summary>
         /// Languages in which subtitles/captions are available, in &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard format&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? SubtitleLanguage { get; set; }
+        Values<ILanguage, string> SubtitleLanguage { get; set; }
 
         /// <summary>
         /// The trailer of a movie or tv/radio series, season, episode, etc.
@@ -95,7 +95,7 @@
         /// </summary>
         [DataMember(Name = "musicBy", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The production company or studio responsible for the item e.g. series, video game, episode etc.
@@ -109,7 +109,7 @@
         /// </summary>
         [DataMember(Name = "subtitleLanguage", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? SubtitleLanguage { get; set; }
+        public Values<ILanguage, string> SubtitleLanguage { get; set; }
 
         /// <summary>
         /// The trailer of a movie or tv/radio series, season, episode, etc.

--- a/Source/Schema.NET/core/MovieSeries.cs
+++ b/Source/Schema.NET/core/MovieSeries.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The production company or studio responsible for the item e.g. series, video game, episode etc.
@@ -66,7 +66,7 @@
         /// </summary>
         [DataMember(Name = "musicBy", Order = 408)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The production company or studio responsible for the item e.g. series, video game, episode etc.

--- a/Source/Schema.NET/core/MusicAlbum.cs
+++ b/Source/Schema.NET/core/MusicAlbum.cs
@@ -27,7 +27,7 @@
         /// <summary>
         /// The artist that performed this album or recording.
         /// </summary>
-        Values<IMusicGroup, IPerson>? ByArtist { get; set; }
+        Values<IMusicGroup, IPerson> ByArtist { get; set; }
     }
 
     /// <summary>
@@ -68,6 +68,6 @@
         /// </summary>
         [DataMember(Name = "byArtist", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? ByArtist { get; set; }
+        public Values<IMusicGroup, IPerson> ByArtist { get; set; }
     }
 }

--- a/Source/Schema.NET/core/MusicComposition.cs
+++ b/Source/Schema.NET/core/MusicComposition.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The person or organization who wrote a composition, or who is the composer of a work performed at some event.
         /// </summary>
-        Values<IOrganization, IPerson>? Composer { get; set; }
+        Values<IOrganization, IPerson> Composer { get; set; }
 
         /// <summary>
         /// The date and place the work was first performed.
@@ -77,7 +77,7 @@
         /// </summary>
         [DataMember(Name = "composer", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Composer { get; set; }
+        public Values<IOrganization, IPerson> Composer { get; set; }
 
         /// <summary>
         /// The date and place the work was first performed.

--- a/Source/Schema.NET/core/MusicGroup.cs
+++ b/Source/Schema.NET/core/MusicGroup.cs
@@ -17,12 +17,12 @@
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        Values<string, Uri>? Genre { get; set; }
+        Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// A music recording (track)&amp;#x2014;usually a single song. If an ItemList is given, the list should contain items of type MusicRecording.
         /// </summary>
-        Values<IItemList, IMusicRecording>? Track { get; set; }
+        Values<IItemList, IMusicRecording> Track { get; set; }
     }
 
     /// <summary>
@@ -49,13 +49,13 @@
         /// </summary>
         [DataMember(Name = "genre", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// A music recording (track)&amp;#x2014;usually a single song. If an ItemList is given, the list should contain items of type MusicRecording.
         /// </summary>
         [DataMember(Name = "track", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IItemList, IMusicRecording>? Track { get; set; }
+        public Values<IItemList, IMusicRecording> Track { get; set; }
     }
 }

--- a/Source/Schema.NET/core/MusicPlaylist.cs
+++ b/Source/Schema.NET/core/MusicPlaylist.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// A music recording (track)&amp;#x2014;usually a single song. If an ItemList is given, the list should contain items of type MusicRecording.
         /// </summary>
-        Values<IItemList, IMusicRecording>? Track { get; set; }
+        Values<IItemList, IMusicRecording> Track { get; set; }
     }
 
     /// <summary>
@@ -44,6 +44,6 @@
         /// </summary>
         [DataMember(Name = "track", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IItemList, IMusicRecording>? Track { get; set; }
+        public Values<IItemList, IMusicRecording> Track { get; set; }
     }
 }

--- a/Source/Schema.NET/core/MusicRecording.cs
+++ b/Source/Schema.NET/core/MusicRecording.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The artist that performed this album or recording.
         /// </summary>
-        Values<IMusicGroup, IPerson>? ByArtist { get; set; }
+        Values<IMusicGroup, IPerson> ByArtist { get; set; }
 
         /// <summary>
         /// The duration of the item (movie, audio recording, event, etc.) in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;.
@@ -57,7 +57,7 @@
         /// </summary>
         [DataMember(Name = "byArtist", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? ByArtist { get; set; }
+        public Values<IMusicGroup, IPerson> ByArtist { get; set; }
 
         /// <summary>
         /// The duration of the item (movie, audio recording, event, etc.) in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;.

--- a/Source/Schema.NET/core/MusicRelease.cs
+++ b/Source/Schema.NET/core/MusicRelease.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The group the release is credited to if different than the byArtist. For example, Red and Blue is credited to "Stefani Germanotta Band", but by Lady Gaga.
         /// </summary>
-        Values<IOrganization, IPerson>? CreditedTo { get; set; }
+        Values<IOrganization, IPerson> CreditedTo { get; set; }
 
         /// <summary>
         /// The duration of the item (movie, audio recording, event, etc.) in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;.
@@ -64,7 +64,7 @@
         /// </summary>
         [DataMember(Name = "creditedTo", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? CreditedTo { get; set; }
+        public Values<IOrganization, IPerson> CreditedTo { get; set; }
 
         /// <summary>
         /// The duration of the item (movie, audio recording, event, etc.) in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;.

--- a/Source/Schema.NET/core/Nerve.cs
+++ b/Source/Schema.NET/core/Nerve.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The neurological pathway extension that inputs and sends information to the brain or spinal cord.
         /// </summary>
-        Values<IAnatomicalStructure, ISuperficialAnatomy>? SensoryUnit { get; set; }
+        Values<IAnatomicalStructure, ISuperficialAnatomy> SensoryUnit { get; set; }
 
         /// <summary>
         /// The neurological pathway that originates the neurons.
@@ -49,7 +49,7 @@
         /// </summary>
         [DataMember(Name = "sensoryUnit", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, ISuperficialAnatomy>? SensoryUnit { get; set; }
+        public Values<IAnatomicalStructure, ISuperficialAnatomy> SensoryUnit { get; set; }
 
         /// <summary>
         /// The neurological pathway that originates the neurons.

--- a/Source/Schema.NET/core/Occupation.cs
+++ b/Source/Schema.NET/core/Occupation.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value.
         /// </summary>
-        Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?>? EstimatedSalary { get; set; }
+        Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?> EstimatedSalary { get; set; }
 
         /// <summary>
         /// Description of skills and experience needed for the position or Occupation.
@@ -75,7 +75,7 @@
         /// </summary>
         [DataMember(Name = "estimatedSalary", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?>? EstimatedSalary { get; set; }
+        public Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?> EstimatedSalary { get; set; }
 
         /// <summary>
         /// Description of skills and experience needed for the position or Occupation.

--- a/Source/Schema.NET/core/Offer.cs
+++ b/Source/Schema.NET/core/Offer.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// The payment method(s) accepted by seller for this offer.
         /// </summary>
-        Values<ILoanOrCredit, PaymentMethod?>? AcceptedPaymentMethod { get; set; }
+        Values<ILoanOrCredit, PaymentMethod?> AcceptedPaymentMethod { get; set; }
 
         /// <summary>
         /// An additional offer that can only be obtained in combination with the first base offer (e.g. supplements and extensions that are available for a surcharge).
@@ -33,7 +33,7 @@
         /// <summary>
         /// The geographic area where a service or offered item is provided.
         /// </summary>
-        Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// The availability of this item&amp;#x2014;for example In stock, Out of stock, Pre-order, etc.
@@ -43,12 +43,12 @@
         /// <summary>
         /// The end of the availability of the product or service included in the offer.
         /// </summary>
-        OneOrMany<DateTimeOffset?> AvailabilityEnds { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityEnds { get; set; }
 
         /// <summary>
         /// The beginning of the availability of the product or service included in the offer.
         /// </summary>
-        OneOrMany<DateTimeOffset?> AvailabilityStarts { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityStarts { get; set; }
 
         /// <summary>
         /// The place(s) from which the offer can be obtained (e.g. store locations).
@@ -68,7 +68,7 @@
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
-        Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The typical delay between the receipt of the order and the goods either leaving the warehouse or being prepared for pickup, in case the delivery method is on site pickup.
@@ -94,12 +94,17 @@
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/ineligibleRegion"&gt;ineligibleRegion&lt;/a&gt;.
         /// </summary>
-        Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount.
         /// </summary>
         OneOrMany<IPriceSpecification> EligibleTransactionVolume { get; set; }
+
+        /// <summary>
+        /// A Global Trade Item Number (&lt;a href="https://www.gs1.org/standards/id-keys/gtin"&gt;GTIN&lt;/a&gt;). GTINs identify trade items, including products and services, using numeric identification codes. The &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; property generalizes the earlier &lt;a class="localLink" href="http://schema.org/gtin8"&gt;gtin8&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin12"&gt;gtin12&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin13"&gt;gtin13&lt;/a&gt;, and &lt;a class="localLink" href="http://schema.org/gtin14"&gt;gtin14&lt;/a&gt; properties. The GS1 &lt;a href="https://www.gs1.org/standards/Digital-Link/"&gt;digital link specifications&lt;/a&gt; express GTINs as URLs. A correct &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a &lt;a href="https://www.gs1.org/services/check-digit-calculator"&gt;valid GS1 check digit&lt;/a&gt; and meet the other rules for valid GTINs. See also &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1's GTIN Summary&lt;/a&gt; and &lt;a href="https://en.wikipedia.org/wiki/Global_Trade_Item_Number"&gt;Wikipedia&lt;/a&gt; for more details. Left-padding of the gtin values is not required or encouraged.
+        /// </summary>
+        OneOrMany<string> Gtin { get; set; }
 
         /// <summary>
         /// The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
@@ -130,7 +135,7 @@
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/eligibleRegion"&gt;eligibleRegion&lt;/a&gt;.
         /// </summary>
-        Values<IGeoShape, IPlace, string>? IneligibleRegion { get; set; }
+        Values<IGeoShape, IPlace, string> IneligibleRegion { get; set; }
 
         /// <summary>
         /// The current approximate inventory level for the item or items.
@@ -145,7 +150,7 @@
         /// <summary>
         /// The item being offered.
         /// </summary>
-        Values<IProduct, IService>? ItemOffered { get; set; }
+        Values<IProduct, IService> ItemOffered { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
@@ -155,7 +160,7 @@
         /// <summary>
         /// A pointer to the organization or person making the offer.
         /// </summary>
-        Values<IOrganization, IPerson>? OfferedBy { get; set; }
+        Values<IOrganization, IPerson> OfferedBy { get; set; }
 
         /// <summary>
         /// The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.&lt;br/&gt;&lt;br/&gt;
@@ -167,7 +172,7 @@
         /// &lt;li&gt;Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<decimal?, string>? Price { get; set; }
+        Values<decimal?, string> Price { get; set; }
 
         /// <summary>
         /// The currency of the price, or a price component when attached to &lt;a class="localLink" href="http://schema.org/PriceSpecification"&gt;PriceSpecification&lt;/a&gt; and its subtypes.&lt;br/&gt;&lt;br/&gt;
@@ -183,7 +188,7 @@
         /// <summary>
         /// The date after which the price is no longer available.
         /// </summary>
-        Values<int?, DateTime?>? PriceValidUntil { get; set; }
+        Values<int?, DateTime?> PriceValidUntil { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -193,7 +198,7 @@
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        Values<IOrganization, IPerson>? Seller { get; set; }
+        Values<IOrganization, IPerson> Seller { get; set; }
 
         /// <summary>
         /// The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer.
@@ -208,12 +213,12 @@
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The warranty promise(s) included in the offer.
@@ -239,7 +244,7 @@
         /// </summary>
         [DataMember(Name = "acceptedPaymentMethod", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILoanOrCredit, PaymentMethod?>? AcceptedPaymentMethod { get; set; }
+        public Values<ILoanOrCredit, PaymentMethod?> AcceptedPaymentMethod { get; set; }
 
         /// <summary>
         /// An additional offer that can only be obtained in combination with the first base offer (e.g. supplements and extensions that are available for a surcharge).
@@ -267,7 +272,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// The availability of this item&amp;#x2014;for example In stock, Out of stock, Pre-order, etc.
@@ -280,15 +285,15 @@
         /// The end of the availability of the product or service included in the offer.
         /// </summary>
         [DataMember(Name = "availabilityEnds", Order = 212)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> AvailabilityEnds { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityEnds { get; set; }
 
         /// <summary>
         /// The beginning of the availability of the product or service included in the offer.
         /// </summary>
         [DataMember(Name = "availabilityStarts", Order = 213)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> AvailabilityStarts { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?, TimeSpan?> AvailabilityStarts { get; set; }
 
         /// <summary>
         /// The place(s) from which the offer can be obtained (e.g. store locations).
@@ -316,7 +321,7 @@
         /// </summary>
         [DataMember(Name = "category", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The typical delay between the receipt of the order and the goods either leaving the warehouse or being prepared for pickup, in case the delivery method is on site pickup.
@@ -352,7 +357,7 @@
         /// </summary>
         [DataMember(Name = "eligibleRegion", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoShape, IPlace, string>? EligibleRegion { get; set; }
+        public Values<IGeoShape, IPlace, string> EligibleRegion { get; set; }
 
         /// <summary>
         /// The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount.
@@ -362,37 +367,44 @@
         public OneOrMany<IPriceSpecification> EligibleTransactionVolume { get; set; }
 
         /// <summary>
+        /// A Global Trade Item Number (&lt;a href="https://www.gs1.org/standards/id-keys/gtin"&gt;GTIN&lt;/a&gt;). GTINs identify trade items, including products and services, using numeric identification codes. The &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; property generalizes the earlier &lt;a class="localLink" href="http://schema.org/gtin8"&gt;gtin8&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin12"&gt;gtin12&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin13"&gt;gtin13&lt;/a&gt;, and &lt;a class="localLink" href="http://schema.org/gtin14"&gt;gtin14&lt;/a&gt; properties. The GS1 &lt;a href="https://www.gs1.org/standards/Digital-Link/"&gt;digital link specifications&lt;/a&gt; express GTINs as URLs. A correct &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a &lt;a href="https://www.gs1.org/services/check-digit-calculator"&gt;valid GS1 check digit&lt;/a&gt; and meet the other rules for valid GTINs. See also &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1's GTIN Summary&lt;/a&gt; and &lt;a href="https://en.wikipedia.org/wiki/Global_Trade_Item_Number"&gt;Wikipedia&lt;/a&gt; for more details. Left-padding of the gtin values is not required or encouraged.
+        /// </summary>
+        [DataMember(Name = "gtin", Order = 224)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> Gtin { get; set; }
+
+        /// <summary>
         /// The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin12", Order = 224)]
+        [DataMember(Name = "gtin12", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin12 { get; set; }
 
         /// <summary>
         /// The GTIN-13 code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceeding zero. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin13", Order = 225)]
+        [DataMember(Name = "gtin13", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin13 { get; set; }
 
         /// <summary>
         /// The GTIN-14 code of the product, or the product to which the offer refers. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin14", Order = 226)]
+        [DataMember(Name = "gtin14", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin14 { get; set; }
 
         /// <summary>
         /// The &lt;a href="http://apps.gs1.org/GDD/glossary/Pages/GTIN-8.aspx"&gt;GTIN-8&lt;/a&gt; code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin8", Order = 227)]
+        [DataMember(Name = "gtin8", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin8 { get; set; }
 
         /// <summary>
         /// This links to a node or nodes indicating the exact quantity of the products included in the offer.
         /// </summary>
-        [DataMember(Name = "includesObject", Order = 228)]
+        [DataMember(Name = "includesObject", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ITypeAndQuantityNode> IncludesObject { get; set; }
 
@@ -400,44 +412,44 @@
         /// The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.&lt;br/&gt;&lt;br/&gt;
         /// See also &lt;a class="localLink" href="http://schema.org/eligibleRegion"&gt;eligibleRegion&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "ineligibleRegion", Order = 229)]
+        [DataMember(Name = "ineligibleRegion", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoShape, IPlace, string>? IneligibleRegion { get; set; }
+        public Values<IGeoShape, IPlace, string> IneligibleRegion { get; set; }
 
         /// <summary>
         /// The current approximate inventory level for the item or items.
         /// </summary>
-        [DataMember(Name = "inventoryLevel", Order = 230)]
+        [DataMember(Name = "inventoryLevel", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IQuantitativeValue> InventoryLevel { get; set; }
 
         /// <summary>
         /// A predefined value from OfferItemCondition or a textual description of the condition of the product or service, or the products or services included in the offer.
         /// </summary>
-        [DataMember(Name = "itemCondition", Order = 231)]
+        [DataMember(Name = "itemCondition", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<OfferItemCondition?> ItemCondition { get; set; }
 
         /// <summary>
         /// The item being offered.
         /// </summary>
-        [DataMember(Name = "itemOffered", Order = 232)]
+        [DataMember(Name = "itemOffered", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? ItemOffered { get; set; }
+        public Values<IProduct, IService> ItemOffered { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "mpn", Order = 233)]
+        [DataMember(Name = "mpn", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Mpn { get; set; }
 
         /// <summary>
         /// A pointer to the organization or person making the offer.
         /// </summary>
-        [DataMember(Name = "offeredBy", Order = 234)]
+        [DataMember(Name = "offeredBy", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? OfferedBy { get; set; }
+        public Values<IOrganization, IPerson> OfferedBy { get; set; }
 
         /// <summary>
         /// The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.&lt;br/&gt;&lt;br/&gt;
@@ -449,78 +461,78 @@
         /// &lt;li&gt;Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        [DataMember(Name = "price", Order = 235)]
+        [DataMember(Name = "price", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, string>? Price { get; set; }
+        public Values<decimal?, string> Price { get; set; }
 
         /// <summary>
         /// The currency of the price, or a price component when attached to &lt;a class="localLink" href="http://schema.org/PriceSpecification"&gt;PriceSpecification&lt;/a&gt; and its subtypes.&lt;br/&gt;&lt;br/&gt;
         /// Use standard formats: &lt;a href="http://en.wikipedia.org/wiki/ISO_4217"&gt;ISO 4217 currency format&lt;/a&gt; e.g. "USD"; &lt;a href="https://en.wikipedia.org/wiki/List_of_cryptocurrencies"&gt;Ticker symbol&lt;/a&gt; for cryptocurrencies e.g. "BTC"; well known names for &lt;a href="https://en.wikipedia.org/wiki/Local_exchange_trading_system"&gt;Local Exchange Tradings Systems&lt;/a&gt; (LETS) and other currency types e.g. "Ithaca HOUR".
         /// </summary>
-        [DataMember(Name = "priceCurrency", Order = 236)]
+        [DataMember(Name = "priceCurrency", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PriceCurrency { get; set; }
 
         /// <summary>
         /// One or more detailed price specifications, indicating the unit price and delivery or payment charges.
         /// </summary>
-        [DataMember(Name = "priceSpecification", Order = 237)]
+        [DataMember(Name = "priceSpecification", Order = 238)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPriceSpecification> PriceSpecification { get; set; }
 
         /// <summary>
         /// The date after which the price is no longer available.
         /// </summary>
-        [DataMember(Name = "priceValidUntil", Order = 238)]
+        [DataMember(Name = "priceValidUntil", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? PriceValidUntil { get; set; }
+        public Values<int?, DateTime?> PriceValidUntil { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 239)]
+        [DataMember(Name = "review", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        [DataMember(Name = "seller", Order = 240)]
+        [DataMember(Name = "seller", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Seller { get; set; }
+        public Values<IOrganization, IPerson> Seller { get; set; }
 
         /// <summary>
         /// The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer.
         /// </summary>
-        [DataMember(Name = "serialNumber", Order = 241)]
+        [DataMember(Name = "serialNumber", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SerialNumber { get; set; }
 
         /// <summary>
         /// The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "sku", Order = 242)]
+        [DataMember(Name = "sku", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Sku { get; set; }
 
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        [DataMember(Name = "validFrom", Order = 243)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        [DataMember(Name = "validFrom", Order = 244)]
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        [DataMember(Name = "validThrough", Order = 244)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        [DataMember(Name = "validThrough", Order = 245)]
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The warranty promise(s) included in the offer.
         /// </summary>
-        [DataMember(Name = "warranty", Order = 245)]
+        [DataMember(Name = "warranty", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IWarrantyPromise> Warranty { get; set; }
     }

--- a/Source/Schema.NET/core/OpeningHoursSpecification.cs
+++ b/Source/Schema.NET/core/OpeningHoursSpecification.cs
@@ -29,12 +29,12 @@
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
     }
 
     /// <summary>
@@ -76,14 +76,14 @@
         /// The date when the item becomes valid.
         /// </summary>
         [DataMember(Name = "validFrom", Order = 309)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
         [DataMember(Name = "validThrough", Order = 310)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Order.cs
+++ b/Source/Schema.NET/core/Order.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred.
         /// </summary>
-        Values<IOrganization, IPerson>? Broker { get; set; }
+        Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// A number that confirms the given order or payment has been received.
@@ -32,12 +32,12 @@
         /// <summary>
         /// Party placing the order or paying the invoice.
         /// </summary>
-        Values<IOrganization, IPerson>? Customer { get; set; }
+        Values<IOrganization, IPerson> Customer { get; set; }
 
         /// <summary>
         /// Any discount applied (to an Order).
         /// </summary>
-        Values<decimal?, string>? Discount { get; set; }
+        Values<decimal?, string> Discount { get; set; }
 
         /// <summary>
         /// Code used to redeem a discount.
@@ -58,7 +58,7 @@
         /// <summary>
         /// Date order was placed.
         /// </summary>
-        OneOrMany<DateTimeOffset?> OrderDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> OrderDate { get; set; }
 
         /// <summary>
         /// The delivery of the parcel related to this order or order item.
@@ -68,7 +68,7 @@
         /// <summary>
         /// The item ordered.
         /// </summary>
-        Values<IOrderItem, IProduct, IService>? OrderedItem { get; set; }
+        Values<IOrderItem, IProduct, IService> OrderedItem { get; set; }
 
         /// <summary>
         /// The identifier of the transaction.
@@ -88,7 +88,7 @@
         /// <summary>
         /// The date that payment is due.
         /// </summary>
-        OneOrMany<DateTimeOffset?> PaymentDueDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> PaymentDueDate { get; set; }
 
         /// <summary>
         /// The name of the credit card or other method of payment for the order.
@@ -108,7 +108,7 @@
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        Values<IOrganization, IPerson>? Seller { get; set; }
+        Values<IOrganization, IPerson> Seller { get; set; }
     }
 
     /// <summary>
@@ -142,7 +142,7 @@
         /// </summary>
         [DataMember(Name = "broker", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Broker { get; set; }
+        public Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// A number that confirms the given order or payment has been received.
@@ -156,14 +156,14 @@
         /// </summary>
         [DataMember(Name = "customer", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Customer { get; set; }
+        public Values<IOrganization, IPerson> Customer { get; set; }
 
         /// <summary>
         /// Any discount applied (to an Order).
         /// </summary>
         [DataMember(Name = "discount", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, string>? Discount { get; set; }
+        public Values<decimal?, string> Discount { get; set; }
 
         /// <summary>
         /// Code used to redeem a discount.
@@ -191,8 +191,8 @@
         /// Date order was placed.
         /// </summary>
         [DataMember(Name = "orderDate", Order = 215)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> OrderDate { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> OrderDate { get; set; }
 
         /// <summary>
         /// The delivery of the parcel related to this order or order item.
@@ -206,7 +206,7 @@
         /// </summary>
         [DataMember(Name = "orderedItem", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrderItem, IProduct, IService>? OrderedItem { get; set; }
+        public Values<IOrderItem, IProduct, IService> OrderedItem { get; set; }
 
         /// <summary>
         /// The identifier of the transaction.
@@ -233,8 +233,8 @@
         /// The date that payment is due.
         /// </summary>
         [DataMember(Name = "paymentDueDate", Order = 221)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> PaymentDueDate { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> PaymentDueDate { get; set; }
 
         /// <summary>
         /// The name of the credit card or other method of payment for the order.
@@ -262,6 +262,6 @@
         /// </summary>
         [DataMember(Name = "seller", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Seller { get; set; }
+        public Values<IOrganization, IPerson> Seller { get; set; }
     }
 }

--- a/Source/Schema.NET/core/OrderItem.cs
+++ b/Source/Schema.NET/core/OrderItem.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The item ordered.
         /// </summary>
-        Values<IOrderItem, IProduct, IService>? OrderedItem { get; set; }
+        Values<IOrderItem, IProduct, IService> OrderedItem { get; set; }
 
         /// <summary>
         /// The identifier of the order item.
@@ -59,7 +59,7 @@
         /// </summary>
         [DataMember(Name = "orderedItem", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrderItem, IProduct, IService>? OrderedItem { get; set; }
+        public Values<IOrderItem, IProduct, IService> OrderedItem { get; set; }
 
         /// <summary>
         /// The identifier of the order item.

--- a/Source/Schema.NET/core/Organization.cs
+++ b/Source/Schema.NET/core/Organization.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// For a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt; or other news-related &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, a statement about public engagement activities (for news media, the newsroom’s), including involving the public - digitally or otherwise -- in coverage decisions, reporting and activities after publication.
         /// </summary>
-        Values<ICreativeWork, Uri>? ActionableFeedbackPolicy { get; set; }
+        Values<ICreativeWork, Uri> ActionableFeedbackPolicy { get; set; }
 
         /// <summary>
         /// Physical address of the item.
         /// </summary>
-        Values<IPostalAddress, string>? Address { get; set; }
+        Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -32,7 +32,7 @@
         /// <summary>
         /// The geographic area where a service or offered item is provided.
         /// </summary>
-        Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -42,7 +42,7 @@
         /// <summary>
         /// The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person.
         /// </summary>
-        Values<IBrand, IOrganization>? Brand { get; set; }
+        Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A contact point for a person or organization.
@@ -52,7 +52,7 @@
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement describing (in news media, the newsroom’s) disclosure and correction policy for errors.
         /// </summary>
-        Values<ICreativeWork, Uri>? CorrectionsPolicy { get; set; }
+        Values<ICreativeWork, Uri> CorrectionsPolicy { get; set; }
 
         /// <summary>
         /// A relationship between an organization and a department of that organization, also described as an organization (allowing different urls, logos, opening hours). For example: a store with a pharmacy, or a bakery with a cafe.
@@ -62,17 +62,17 @@
         /// <summary>
         /// The date that this organization was dissolved.
         /// </summary>
-        Values<int?, DateTime?>? DissolutionDate { get; set; }
+        Values<int?, DateTime?> DissolutionDate { get; set; }
 
         /// <summary>
         /// Statement on diversity policy by an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; e.g. a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;. For a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;, a statement describing the newsroom’s diversity policy on both staffing and sources, typically providing staffing data.
         /// </summary>
-        Values<ICreativeWork, Uri>? DiversityPolicy { get; set; }
+        Values<ICreativeWork, Uri> DiversityPolicy { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a report on staffing diversity issues. In a news context this might be for example ASNE or RTDNA (US) reports, or self-reported.
         /// </summary>
-        Values<IArticle, Uri>? DiversityStaffingReport { get; set; }
+        Values<IArticle, Uri> DiversityStaffingReport { get; set; }
 
         /// <summary>
         /// The Dun &amp;amp; Bradstreet DUNS number for identifying an organization or business person.
@@ -92,7 +92,7 @@
         /// <summary>
         /// Statement about ethics policy, e.g. of a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt; regarding journalistic and publishing practices, or of a &lt;a class="localLink" href="http://schema.org/Restaurant"&gt;Restaurant&lt;/a&gt;, a page describing food source policies. In the case of a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;, an ethicsPolicy is typically a statement describing the personal, organizational, and corporate standards of behavior expected by the organization.
         /// </summary>
-        Values<ICreativeWork, Uri>? EthicsPolicy { get; set; }
+        Values<ICreativeWork, Uri> EthicsPolicy { get; set; }
 
         /// <summary>
         /// Upcoming or past event associated with this place, organization, or action.
@@ -112,7 +112,7 @@
         /// <summary>
         /// The date that this organization was founded.
         /// </summary>
-        Values<int?, DateTime?>? FoundingDate { get; set; }
+        Values<int?, DateTime?> FoundingDate { get; set; }
 
         /// <summary>
         /// The place where the Organization was founded.
@@ -122,7 +122,7 @@
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        Values<IOrganization, IPerson>? Funder { get; set; }
+        Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// The &lt;a href="http://www.gs1.org/gln"&gt;Global Location Number&lt;/a&gt; (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.
@@ -145,14 +145,14 @@
         OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
-        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or yet relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
+        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        Values<string, IThing, Uri>? KnowsAbout { get; set; }
+        Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? KnowsLanguage { get; set; }
+        Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
@@ -167,12 +167,12 @@
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        Values<IImageObject, Uri>? Logo { get; set; }
+        Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
@@ -182,12 +182,12 @@
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        Values<IOrganization, IPerson>? Member { get; set; }
+        Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        Values<IOrganization, IProgramMembership>? MemberOf { get; set; }
+        Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
@@ -202,12 +202,12 @@
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt; is also available and can be used to make basic funder information machine-readable.
         /// </summary>
-        Values<IAboutPage, ICreativeWork, string, Uri>? OwnershipFundingInfo { get; set; }
+        Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        Values<IOwnershipInfo, IProduct>? Owns { get; set; }
+        Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
@@ -218,7 +218,7 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -238,7 +238,7 @@
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        Values<IOrganization, IPerson>? Sponsor { get; set; }
+        Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
@@ -258,7 +258,7 @@
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (typically a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement about policy on use of unnamed sources and the decision process required.
         /// </summary>
-        Values<ICreativeWork, Uri>? UnnamedSourcesPolicy { get; set; }
+        Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
@@ -283,14 +283,14 @@
         /// </summary>
         [DataMember(Name = "actionableFeedbackPolicy", Order = 106)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? ActionableFeedbackPolicy { get; set; }
+        public Values<ICreativeWork, Uri> ActionableFeedbackPolicy { get; set; }
 
         /// <summary>
         /// Physical address of the item.
         /// </summary>
         [DataMember(Name = "address", Order = 107)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPostalAddress, string>? Address { get; set; }
+        public Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -311,7 +311,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 110)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -325,7 +325,7 @@
         /// </summary>
         [DataMember(Name = "brand", Order = 112)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBrand, IOrganization>? Brand { get; set; }
+        public Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A contact point for a person or organization.
@@ -339,7 +339,7 @@
         /// </summary>
         [DataMember(Name = "correctionsPolicy", Order = 114)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? CorrectionsPolicy { get; set; }
+        public Values<ICreativeWork, Uri> CorrectionsPolicy { get; set; }
 
         /// <summary>
         /// A relationship between an organization and a department of that organization, also described as an organization (allowing different urls, logos, opening hours). For example: a store with a pharmacy, or a bakery with a cafe.
@@ -353,21 +353,21 @@
         /// </summary>
         [DataMember(Name = "dissolutionDate", Order = 116)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DissolutionDate { get; set; }
+        public Values<int?, DateTime?> DissolutionDate { get; set; }
 
         /// <summary>
         /// Statement on diversity policy by an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; e.g. a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;. For a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;, a statement describing the newsroom’s diversity policy on both staffing and sources, typically providing staffing data.
         /// </summary>
         [DataMember(Name = "diversityPolicy", Order = 117)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? DiversityPolicy { get; set; }
+        public Values<ICreativeWork, Uri> DiversityPolicy { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a report on staffing diversity issues. In a news context this might be for example ASNE or RTDNA (US) reports, or self-reported.
         /// </summary>
         [DataMember(Name = "diversityStaffingReport", Order = 118)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IArticle, Uri>? DiversityStaffingReport { get; set; }
+        public Values<IArticle, Uri> DiversityStaffingReport { get; set; }
 
         /// <summary>
         /// The Dun &amp;amp; Bradstreet DUNS number for identifying an organization or business person.
@@ -395,7 +395,7 @@
         /// </summary>
         [DataMember(Name = "ethicsPolicy", Order = 122)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? EthicsPolicy { get; set; }
+        public Values<ICreativeWork, Uri> EthicsPolicy { get; set; }
 
         /// <summary>
         /// Upcoming or past event associated with this place, organization, or action.
@@ -423,7 +423,7 @@
         /// </summary>
         [DataMember(Name = "foundingDate", Order = 126)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? FoundingDate { get; set; }
+        public Values<int?, DateTime?> FoundingDate { get; set; }
 
         /// <summary>
         /// The place where the Organization was founded.
@@ -437,7 +437,7 @@
         /// </summary>
         [DataMember(Name = "funder", Order = 128)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// The &lt;a href="http://www.gs1.org/gln"&gt;Global Location Number&lt;/a&gt; (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.
@@ -468,18 +468,18 @@
         public OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
-        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or yet relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
+        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
         [DataMember(Name = "knowsAbout", Order = 133)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IThing, Uri>? KnowsAbout { get; set; }
+        public Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "knowsLanguage", Order = 134)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? KnowsLanguage { get; set; }
+        public Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
@@ -500,14 +500,14 @@
         /// </summary>
         [DataMember(Name = "location", Order = 137)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        public Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
         [DataMember(Name = "logo", Order = 138)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Logo { get; set; }
+        public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
@@ -521,14 +521,14 @@
         /// </summary>
         [DataMember(Name = "member", Order = 140)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Member { get; set; }
+        public Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
         [DataMember(Name = "memberOf", Order = 141)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IProgramMembership>? MemberOf { get; set; }
+        public Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
@@ -549,14 +549,14 @@
         /// </summary>
         [DataMember(Name = "ownershipFundingInfo", Order = 144)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAboutPage, ICreativeWork, string, Uri>? OwnershipFundingInfo { get; set; }
+        public Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
         [DataMember(Name = "owns", Order = 145)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOwnershipInfo, IProduct>? Owns { get; set; }
+        public Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
@@ -571,7 +571,7 @@
         /// </summary>
         [DataMember(Name = "publishingPrinciples", Order = 147)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -599,7 +599,7 @@
         /// </summary>
         [DataMember(Name = "sponsor", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
@@ -627,7 +627,7 @@
         /// </summary>
         [DataMember(Name = "unnamedSourcesPolicy", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? UnnamedSourcesPolicy { get; set; }
+        public Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.

--- a/Source/Schema.NET/core/OwnershipInfo.cs
+++ b/Source/Schema.NET/core/OwnershipInfo.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The organization or person from which the product was acquired.
         /// </summary>
-        Values<IOrganization, IPerson>? AcquiredFrom { get; set; }
+        Values<IOrganization, IPerson> AcquiredFrom { get; set; }
 
         /// <summary>
         /// The date and time of obtaining the product.
@@ -27,7 +27,7 @@
         /// <summary>
         /// The product that this structured value is referring to.
         /// </summary>
-        Values<IProduct, IService>? TypeOfGood { get; set; }
+        Values<IProduct, IService> TypeOfGood { get; set; }
     }
 
     /// <summary>
@@ -47,7 +47,7 @@
         /// </summary>
         [DataMember(Name = "acquiredFrom", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? AcquiredFrom { get; set; }
+        public Values<IOrganization, IPerson> AcquiredFrom { get; set; }
 
         /// <summary>
         /// The date and time of obtaining the product.
@@ -68,6 +68,6 @@
         /// </summary>
         [DataMember(Name = "typeOfGood", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? TypeOfGood { get; set; }
+        public Values<IProduct, IService> TypeOfGood { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ParcelDelivery.cs
+++ b/Source/Schema.NET/core/ParcelDelivery.cs
@@ -22,12 +22,12 @@
         /// <summary>
         /// The earliest date the package may arrive.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ExpectedArrivalFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ExpectedArrivalFrom { get; set; }
 
         /// <summary>
         /// The latest date the package may arrive.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ExpectedArrivalUntil { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ExpectedArrivalUntil { get; set; }
 
         /// <summary>
         /// Method used for delivery or shipping.
@@ -52,7 +52,7 @@
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        Values<IOrganization, IPerson>? Provider { get; set; }
+        Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// Shipper tracking number.
@@ -95,15 +95,15 @@
         /// The earliest date the package may arrive.
         /// </summary>
         [DataMember(Name = "expectedArrivalFrom", Order = 208)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ExpectedArrivalFrom { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ExpectedArrivalFrom { get; set; }
 
         /// <summary>
         /// The latest date the package may arrive.
         /// </summary>
         [DataMember(Name = "expectedArrivalUntil", Order = 209)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ExpectedArrivalUntil { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ExpectedArrivalUntil { get; set; }
 
         /// <summary>
         /// Method used for delivery or shipping.
@@ -138,7 +138,7 @@
         /// </summary>
         [DataMember(Name = "provider", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// Shipper tracking number.

--- a/Source/Schema.NET/core/PayAction.cs
+++ b/Source/Schema.NET/core/PayAction.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// A goal towards an action is taken. Can be concrete or abstract.
         /// </summary>
-        Values<MedicalDevicePurpose?, IThing>? Purpose { get; set; }
+        Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
 
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -37,13 +37,13 @@
         /// </summary>
         [DataMember(Name = "purpose", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<MedicalDevicePurpose?, IThing>? Purpose { get; set; }
+        public Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
 
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
         [DataMember(Name = "recipient", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Permit.cs
+++ b/Source/Schema.NET/core/Permit.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The geographic area where a permit or similar thing is valid.
@@ -42,7 +42,7 @@
         /// <summary>
         /// The date when the item is no longer valid.
         /// </summary>
-        Values<int?, DateTime?>? ValidUntil { get; set; }
+        Values<int?, DateTime?> ValidUntil { get; set; }
     }
 
     /// <summary>
@@ -89,8 +89,8 @@
         /// The date when the item becomes valid.
         /// </summary>
         [DataMember(Name = "validFrom", Order = 210)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The geographic area where a permit or similar thing is valid.
@@ -104,6 +104,6 @@
         /// </summary>
         [DataMember(Name = "validUntil", Order = 212)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? ValidUntil { get; set; }
+        public Values<int?, DateTime?> ValidUntil { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Person.cs
+++ b/Source/Schema.NET/core/Person.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// Physical address of the item.
         /// </summary>
-        Values<IPostalAddress, string>? Address { get; set; }
+        Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// An organization that this person is affiliated with. For example, a school/university, a club, or a team.
@@ -27,7 +27,7 @@
         /// <summary>
         /// An organization that the person is an alumni of.
         /// </summary>
-        Values<IEducationalOrganization, IOrganization>? AlumniOf { get; set; }
+        Values<IEducationalOrganization, IOrganization> AlumniOf { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -37,7 +37,7 @@
         /// <summary>
         /// Date of birth.
         /// </summary>
-        Values<int?, DateTime?>? BirthDate { get; set; }
+        Values<int?, DateTime?> BirthDate { get; set; }
 
         /// <summary>
         /// The place where the person was born.
@@ -47,7 +47,7 @@
         /// <summary>
         /// The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person.
         /// </summary>
-        Values<IBrand, IOrganization>? Brand { get; set; }
+        Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A child of the person.
@@ -57,7 +57,7 @@
         /// <summary>
         /// A colleague of the person.
         /// </summary>
-        Values<IPerson, Uri>? Colleague { get; set; }
+        Values<IPerson, Uri> Colleague { get; set; }
 
         /// <summary>
         /// A contact point for a person or organization.
@@ -67,7 +67,7 @@
         /// <summary>
         /// Date of death.
         /// </summary>
-        Values<int?, DateTime?>? DeathDate { get; set; }
+        Values<int?, DateTime?> DeathDate { get; set; }
 
         /// <summary>
         /// The place where the person died.
@@ -102,12 +102,12 @@
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        Values<IOrganization, IPerson>? Funder { get; set; }
+        Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender.
         /// </summary>
-        Values<GenderType?, string>? Gender { get; set; }
+        Values<GenderType?, string> Gender { get; set; }
 
         /// <summary>
         /// Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
@@ -137,12 +137,12 @@
         /// <summary>
         /// The height of the item.
         /// </summary>
-        Values<string, IQuantitativeValue>? Height { get; set; }
+        Values<string, IQuantitativeValue> Height { get; set; }
 
         /// <summary>
         /// A contact location for a person's residence.
         /// </summary>
-        Values<IContactPoint, IPlace>? HomeLocation { get; set; }
+        Values<IContactPoint, IPlace> HomeLocation { get; set; }
 
         /// <summary>
         /// An honorific prefix preceding a Person's name such as Dr/Mrs/Mr.
@@ -170,14 +170,14 @@
         OneOrMany<IPerson> Knows { get; set; }
 
         /// <summary>
-        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or yet relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
+        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        Values<string, IThing, Uri>? KnowsAbout { get; set; }
+        Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? KnowsLanguage { get; set; }
+        Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
@@ -187,7 +187,7 @@
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        Values<IOrganization, IProgramMembership>? MemberOf { get; set; }
+        Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
@@ -202,12 +202,12 @@
         /// <summary>
         /// The total financial value of the person as calculated by subtracting assets from liabilities.
         /// </summary>
-        Values<IMonetaryAmount, IPriceSpecification>? NetWorth { get; set; }
+        Values<IMonetaryAmount, IPriceSpecification> NetWorth { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        Values<IOwnershipInfo, IProduct>? Owns { get; set; }
+        Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// A parent of this person.
@@ -223,7 +223,7 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The most generic familial relation.
@@ -243,7 +243,7 @@
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        Values<IOrganization, IPerson>? Sponsor { get; set; }
+        Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The person's spouse.
@@ -273,7 +273,7 @@
         /// <summary>
         /// A contact location for a person's place of work.
         /// </summary>
-        Values<IContactPoint, IPlace>? WorkLocation { get; set; }
+        Values<IContactPoint, IPlace> WorkLocation { get; set; }
 
         /// <summary>
         /// Organizations that the person works for.
@@ -305,7 +305,7 @@
         /// </summary>
         [DataMember(Name = "address", Order = 107)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPostalAddress, string>? Address { get; set; }
+        public Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// An organization that this person is affiliated with. For example, a school/university, a club, or a team.
@@ -319,7 +319,7 @@
         /// </summary>
         [DataMember(Name = "alumniOf", Order = 109)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IEducationalOrganization, IOrganization>? AlumniOf { get; set; }
+        public Values<IEducationalOrganization, IOrganization> AlumniOf { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -333,7 +333,7 @@
         /// </summary>
         [DataMember(Name = "birthDate", Order = 111)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? BirthDate { get; set; }
+        public Values<int?, DateTime?> BirthDate { get; set; }
 
         /// <summary>
         /// The place where the person was born.
@@ -347,7 +347,7 @@
         /// </summary>
         [DataMember(Name = "brand", Order = 113)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBrand, IOrganization>? Brand { get; set; }
+        public Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A child of the person.
@@ -361,7 +361,7 @@
         /// </summary>
         [DataMember(Name = "colleague", Order = 115)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPerson, Uri>? Colleague { get; set; }
+        public Values<IPerson, Uri> Colleague { get; set; }
 
         /// <summary>
         /// A contact point for a person or organization.
@@ -375,7 +375,7 @@
         /// </summary>
         [DataMember(Name = "deathDate", Order = 117)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DeathDate { get; set; }
+        public Values<int?, DateTime?> DeathDate { get; set; }
 
         /// <summary>
         /// The place where the person died.
@@ -424,14 +424,14 @@
         /// </summary>
         [DataMember(Name = "funder", Order = 124)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender.
         /// </summary>
         [DataMember(Name = "gender", Order = 125)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<GenderType?, string>? Gender { get; set; }
+        public Values<GenderType?, string> Gender { get; set; }
 
         /// <summary>
         /// Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
@@ -473,14 +473,14 @@
         /// </summary>
         [DataMember(Name = "height", Order = 131)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue>? Height { get; set; }
+        public Values<string, IQuantitativeValue> Height { get; set; }
 
         /// <summary>
         /// A contact location for a person's residence.
         /// </summary>
         [DataMember(Name = "homeLocation", Order = 132)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IContactPoint, IPlace>? HomeLocation { get; set; }
+        public Values<IContactPoint, IPlace> HomeLocation { get; set; }
 
         /// <summary>
         /// An honorific prefix preceding a Person's name such as Dr/Mrs/Mr.
@@ -518,18 +518,18 @@
         public OneOrMany<IPerson> Knows { get; set; }
 
         /// <summary>
-        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or yet relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
+        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
         [DataMember(Name = "knowsAbout", Order = 138)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IThing, Uri>? KnowsAbout { get; set; }
+        public Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "knowsLanguage", Order = 139)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? KnowsLanguage { get; set; }
+        public Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
@@ -543,7 +543,7 @@
         /// </summary>
         [DataMember(Name = "memberOf", Order = 141)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IProgramMembership>? MemberOf { get; set; }
+        public Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
@@ -564,14 +564,14 @@
         /// </summary>
         [DataMember(Name = "netWorth", Order = 144)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, IPriceSpecification>? NetWorth { get; set; }
+        public Values<IMonetaryAmount, IPriceSpecification> NetWorth { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
         [DataMember(Name = "owns", Order = 145)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOwnershipInfo, IProduct>? Owns { get; set; }
+        public Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// A parent of this person.
@@ -593,7 +593,7 @@
         /// </summary>
         [DataMember(Name = "publishingPrinciples", Order = 148)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The most generic familial relation.
@@ -621,7 +621,7 @@
         /// </summary>
         [DataMember(Name = "sponsor", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The person's spouse.
@@ -663,7 +663,7 @@
         /// </summary>
         [DataMember(Name = "workLocation", Order = 158)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IContactPoint, IPlace>? WorkLocation { get; set; }
+        public Values<IContactPoint, IPlace> WorkLocation { get; set; }
 
         /// <summary>
         /// Organizations that the person works for.

--- a/Source/Schema.NET/core/PhysicalActivity.cs
+++ b/Source/Schema.NET/core/PhysicalActivity.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// The anatomy of the underlying organ system or structures associated with this entity.
         /// </summary>
-        Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy>? AssociatedAnatomy { get; set; }
+        Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
-        Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The characteristics of associated patients, such as age, gender, race etc.
@@ -47,14 +47,14 @@
         /// </summary>
         [DataMember(Name = "associatedAnatomy", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy>? AssociatedAnatomy { get; set; }
+        public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
         [DataMember(Name = "category", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The characteristics of associated patients, such as age, gender, race etc.

--- a/Source/Schema.NET/core/Physician.cs
+++ b/Source/Schema.NET/core/Physician.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A medical service available from this provider.
         /// </summary>
-        Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy>? AvailableService { get; set; }
+        Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy> AvailableService { get; set; }
 
         /// <summary>
         /// A hospital with which the physician or office is affiliated.
@@ -37,7 +37,7 @@
         /// </summary>
         [DataMember(Name = "availableService", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy>? AvailableService { get; set; }
+        public Values<IMedicalProcedure, IMedicalTest, IMedicalTherapy> AvailableService { get; set; }
 
         /// <summary>
         /// A hospital with which the physician or office is affiliated.

--- a/Source/Schema.NET/core/Place.cs
+++ b/Source/Schema.NET/core/Place.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// Physical address of the item.
         /// </summary>
-        Values<IPostalAddress, string>? Address { get; set; }
+        Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -59,7 +59,7 @@
         /// <summary>
         /// The geo coordinates of the place.
         /// </summary>
-        Values<IGeoCoordinates, IGeoShape>? Geo { get; set; }
+        Values<IGeoCoordinates, IGeoShape> Geo { get; set; }
 
         /// <summary>
         /// Represents a relationship between two geometries (or the places they represent), relating a containing geometry to a contained geometry. "a contains b iff no points of b lie in the exterior of a, and at least one point of the interior of b lies in the interior of a". As defined in &lt;a href="https://en.wikipedia.org/wiki/DE-9IM"&gt;DE-9IM&lt;/a&gt;.
@@ -119,7 +119,7 @@
         /// <summary>
         /// A URL to a map of the place.
         /// </summary>
-        Values<IMap, Uri>? HasMap { get; set; }
+        Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
@@ -134,7 +134,7 @@
         /// <summary>
         /// An associated logo.
         /// </summary>
-        Values<IImageObject, Uri>? Logo { get; set; }
+        Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
@@ -149,7 +149,7 @@
         /// <summary>
         /// A photograph of this place.
         /// </summary>
-        Values<IImageObject, IPhotograph>? Photo { get; set; }
+        Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
@@ -208,7 +208,7 @@
         /// </summary>
         [DataMember(Name = "address", Order = 107)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPostalAddress, string>? Address { get; set; }
+        public Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -265,7 +265,7 @@
         /// </summary>
         [DataMember(Name = "geo", Order = 115)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IGeoCoordinates, IGeoShape>? Geo { get; set; }
+        public Values<IGeoCoordinates, IGeoShape> Geo { get; set; }
 
         /// <summary>
         /// Represents a relationship between two geometries (or the places they represent), relating a containing geometry to a contained geometry. "a contains b iff no points of b lie in the exterior of a, and at least one point of the interior of b lies in the interior of a". As defined in &lt;a href="https://en.wikipedia.org/wiki/DE-9IM"&gt;DE-9IM&lt;/a&gt;.
@@ -349,7 +349,7 @@
         /// </summary>
         [DataMember(Name = "hasMap", Order = 127)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMap, Uri>? HasMap { get; set; }
+        public Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
@@ -370,7 +370,7 @@
         /// </summary>
         [DataMember(Name = "logo", Order = 130)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Logo { get; set; }
+        public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
@@ -391,7 +391,7 @@
         /// </summary>
         [DataMember(Name = "photo", Order = 133)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, IPhotograph>? Photo { get; set; }
+        public Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value

--- a/Source/Schema.NET/core/PostalAddress.cs
+++ b/Source/Schema.NET/core/PostalAddress.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The country. For example, USA. You can also provide the two-letter &lt;a href="http://en.wikipedia.org/wiki/ISO_3166-1"&gt;ISO 3166-1 alpha-2 country code&lt;/a&gt;.
         /// </summary>
-        Values<ICountry, string>? AddressCountry { get; set; }
+        Values<ICountry, string> AddressCountry { get; set; }
 
         /// <summary>
         /// The locality in which the street address is, and which is in the region. For example, Mountain View.
@@ -57,7 +57,7 @@
         /// </summary>
         [DataMember(Name = "addressCountry", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICountry, string>? AddressCountry { get; set; }
+        public Values<ICountry, string> AddressCountry { get; set; }
 
         /// <summary>
         /// The locality in which the street address is, and which is in the region. For example, Mountain View.

--- a/Source/Schema.NET/core/PriceSpecification.cs
+++ b/Source/Schema.NET/core/PriceSpecification.cs
@@ -39,7 +39,7 @@
         /// &lt;li&gt;Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<decimal?, string>? Price { get; set; }
+        Values<decimal?, string> Price { get; set; }
 
         /// <summary>
         /// The currency of the price, or a price component when attached to &lt;a class="localLink" href="http://schema.org/PriceSpecification"&gt;PriceSpecification&lt;/a&gt; and its subtypes.&lt;br/&gt;&lt;br/&gt;
@@ -50,12 +50,12 @@
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// Specifies whether the applicable value-added tax (VAT) is included in the price specification or not.
@@ -115,7 +115,7 @@
         /// </summary>
         [DataMember(Name = "price", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, string>? Price { get; set; }
+        public Values<decimal?, string> Price { get; set; }
 
         /// <summary>
         /// The currency of the price, or a price component when attached to &lt;a class="localLink" href="http://schema.org/PriceSpecification"&gt;PriceSpecification&lt;/a&gt; and its subtypes.&lt;br/&gt;&lt;br/&gt;
@@ -129,15 +129,15 @@
         /// The date when the item becomes valid.
         /// </summary>
         [DataMember(Name = "validFrom", Order = 312)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidFrom { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
         [DataMember(Name = "validThrough", Order = 313)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ValidThrough { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// Specifies whether the applicable value-added tax (VAT) is included in the price specification or not.

--- a/Source/Schema.NET/core/Product.cs
+++ b/Source/Schema.NET/core/Product.cs
@@ -33,12 +33,12 @@
         /// <summary>
         /// The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person.
         /// </summary>
-        Values<IBrand, IOrganization>? Brand { get; set; }
+        Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
-        Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The color of the product.
@@ -48,7 +48,12 @@
         /// <summary>
         /// The depth of the item.
         /// </summary>
-        Values<string, IQuantitativeValue>? Depth { get; set; }
+        Values<string, IQuantitativeValue> Depth { get; set; }
+
+        /// <summary>
+        /// A Global Trade Item Number (&lt;a href="https://www.gs1.org/standards/id-keys/gtin"&gt;GTIN&lt;/a&gt;). GTINs identify trade items, including products and services, using numeric identification codes. The &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; property generalizes the earlier &lt;a class="localLink" href="http://schema.org/gtin8"&gt;gtin8&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin12"&gt;gtin12&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin13"&gt;gtin13&lt;/a&gt;, and &lt;a class="localLink" href="http://schema.org/gtin14"&gt;gtin14&lt;/a&gt; properties. The GS1 &lt;a href="https://www.gs1.org/standards/Digital-Link/"&gt;digital link specifications&lt;/a&gt; express GTINs as URLs. A correct &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a &lt;a href="https://www.gs1.org/services/check-digit-calculator"&gt;valid GS1 check digit&lt;/a&gt; and meet the other rules for valid GTINs. See also &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1's GTIN Summary&lt;/a&gt; and &lt;a href="https://en.wikipedia.org/wiki/Global_Trade_Item_Number"&gt;Wikipedia&lt;/a&gt; for more details. Left-padding of the gtin values is not required or encouraged.
+        /// </summary>
+        OneOrMany<string> Gtin { get; set; }
 
         /// <summary>
         /// The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
@@ -73,7 +78,7 @@
         /// <summary>
         /// The height of the item.
         /// </summary>
-        Values<string, IQuantitativeValue>? Height { get; set; }
+        Values<string, IQuantitativeValue> Height { get; set; }
 
         /// <summary>
         /// A pointer to another product (or multiple products) for which this product is an accessory or spare part.
@@ -88,12 +93,12 @@
         /// <summary>
         /// A pointer to another, somehow related product (or multiple products).
         /// </summary>
-        Values<IProduct, IService>? IsRelatedTo { get; set; }
+        Values<IProduct, IService> IsRelatedTo { get; set; }
 
         /// <summary>
         /// A pointer to another, functionally similar product (or multiple products).
         /// </summary>
-        Values<IProduct, IService>? IsSimilarTo { get; set; }
+        Values<IProduct, IService> IsSimilarTo { get; set; }
 
         /// <summary>
         /// A predefined value from OfferItemCondition or a textual description of the condition of the product or service, or the products or services included in the offer.
@@ -103,7 +108,7 @@
         /// <summary>
         /// An associated logo.
         /// </summary>
-        Values<IImageObject, Uri>? Logo { get; set; }
+        Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The manufacturer of the product.
@@ -113,12 +118,12 @@
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        Values<IProduct, string, Uri>? Material { get; set; }
+        Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The model of the product. Use with the URL of a ProductModel or a textual representation of the model identifier. The URL of the ProductModel can be from an external source. It is recommended to additionally provide strong product identifiers via the gtin8/gtin13/gtin14 and mpn properties.
         /// </summary>
-        Values<IProductModel, string>? Model { get; set; }
+        Values<IProductModel, string> Model { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
@@ -143,17 +148,17 @@
         /// <summary>
         /// The date of production of the item, e.g. vehicle.
         /// </summary>
-        Values<int?, DateTime?>? ProductionDate { get; set; }
+        Values<int?, DateTime?> ProductionDate { get; set; }
 
         /// <summary>
         /// The date the item e.g. vehicle was purchased by the current owner.
         /// </summary>
-        Values<int?, DateTime?>? PurchaseDate { get; set; }
+        Values<int?, DateTime?> PurchaseDate { get; set; }
 
         /// <summary>
         /// The release date of a product or product model. This can be used to distinguish the exact variant of a product.
         /// </summary>
-        Values<int?, DateTime?>? ReleaseDate { get; set; }
+        Values<int?, DateTime?> ReleaseDate { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -178,7 +183,7 @@
         /// <summary>
         /// The width of the item.
         /// </summary>
-        Values<string, IQuantitativeValue>? Width { get; set; }
+        Values<string, IQuantitativeValue> Width { get; set; }
     }
 
     /// <summary>
@@ -227,14 +232,14 @@
         /// </summary>
         [DataMember(Name = "brand", Order = 110)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBrand, IOrganization>? Brand { get; set; }
+        public Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
         [DataMember(Name = "category", Order = 111)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// The color of the product.
@@ -248,188 +253,195 @@
         /// </summary>
         [DataMember(Name = "depth", Order = 113)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue>? Depth { get; set; }
+        public Values<string, IQuantitativeValue> Depth { get; set; }
+
+        /// <summary>
+        /// A Global Trade Item Number (&lt;a href="https://www.gs1.org/standards/id-keys/gtin"&gt;GTIN&lt;/a&gt;). GTINs identify trade items, including products and services, using numeric identification codes. The &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; property generalizes the earlier &lt;a class="localLink" href="http://schema.org/gtin8"&gt;gtin8&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin12"&gt;gtin12&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/gtin13"&gt;gtin13&lt;/a&gt;, and &lt;a class="localLink" href="http://schema.org/gtin14"&gt;gtin14&lt;/a&gt; properties. The GS1 &lt;a href="https://www.gs1.org/standards/Digital-Link/"&gt;digital link specifications&lt;/a&gt; express GTINs as URLs. A correct &lt;a class="localLink" href="http://schema.org/gtin"&gt;gtin&lt;/a&gt; value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a &lt;a href="https://www.gs1.org/services/check-digit-calculator"&gt;valid GS1 check digit&lt;/a&gt; and meet the other rules for valid GTINs. See also &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1's GTIN Summary&lt;/a&gt; and &lt;a href="https://en.wikipedia.org/wiki/Global_Trade_Item_Number"&gt;Wikipedia&lt;/a&gt; for more details. Left-padding of the gtin values is not required or encouraged.
+        /// </summary>
+        [DataMember(Name = "gtin", Order = 114)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> Gtin { get; set; }
 
         /// <summary>
         /// The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin12", Order = 114)]
+        [DataMember(Name = "gtin12", Order = 115)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin12 { get; set; }
 
         /// <summary>
         /// The GTIN-13 code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceeding zero. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin13", Order = 115)]
+        [DataMember(Name = "gtin13", Order = 116)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin13 { get; set; }
 
         /// <summary>
         /// The GTIN-14 code of the product, or the product to which the offer refers. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin14", Order = 116)]
+        [DataMember(Name = "gtin14", Order = 117)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin14 { get; set; }
 
         /// <summary>
         /// The &lt;a href="http://apps.gs1.org/GDD/glossary/Pages/GTIN-8.aspx"&gt;GTIN-8&lt;/a&gt; code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.
         /// </summary>
-        [DataMember(Name = "gtin8", Order = 117)]
+        [DataMember(Name = "gtin8", Order = 118)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Gtin8 { get; set; }
 
         /// <summary>
         /// The height of the item.
         /// </summary>
-        [DataMember(Name = "height", Order = 118)]
+        [DataMember(Name = "height", Order = 119)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue>? Height { get; set; }
+        public Values<string, IQuantitativeValue> Height { get; set; }
 
         /// <summary>
         /// A pointer to another product (or multiple products) for which this product is an accessory or spare part.
         /// </summary>
-        [DataMember(Name = "isAccessoryOrSparePartFor", Order = 119)]
+        [DataMember(Name = "isAccessoryOrSparePartFor", Order = 120)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IProduct> IsAccessoryOrSparePartFor { get; set; }
 
         /// <summary>
         /// A pointer to another product (or multiple products) for which this product is a consumable.
         /// </summary>
-        [DataMember(Name = "isConsumableFor", Order = 120)]
+        [DataMember(Name = "isConsumableFor", Order = 121)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IProduct> IsConsumableFor { get; set; }
 
         /// <summary>
         /// A pointer to another, somehow related product (or multiple products).
         /// </summary>
-        [DataMember(Name = "isRelatedTo", Order = 121)]
+        [DataMember(Name = "isRelatedTo", Order = 122)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? IsRelatedTo { get; set; }
+        public Values<IProduct, IService> IsRelatedTo { get; set; }
 
         /// <summary>
         /// A pointer to another, functionally similar product (or multiple products).
         /// </summary>
-        [DataMember(Name = "isSimilarTo", Order = 122)]
+        [DataMember(Name = "isSimilarTo", Order = 123)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? IsSimilarTo { get; set; }
+        public Values<IProduct, IService> IsSimilarTo { get; set; }
 
         /// <summary>
         /// A predefined value from OfferItemCondition or a textual description of the condition of the product or service, or the products or services included in the offer.
         /// </summary>
-        [DataMember(Name = "itemCondition", Order = 123)]
+        [DataMember(Name = "itemCondition", Order = 124)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<OfferItemCondition?> ItemCondition { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 124)]
+        [DataMember(Name = "logo", Order = 125)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Logo { get; set; }
+        public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The manufacturer of the product.
         /// </summary>
-        [DataMember(Name = "manufacturer", Order = 125)]
+        [DataMember(Name = "manufacturer", Order = 126)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> Manufacturer { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 126)]
+        [DataMember(Name = "material", Order = 127)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string, Uri>? Material { get; set; }
+        public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The model of the product. Use with the URL of a ProductModel or a textual representation of the model identifier. The URL of the ProductModel can be from an external source. It is recommended to additionally provide strong product identifiers via the gtin8/gtin13/gtin14 and mpn properties.
         /// </summary>
-        [DataMember(Name = "model", Order = 127)]
+        [DataMember(Name = "model", Order = 128)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProductModel, string>? Model { get; set; }
+        public Values<IProductModel, string> Model { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "mpn", Order = 128)]
+        [DataMember(Name = "mpn", Order = 129)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Mpn { get; set; }
 
         /// <summary>
         /// Indicates the &lt;a href="https://en.wikipedia.org/wiki/NATO_Stock_Number"&gt;NATO stock number&lt;/a&gt; (nsn) of a &lt;a class="localLink" href="http://schema.org/Product"&gt;Product&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "nsn", Order = 129)]
+        [DataMember(Name = "nsn", Order = 130)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Nsn { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
         /// </summary>
-        [DataMember(Name = "offers", Order = 130)]
+        [DataMember(Name = "offers", Order = 131)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> Offers { get; set; }
 
         /// <summary>
         /// The product identifier, such as ISBN. For example: &lt;code&gt;meta itemprop="productID" content="isbn:123-456-789"&lt;/code&gt;.
         /// </summary>
-        [DataMember(Name = "productID", Order = 131)]
+        [DataMember(Name = "productID", Order = 132)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ProductID { get; set; }
 
         /// <summary>
         /// The date of production of the item, e.g. vehicle.
         /// </summary>
-        [DataMember(Name = "productionDate", Order = 132)]
+        [DataMember(Name = "productionDate", Order = 133)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public virtual Values<int?, DateTime?>? ProductionDate { get; set; }
+        public virtual Values<int?, DateTime?> ProductionDate { get; set; }
 
         /// <summary>
         /// The date the item e.g. vehicle was purchased by the current owner.
         /// </summary>
-        [DataMember(Name = "purchaseDate", Order = 133)]
+        [DataMember(Name = "purchaseDate", Order = 134)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public virtual Values<int?, DateTime?>? PurchaseDate { get; set; }
+        public virtual Values<int?, DateTime?> PurchaseDate { get; set; }
 
         /// <summary>
         /// The release date of a product or product model. This can be used to distinguish the exact variant of a product.
         /// </summary>
-        [DataMember(Name = "releaseDate", Order = 134)]
+        [DataMember(Name = "releaseDate", Order = 135)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? ReleaseDate { get; set; }
+        public Values<int?, DateTime?> ReleaseDate { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 135)]
+        [DataMember(Name = "review", Order = 136)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "sku", Order = 136)]
+        [DataMember(Name = "sku", Order = 137)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Sku { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 137)]
+        [DataMember(Name = "slogan", Order = 138)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// The weight of the product or person.
         /// </summary>
-        [DataMember(Name = "weight", Order = 138)]
+        [DataMember(Name = "weight", Order = 139)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IQuantitativeValue> Weight { get; set; }
 
         /// <summary>
         /// The width of the item.
         /// </summary>
-        [DataMember(Name = "width", Order = 139)]
+        [DataMember(Name = "width", Order = 140)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue>? Width { get; set; }
+        public Values<string, IQuantitativeValue> Width { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ProgramMembership.cs
+++ b/Source/Schema.NET/core/ProgramMembership.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        Values<IOrganization, IPerson>? Member { get; set; }
+        Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// A unique identifier for the membership.
@@ -27,7 +27,7 @@
         /// <summary>
         /// The number of membership points earned by the member. If necessary, the unitText can be used to express the units the points are issued in. (e.g. stars, miles, etc.)
         /// </summary>
-        Values<double?, IQuantitativeValue>? MembershipPointsEarned { get; set; }
+        Values<double?, IQuantitativeValue> MembershipPointsEarned { get; set; }
 
         /// <summary>
         /// The program providing the membership.
@@ -59,7 +59,7 @@
         /// </summary>
         [DataMember(Name = "member", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Member { get; set; }
+        public Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// A unique identifier for the membership.
@@ -73,7 +73,7 @@
         /// </summary>
         [DataMember(Name = "membershipPointsEarned", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, IQuantitativeValue>? MembershipPointsEarned { get; set; }
+        public Values<double?, IQuantitativeValue> MembershipPointsEarned { get; set; }
 
         /// <summary>
         /// The program providing the membership.

--- a/Source/Schema.NET/core/PropertyValue.cs
+++ b/Source/Schema.NET/core/PropertyValue.cs
@@ -22,7 +22,7 @@
         /// If the &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; is "depression rating", the &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt; could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".&lt;br/&gt;&lt;br/&gt;
         /// If there are several &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; properties recorded for some given data object, use a &lt;a class="localLink" href="http://schema.org/PropertyValue"&gt;PropertyValue&lt;/a&gt; for each &lt;a class="localLink" href="http://schema.org/variableMeasured"&gt;variableMeasured&lt;/a&gt; and attach the corresponding &lt;a class="localLink" href="http://schema.org/measurementTechnique"&gt;measurementTechnique&lt;/a&gt;.
         /// </summary>
-        Values<string, Uri>? MeasurementTechnique { get; set; }
+        Values<string, Uri> MeasurementTechnique { get; set; }
 
         /// <summary>
         /// The lower value of some characteristic or property.
@@ -35,12 +35,12 @@
         /// a URL indicating the type of the property, either pointing to an external vocabulary, or a Web resource that describes the property (e.g. a glossary entry).
         /// Standards bodies should promote a standard prefix for the identifiers of properties from their standards.
         /// </summary>
-        Values<string, Uri>? PropertyID { get; set; }
+        Values<string, Uri> PropertyID { get; set; }
 
         /// <summary>
         /// The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon.
         /// </summary>
-        Values<string, Uri>? UnitCode { get; set; }
+        Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
@@ -57,12 +57,12 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<bool?, double?, IStructuredValue, string>? Value { get; set; }
+        Values<bool?, double?, IStructuredValue, string> Value { get; set; }
 
         /// <summary>
         /// A pointer to a secondary value that provides additional information on the original value, e.g. a reference temperature.
         /// </summary>
-        Values<IPropertyValue, IQuantitativeValue, IStructuredValue>? ValueReference { get; set; }
+        Values<IPropertyValue, IQuantitativeValue, IStructuredValue> ValueReference { get; set; }
     }
 
     /// <summary>
@@ -94,7 +94,7 @@
         /// </summary>
         [DataMember(Name = "measurementTechnique", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? MeasurementTechnique { get; set; }
+        public Values<string, Uri> MeasurementTechnique { get; set; }
 
         /// <summary>
         /// The lower value of some characteristic or property.
@@ -111,14 +111,14 @@
         /// </summary>
         [DataMember(Name = "propertyID", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? PropertyID { get; set; }
+        public Values<string, Uri> PropertyID { get; set; }
 
         /// <summary>
         /// The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon.
         /// </summary>
         [DataMember(Name = "unitCode", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? UnitCode { get; set; }
+        public Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
@@ -139,13 +139,13 @@
         /// </summary>
         [DataMember(Name = "value", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, double?, IStructuredValue, string>? Value { get; set; }
+        public Values<bool?, double?, IStructuredValue, string> Value { get; set; }
 
         /// <summary>
         /// A pointer to a secondary value that provides additional information on the original value, e.g. a reference temperature.
         /// </summary>
         [DataMember(Name = "valueReference", Order = 313)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPropertyValue, IQuantitativeValue, IStructuredValue>? ValueReference { get; set; }
+        public Values<IPropertyValue, IQuantitativeValue, IStructuredValue> ValueReference { get; set; }
     }
 }

--- a/Source/Schema.NET/core/PropertyValueSpecification.cs
+++ b/Source/Schema.NET/core/PropertyValueSpecification.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The default value of the input.  For properties that expect a literal, the default is a literal value, for properties that expect an object, it's an ID reference to one of the current values.
         /// </summary>
-        Values<string, IThing>? DefaultValue { get; set; }
+        Values<string, IThing> DefaultValue { get; set; }
 
         /// <summary>
         /// The upper value of some characteristic or property.
@@ -82,7 +82,7 @@
         /// </summary>
         [DataMember(Name = "defaultValue", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IThing>? DefaultValue { get; set; }
+        public Values<string, IThing> DefaultValue { get; set; }
 
         /// <summary>
         /// The upper value of some characteristic or property.

--- a/Source/Schema.NET/core/PublicationEvent.cs
+++ b/Source/Schema.NET/core/PublicationEvent.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// An agent associated with the publication event.
         /// </summary>
-        Values<IOrganization, IPerson>? PublishedBy { get; set; }
+        Values<IOrganization, IPerson> PublishedBy { get; set; }
 
         /// <summary>
         /// A broadcast service associated with the publication event.
@@ -44,7 +44,7 @@
         /// </summary>
         [DataMember(Name = "publishedBy", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? PublishedBy { get; set; }
+        public Values<IOrganization, IPerson> PublishedBy { get; set; }
 
         /// <summary>
         /// A broadcast service associated with the publication event.

--- a/Source/Schema.NET/core/PublicationIssue.cs
+++ b/Source/Schema.NET/core/PublicationIssue.cs
@@ -13,17 +13,17 @@
         /// <summary>
         /// Identifies the issue of publication; for example, "iii" or "2".
         /// </summary>
-        Values<int?, string>? IssueNumber { get; set; }
+        Values<int?, string> IssueNumber { get; set; }
 
         /// <summary>
         /// The page on which the work ends; for example "138" or "xvi".
         /// </summary>
-        Values<int?, string>? PageEnd { get; set; }
+        Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
-        Values<int?, string>? PageStart { get; set; }
+        Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".
@@ -49,21 +49,21 @@
         /// </summary>
         [DataMember(Name = "issueNumber", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? IssueNumber { get; set; }
+        public Values<int?, string> IssueNumber { get; set; }
 
         /// <summary>
         /// The page on which the work ends; for example "138" or "xvi".
         /// </summary>
         [DataMember(Name = "pageEnd", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageEnd { get; set; }
+        public Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
         [DataMember(Name = "pageStart", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageStart { get; set; }
+        public Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".

--- a/Source/Schema.NET/core/PublicationVolume.cs
+++ b/Source/Schema.NET/core/PublicationVolume.cs
@@ -13,12 +13,12 @@
         /// <summary>
         /// The page on which the work ends; for example "138" or "xvi".
         /// </summary>
-        Values<int?, string>? PageEnd { get; set; }
+        Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
-        Values<int?, string>? PageStart { get; set; }
+        Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".
@@ -28,7 +28,7 @@
         /// <summary>
         /// Identifies the volume of publication or multi-part work; for example, "iii" or "2".
         /// </summary>
-        Values<int?, string>? VolumeNumber { get; set; }
+        Values<int?, string> VolumeNumber { get; set; }
     }
 
     /// <summary>
@@ -49,14 +49,14 @@
         /// </summary>
         [DataMember(Name = "pageEnd", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageEnd { get; set; }
+        public Values<int?, string> PageEnd { get; set; }
 
         /// <summary>
         /// The page on which the work starts; for example "135" or "xiii".
         /// </summary>
         [DataMember(Name = "pageStart", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? PageStart { get; set; }
+        public Values<int?, string> PageStart { get; set; }
 
         /// <summary>
         /// Any description of pages that is not separated into pageStart and pageEnd; for example, "1-6, 9, 55" or "10-12, 46-49".
@@ -70,6 +70,6 @@
         /// </summary>
         [DataMember(Name = "volumeNumber", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? VolumeNumber { get; set; }
+        public Values<int?, string> VolumeNumber { get; set; }
     }
 }

--- a/Source/Schema.NET/core/QuantitativeValue.cs
+++ b/Source/Schema.NET/core/QuantitativeValue.cs
@@ -28,7 +28,7 @@
         /// <summary>
         /// The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon.
         /// </summary>
-        Values<string, Uri>? UnitCode { get; set; }
+        Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
@@ -45,12 +45,12 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<bool?, double?, IStructuredValue, string>? Value { get; set; }
+        Values<bool?, double?, IStructuredValue, string> Value { get; set; }
 
         /// <summary>
         /// A pointer to a secondary value that provides additional information on the original value, e.g. a reference temperature.
         /// </summary>
-        Values<IPropertyValue, IQuantitativeValue, IStructuredValue>? ValueReference { get; set; }
+        Values<IPropertyValue, IQuantitativeValue, IStructuredValue> ValueReference { get; set; }
     }
 
     /// <summary>
@@ -92,7 +92,7 @@
         /// </summary>
         [DataMember(Name = "unitCode", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? UnitCode { get; set; }
+        public Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
@@ -113,13 +113,13 @@
         /// </summary>
         [DataMember(Name = "value", Order = 311)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, double?, IStructuredValue, string>? Value { get; set; }
+        public Values<bool?, double?, IStructuredValue, string> Value { get; set; }
 
         /// <summary>
         /// A pointer to a secondary value that provides additional information on the original value, e.g. a reference temperature.
         /// </summary>
         [DataMember(Name = "valueReference", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPropertyValue, IQuantitativeValue, IStructuredValue>? ValueReference { get; set; }
+        public Values<IPropertyValue, IQuantitativeValue, IStructuredValue> ValueReference { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Question.cs
+++ b/Source/Schema.NET/core/Question.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The answer(s) that has been accepted as best, typically on a Question/Answer site. Sites vary in their selection mechanisms, e.g. drawing on community opinion and/or the view of the Question author.
         /// </summary>
-        Values<IAnswer, IItemList>? AcceptedAnswer { get; set; }
+        Values<IAnswer, IItemList> AcceptedAnswer { get; set; }
 
         /// <summary>
         /// The number of answers this question has received.
@@ -27,7 +27,7 @@
         /// <summary>
         /// An answer (possibly one of several, possibly incorrect) to a Question, e.g. on a Question/Answer site.
         /// </summary>
-        Values<IAnswer, IItemList>? SuggestedAnswer { get; set; }
+        Values<IAnswer, IItemList> SuggestedAnswer { get; set; }
 
         /// <summary>
         /// The number of upvotes this question, answer or comment has received from the community.
@@ -52,7 +52,7 @@
         /// </summary>
         [DataMember(Name = "acceptedAnswer", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnswer, IItemList>? AcceptedAnswer { get; set; }
+        public Values<IAnswer, IItemList> AcceptedAnswer { get; set; }
 
         /// <summary>
         /// The number of answers this question has received.
@@ -73,7 +73,7 @@
         /// </summary>
         [DataMember(Name = "suggestedAnswer", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnswer, IItemList>? SuggestedAnswer { get; set; }
+        public Values<IAnswer, IItemList> SuggestedAnswer { get; set; }
 
         /// <summary>
         /// The number of upvotes this question, answer or comment has received from the community.

--- a/Source/Schema.NET/core/RadioSeries.cs
+++ b/Source/Schema.NET/core/RadioSeries.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The number of episodes in this season or series.
@@ -100,7 +100,7 @@
         /// </summary>
         [DataMember(Name = "musicBy", Order = 410)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The number of episodes in this season or series.

--- a/Source/Schema.NET/core/Rating.cs
+++ b/Source/Schema.NET/core/Rating.cs
@@ -12,12 +12,17 @@
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        Values<IOrganization, IPerson>? Author { get; set; }
+        Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// The highest value allowed in this rating system. If bestRating is omitted, 5 is assumed.
         /// </summary>
-        Values<double?, string>? BestRating { get; set; }
+        Values<double?, string> BestRating { get; set; }
+
+        /// <summary>
+        /// A short explanation (e.g. one to two sentences) providing background context and other information that led to the conclusion expressed in the rating. This is particularly applicable to ratings associated with "fact check" markup using &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt;.
+        /// </summary>
+        OneOrMany<string> RatingExplanation { get; set; }
 
         /// <summary>
         /// The rating for the content.&lt;br/&gt;&lt;br/&gt;
@@ -27,7 +32,7 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<double?, string>? RatingValue { get; set; }
+        Values<double?, string> RatingValue { get; set; }
 
         /// <summary>
         /// This Review or Rating is relevant to this part or facet of the itemReviewed.
@@ -37,7 +42,7 @@
         /// <summary>
         /// The lowest value allowed in this rating system. If worstRating is omitted, 1 is assumed.
         /// </summary>
-        Values<double?, string>? WorstRating { get; set; }
+        Values<double?, string> WorstRating { get; set; }
     }
 
     /// <summary>
@@ -57,14 +62,21 @@
         /// </summary>
         [DataMember(Name = "author", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Author { get; set; }
+        public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// The highest value allowed in this rating system. If bestRating is omitted, 5 is assumed.
         /// </summary>
         [DataMember(Name = "bestRating", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? BestRating { get; set; }
+        public Values<double?, string> BestRating { get; set; }
+
+        /// <summary>
+        /// A short explanation (e.g. one to two sentences) providing background context and other information that led to the conclusion expressed in the rating. This is particularly applicable to ratings associated with "fact check" markup using &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "ratingExplanation", Order = 208)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> RatingExplanation { get; set; }
 
         /// <summary>
         /// The rating for the content.&lt;br/&gt;&lt;br/&gt;
@@ -74,22 +86,22 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        [DataMember(Name = "ratingValue", Order = 208)]
+        [DataMember(Name = "ratingValue", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? RatingValue { get; set; }
+        public Values<double?, string> RatingValue { get; set; }
 
         /// <summary>
         /// This Review or Rating is relevant to this part or facet of the itemReviewed.
         /// </summary>
-        [DataMember(Name = "reviewAspect", Order = 209)]
+        [DataMember(Name = "reviewAspect", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ReviewAspect { get; set; }
 
         /// <summary>
         /// The lowest value allowed in this rating system. If worstRating is omitted, 1 is assumed.
         /// </summary>
-        [DataMember(Name = "worstRating", Order = 210)]
+        [DataMember(Name = "worstRating", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? WorstRating { get; set; }
+        public Values<double?, string> WorstRating { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ReceiveAction.cs
+++ b/Source/Schema.NET/core/ReceiveAction.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the sending end of the action.
         /// </summary>
-        Values<IAudience, IOrganization, IPerson>? Sender { get; set; }
+        Values<IAudience, IOrganization, IPerson> Sender { get; set; }
     }
 
     /// <summary>
@@ -54,6 +54,6 @@
         /// </summary>
         [DataMember(Name = "sender", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IOrganization, IPerson>? Sender { get; set; }
+        public Values<IAudience, IOrganization, IPerson> Sender { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Recipe.cs
+++ b/Source/Schema.NET/core/Recipe.cs
@@ -42,12 +42,12 @@
         /// <summary>
         /// A step in making the recipe, in the form of a single item (document, video, etc.) or an ordered list with HowToStep and/or HowToSection items.
         /// </summary>
-        Values<ICreativeWork, IItemList, string>? RecipeInstructions { get; set; }
+        Values<ICreativeWork, IItemList, string> RecipeInstructions { get; set; }
 
         /// <summary>
         /// The quantity produced by the recipe (for example, number of people served, number of servings, etc).
         /// </summary>
-        Values<IQuantitativeValue, string>? RecipeYield { get; set; }
+        Values<IQuantitativeValue, string> RecipeYield { get; set; }
 
         /// <summary>
         /// Indicates a dietary restriction or guideline for which this recipe or menu item is suitable, e.g. diabetic, halal etc.
@@ -114,14 +114,14 @@
         /// </summary>
         [DataMember(Name = "recipeInstructions", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IItemList, string>? RecipeInstructions { get; set; }
+        public Values<ICreativeWork, IItemList, string> RecipeInstructions { get; set; }
 
         /// <summary>
         /// The quantity produced by the recipe (for example, number of people served, number of servings, etc).
         /// </summary>
         [DataMember(Name = "recipeYield", Order = 313)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? RecipeYield { get; set; }
+        public Values<IQuantitativeValue, string> RecipeYield { get; set; }
 
         /// <summary>
         /// Indicates a dietary restriction or guideline for which this recipe or menu item is suitable, e.g. diabetic, halal etc.

--- a/Source/Schema.NET/core/RentAction.cs
+++ b/Source/Schema.NET/core/RentAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of participant. The owner of the real estate property.
         /// </summary>
-        Values<IOrganization, IPerson>? Landlord { get; set; }
+        Values<IOrganization, IPerson> Landlord { get; set; }
 
         /// <summary>
         /// A sub property of participant. The real estate agent involved in the action.
@@ -37,7 +37,7 @@
         /// </summary>
         [DataMember(Name = "landlord", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Landlord { get; set; }
+        public Values<IOrganization, IPerson> Landlord { get; set; }
 
         /// <summary>
         /// A sub property of participant. The real estate agent involved in the action.

--- a/Source/Schema.NET/core/Reservation.cs
+++ b/Source/Schema.NET/core/Reservation.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred.
         /// </summary>
-        Values<IOrganization, IPerson>? Broker { get; set; }
+        Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// The date and time the reservation was modified.
@@ -39,7 +39,7 @@
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        Values<IOrganization, IPerson>? Provider { get; set; }
+        Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// The thing -- flight, event, restaurant,etc. being reserved.
@@ -69,12 +69,12 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<decimal?, IPriceSpecification, string>? TotalPrice { get; set; }
+        Values<decimal?, IPriceSpecification, string> TotalPrice { get; set; }
 
         /// <summary>
         /// The person or organization the reservation or ticket is for.
         /// </summary>
-        Values<IOrganization, IPerson>? UnderName { get; set; }
+        Values<IOrganization, IPerson> UnderName { get; set; }
     }
 
     /// <summary>
@@ -102,7 +102,7 @@
         /// </summary>
         [DataMember(Name = "broker", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Broker { get; set; }
+        public Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// The date and time the reservation was modified.
@@ -131,7 +131,7 @@
         /// </summary>
         [DataMember(Name = "provider", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// The thing -- flight, event, restaurant,etc. being reserved.
@@ -171,13 +171,13 @@
         /// </summary>
         [DataMember(Name = "totalPrice", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, IPriceSpecification, string>? TotalPrice { get; set; }
+        public Values<decimal?, IPriceSpecification, string> TotalPrice { get; set; }
 
         /// <summary>
         /// The person or organization the reservation or ticket is for.
         /// </summary>
         [DataMember(Name = "underName", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? UnderName { get; set; }
+        public Values<IOrganization, IPerson> UnderName { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ReturnAction.cs
+++ b/Source/Schema.NET/core/ReturnAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "recipient", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Role.cs
+++ b/Source/Schema.NET/core/Role.cs
@@ -13,17 +13,17 @@
         /// <summary>
         /// A role played, performed or filled by a person or organization. For example, the team of creators for a comic book might fill the roles named 'inker', 'penciller', and 'letterer'; or an athlete in a SportsTeam might play in the position named 'Quarterback'.
         /// </summary>
-        Values<string, Uri>? RoleName { get; set; }
+        Values<string, Uri> RoleName { get; set; }
 
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
     }
 
     /// <summary>
@@ -44,20 +44,20 @@
         /// </summary>
         [DataMember(Name = "roleName", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? RoleName { get; set; }
+        public Values<string, Uri> RoleName { get; set; }
 
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "startDate", Order = 207)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? StartDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
         [DataMember(Name = "endDate", Order = 208)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? EndDate { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ScreeningEvent.cs
+++ b/Source/Schema.NET/core/ScreeningEvent.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// Languages in which subtitles/captions are available, in &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard format&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? SubtitleLanguage { get; set; }
+        Values<ILanguage, string> SubtitleLanguage { get; set; }
 
         /// <summary>
         /// The type of screening or video broadcast used (e.g. IMAX, 3D, SD, HD, etc.).
@@ -42,7 +42,7 @@
         /// </summary>
         [DataMember(Name = "subtitleLanguage", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? SubtitleLanguage { get; set; }
+        public Values<ILanguage, string> SubtitleLanguage { get; set; }
 
         /// <summary>
         /// The type of screening or video broadcast used (e.g. IMAX, 3D, SD, HD, etc.).

--- a/Source/Schema.NET/core/SearchAction.cs
+++ b/Source/Schema.NET/core/SearchAction.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// Gets or sets the query input search parameter.
         /// </summary>
-        Values<string, PropertyValueSpecification>? QueryInput { get; set; }
+        Values<string, PropertyValueSpecification> QueryInput { get; set; }
     }
 
     /// <summary>
@@ -52,6 +52,6 @@
         /// </summary>
         [DataMember(Name = "query-input", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, PropertyValueSpecification>? QueryInput { get; set; }
+        public Values<string, PropertyValueSpecification> QueryInput { get; set; }
     }
 }

--- a/Source/Schema.NET/core/SendAction.cs
+++ b/Source/Schema.NET/core/SendAction.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -52,6 +52,6 @@
         /// </summary>
         [DataMember(Name = "recipient", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Service.cs
+++ b/Source/Schema.NET/core/Service.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The geographic area where a service or offered item is provided.
         /// </summary>
-        Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
@@ -37,17 +37,17 @@
         /// <summary>
         /// The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person.
         /// </summary>
-        Values<IBrand, IOrganization>? Brand { get; set; }
+        Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred.
         /// </summary>
-        Values<IOrganization, IPerson>? Broker { get; set; }
+        Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
-        Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// Indicates an OfferCatalog listing for this Organization, Person, or Service.
@@ -62,17 +62,17 @@
         /// <summary>
         /// A pointer to another, somehow related product (or multiple products).
         /// </summary>
-        Values<IProduct, IService>? IsRelatedTo { get; set; }
+        Values<IProduct, IService> IsRelatedTo { get; set; }
 
         /// <summary>
         /// A pointer to another, functionally similar product (or multiple products).
         /// </summary>
-        Values<IProduct, IService>? IsSimilarTo { get; set; }
+        Values<IProduct, IService> IsSimilarTo { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        Values<IImageObject, Uri>? Logo { get; set; }
+        Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
@@ -82,7 +82,7 @@
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        Values<IOrganization, IPerson>? Provider { get; set; }
+        Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// Indicates the mobility of a provided service (e.g. 'static', 'dynamic').
@@ -112,7 +112,7 @@
         /// <summary>
         /// Human-readable terms of service documentation.
         /// </summary>
-        Values<string, Uri>? TermsOfService { get; set; }
+        Values<string, Uri> TermsOfService { get; set; }
     }
 
     /// <summary>
@@ -139,7 +139,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
@@ -167,21 +167,21 @@
         /// </summary>
         [DataMember(Name = "brand", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBrand, IOrganization>? Brand { get; set; }
+        public Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred.
         /// </summary>
         [DataMember(Name = "broker", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Broker { get; set; }
+        public Values<IOrganization, IPerson> Broker { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
         [DataMember(Name = "category", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// Indicates an OfferCatalog listing for this Organization, Person, or Service.
@@ -202,21 +202,21 @@
         /// </summary>
         [DataMember(Name = "isRelatedTo", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? IsRelatedTo { get; set; }
+        public Values<IProduct, IService> IsRelatedTo { get; set; }
 
         /// <summary>
         /// A pointer to another, functionally similar product (or multiple products).
         /// </summary>
         [DataMember(Name = "isSimilarTo", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? IsSimilarTo { get; set; }
+        public Values<IProduct, IService> IsSimilarTo { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
         [DataMember(Name = "logo", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Logo { get; set; }
+        public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
@@ -230,7 +230,7 @@
         /// </summary>
         [DataMember(Name = "provider", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// Indicates the mobility of a provided service (e.g. 'static', 'dynamic').
@@ -272,6 +272,6 @@
         /// </summary>
         [DataMember(Name = "termsOfService", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? TermsOfService { get; set; }
+        public Values<string, Uri> TermsOfService { get; set; }
     }
 }

--- a/Source/Schema.NET/core/ServiceChannel.cs
+++ b/Source/Schema.NET/core/ServiceChannel.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A language someone may use with or at the item, service or place. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/inLanguage"&gt;inLanguage&lt;/a&gt;
         /// </summary>
-        Values<ILanguage, string>? AvailableLanguage { get; set; }
+        Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// Estimated processing time for the service using this channel.
@@ -67,7 +67,7 @@
         /// </summary>
         [DataMember(Name = "availableLanguage", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? AvailableLanguage { get; set; }
+        public Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// Estimated processing time for the service using this channel.

--- a/Source/Schema.NET/core/SingleFamilyResidence.cs
+++ b/Source/Schema.NET/core/SingleFamilyResidence.cs
@@ -34,7 +34,7 @@
         /// </summary>
         [DataMember(Name = "numberOfRooms", Order = 406)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        public override Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).

--- a/Source/Schema.NET/core/SoftwareApplication.cs
+++ b/Source/Schema.NET/core/SoftwareApplication.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// Type of software application, e.g. 'Game, Multimedia'.
         /// </summary>
-        Values<string, Uri>? ApplicationCategory { get; set; }
+        Values<string, Uri> ApplicationCategory { get; set; }
 
         /// <summary>
         /// Subcategory of the application, e.g. 'Arcade Game'.
         /// </summary>
-        Values<string, Uri>? ApplicationSubCategory { get; set; }
+        Values<string, Uri> ApplicationSubCategory { get; set; }
 
         /// <summary>
         /// The name of the application suite to which the application belongs (e.g. Excel belongs to Office).
@@ -47,7 +47,7 @@
         /// <summary>
         /// Features or modules provided by this application (and possibly required by other applications).
         /// </summary>
-        Values<string, Uri>? FeatureList { get; set; }
+        Values<string, Uri> FeatureList { get; set; }
 
         /// <summary>
         /// Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed.
@@ -62,7 +62,7 @@
         /// <summary>
         /// Minimum memory requirements.
         /// </summary>
-        Values<string, Uri>? MemoryRequirements { get; set; }
+        Values<string, Uri> MemoryRequirements { get; set; }
 
         /// <summary>
         /// Operating systems supported (Windows 7, OSX 10.6, Android 1.6).
@@ -82,12 +82,12 @@
         /// <summary>
         /// Description of what changed in this version.
         /// </summary>
-        Values<string, Uri>? ReleaseNotes { get; set; }
+        Values<string, Uri> ReleaseNotes { get; set; }
 
         /// <summary>
         /// A link to a screenshot image of the app.
         /// </summary>
-        Values<IImageObject, Uri>? Screenshot { get; set; }
+        Values<IImageObject, Uri> Screenshot { get; set; }
 
         /// <summary>
         /// Additional content for a software application.
@@ -102,7 +102,7 @@
         /// <summary>
         /// Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (Examples: DirectX, Java or .NET runtime).
         /// </summary>
-        Values<string, Uri>? SoftwareRequirements { get; set; }
+        Values<string, Uri> SoftwareRequirements { get; set; }
 
         /// <summary>
         /// Version of the software instance.
@@ -112,7 +112,7 @@
         /// <summary>
         /// Storage requirements (free space required).
         /// </summary>
-        Values<string, Uri>? StorageRequirements { get; set; }
+        Values<string, Uri> StorageRequirements { get; set; }
 
         /// <summary>
         /// Supporting data for a SoftwareApplication.
@@ -137,14 +137,14 @@
         /// </summary>
         [DataMember(Name = "applicationCategory", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ApplicationCategory { get; set; }
+        public Values<string, Uri> ApplicationCategory { get; set; }
 
         /// <summary>
         /// Subcategory of the application, e.g. 'Arcade Game'.
         /// </summary>
         [DataMember(Name = "applicationSubCategory", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ApplicationSubCategory { get; set; }
+        public Values<string, Uri> ApplicationSubCategory { get; set; }
 
         /// <summary>
         /// The name of the application suite to which the application belongs (e.g. Excel belongs to Office).
@@ -186,7 +186,7 @@
         /// </summary>
         [DataMember(Name = "featureList", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? FeatureList { get; set; }
+        public Values<string, Uri> FeatureList { get; set; }
 
         /// <summary>
         /// Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed.
@@ -207,7 +207,7 @@
         /// </summary>
         [DataMember(Name = "memoryRequirements", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? MemoryRequirements { get; set; }
+        public Values<string, Uri> MemoryRequirements { get; set; }
 
         /// <summary>
         /// Operating systems supported (Windows 7, OSX 10.6, Android 1.6).
@@ -235,14 +235,14 @@
         /// </summary>
         [DataMember(Name = "releaseNotes", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ReleaseNotes { get; set; }
+        public Values<string, Uri> ReleaseNotes { get; set; }
 
         /// <summary>
         /// A link to a screenshot image of the app.
         /// </summary>
         [DataMember(Name = "screenshot", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Screenshot { get; set; }
+        public Values<IImageObject, Uri> Screenshot { get; set; }
 
         /// <summary>
         /// Additional content for a software application.
@@ -263,7 +263,7 @@
         /// </summary>
         [DataMember(Name = "softwareRequirements", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SoftwareRequirements { get; set; }
+        public Values<string, Uri> SoftwareRequirements { get; set; }
 
         /// <summary>
         /// Version of the software instance.
@@ -277,7 +277,7 @@
         /// </summary>
         [DataMember(Name = "storageRequirements", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? StorageRequirements { get; set; }
+        public Values<string, Uri> StorageRequirements { get; set; }
 
         /// <summary>
         /// Supporting data for a SoftwareApplication.

--- a/Source/Schema.NET/core/SoftwareSourceCode.cs
+++ b/Source/Schema.NET/core/SoftwareSourceCode.cs
@@ -22,7 +22,7 @@
         /// <summary>
         /// The computer programming language.
         /// </summary>
-        Values<IComputerLanguage, string>? ProgrammingLanguage { get; set; }
+        Values<IComputerLanguage, string> ProgrammingLanguage { get; set; }
 
         /// <summary>
         /// Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0).
@@ -66,7 +66,7 @@
         /// </summary>
         [DataMember(Name = "programmingLanguage", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IComputerLanguage, string>? ProgrammingLanguage { get; set; }
+        public Values<IComputerLanguage, string> ProgrammingLanguage { get; set; }
 
         /// <summary>
         /// Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0).

--- a/Source/Schema.NET/core/SportsEvent.cs
+++ b/Source/Schema.NET/core/SportsEvent.cs
@@ -12,17 +12,17 @@
         /// <summary>
         /// The away team in a sports event.
         /// </summary>
-        Values<IPerson, ISportsTeam>? AwayTeam { get; set; }
+        Values<IPerson, ISportsTeam> AwayTeam { get; set; }
 
         /// <summary>
         /// A competitor in a sports event.
         /// </summary>
-        Values<IPerson, ISportsTeam>? Competitor { get; set; }
+        Values<IPerson, ISportsTeam> Competitor { get; set; }
 
         /// <summary>
         /// The home team in a sports event.
         /// </summary>
-        Values<IPerson, ISportsTeam>? HomeTeam { get; set; }
+        Values<IPerson, ISportsTeam> HomeTeam { get; set; }
     }
 
     /// <summary>
@@ -42,20 +42,20 @@
         /// </summary>
         [DataMember(Name = "awayTeam", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPerson, ISportsTeam>? AwayTeam { get; set; }
+        public Values<IPerson, ISportsTeam> AwayTeam { get; set; }
 
         /// <summary>
         /// A competitor in a sports event.
         /// </summary>
         [DataMember(Name = "competitor", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPerson, ISportsTeam>? Competitor { get; set; }
+        public Values<IPerson, ISportsTeam> Competitor { get; set; }
 
         /// <summary>
         /// The home team in a sports event.
         /// </summary>
         [DataMember(Name = "homeTeam", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPerson, ISportsTeam>? HomeTeam { get; set; }
+        public Values<IPerson, ISportsTeam> HomeTeam { get; set; }
     }
 }

--- a/Source/Schema.NET/core/SportsOrganization.cs
+++ b/Source/Schema.NET/core/SportsOrganization.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A type of sport (e.g. Baseball).
         /// </summary>
-        Values<string, Uri>? Sport { get; set; }
+        Values<string, Uri> Sport { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "sport", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Sport { get; set; }
+        public Values<string, Uri> Sport { get; set; }
     }
 }

--- a/Source/Schema.NET/core/Suite.cs
+++ b/Source/Schema.NET/core/Suite.cs
@@ -15,7 +15,7 @@
         /// The type of bed or beds included in the accommodation. For the single case of just one bed of a certain type, you use bed directly with a text.
         ///       If you want to indicate the quantity of a certain kind of bed, use an instance of BedDetails. For more detailed information, use the amenityFeature property.
         /// </summary>
-        Values<IBedDetails, BedType?, string>? Bed { get; set; }
+        Values<IBedDetails, BedType?, string> Bed { get; set; }
 
         /// <summary>
         /// The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).
@@ -44,7 +44,7 @@
         /// </summary>
         [DataMember(Name = "bed", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBedDetails, BedType?, string>? Bed { get; set; }
+        public Values<IBedDetails, BedType?, string> Bed { get; set; }
 
         /// <summary>
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
@@ -52,7 +52,7 @@
         /// </summary>
         [DataMember(Name = "numberOfRooms", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        public override Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).

--- a/Source/Schema.NET/core/SuperficialAnatomy.cs
+++ b/Source/Schema.NET/core/SuperficialAnatomy.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// Anatomical systems or structures that relate to the superficial anatomy.
         /// </summary>
-        Values<IAnatomicalStructure, IAnatomicalSystem>? RelatedAnatomy { get; set; }
+        Values<IAnatomicalStructure, IAnatomicalSystem> RelatedAnatomy { get; set; }
 
         /// <summary>
         /// A medical condition associated with this anatomy.
@@ -59,7 +59,7 @@
         /// </summary>
         [DataMember(Name = "relatedAnatomy", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, IAnatomicalSystem>? RelatedAnatomy { get; set; }
+        public Values<IAnatomicalStructure, IAnatomicalSystem> RelatedAnatomy { get; set; }
 
         /// <summary>
         /// A medical condition associated with this anatomy.

--- a/Source/Schema.NET/core/TVEpisode.cs
+++ b/Source/Schema.NET/core/TVEpisode.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// Languages in which subtitles/captions are available, in &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard format&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? SubtitleLanguage { get; set; }
+        Values<ILanguage, string> SubtitleLanguage { get; set; }
     }
 
     /// <summary>
@@ -44,6 +44,6 @@
         /// </summary>
         [DataMember(Name = "subtitleLanguage", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? SubtitleLanguage { get; set; }
+        public Values<ILanguage, string> SubtitleLanguage { get; set; }
     }
 }

--- a/Source/Schema.NET/core/TVSeries.cs
+++ b/Source/Schema.NET/core/TVSeries.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The number of episodes in this season or series.
@@ -112,7 +112,7 @@
         /// </summary>
         [DataMember(Name = "musicBy", Order = 411)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The number of episodes in this season or series.

--- a/Source/Schema.NET/core/TaxiReservation.cs
+++ b/Source/Schema.NET/core/TaxiReservation.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// Number of people the reservation should accommodate.
         /// </summary>
-        Values<int?, IQuantitativeValue>? PartySize { get; set; }
+        Values<int?, IQuantitativeValue> PartySize { get; set; }
 
         /// <summary>
         /// Where a taxi will pick up a passenger or a rental car can be picked up.
@@ -44,7 +44,7 @@
         /// </summary>
         [DataMember(Name = "partySize", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? PartySize { get; set; }
+        public Values<int?, IQuantitativeValue> PartySize { get; set; }
 
         /// <summary>
         /// Where a taxi will pick up a passenger or a rental car can be picked up.

--- a/Source/Schema.NET/core/Thing.cs
+++ b/Source/Schema.NET/core/Thing.cs
@@ -37,17 +37,17 @@ namespace Schema.NET
         /// <summary>
         /// The identifier property represents any kind of identifier for any kind of &lt;a class="localLink" href="http://schema.org/Thing"&gt;Thing&lt;/a&gt;, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See &lt;a href="/docs/datamodel.html#identifierBg"&gt;background notes&lt;/a&gt; for more details.
         /// </summary>
-        Values<IPropertyValue, string, Uri>? Identifier { get; set; }
+        Values<IPropertyValue, string, Uri> Identifier { get; set; }
 
         /// <summary>
         /// An image of the item. This can be a &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt; or a fully described &lt;a class="localLink" href="http://schema.org/ImageObject"&gt;ImageObject&lt;/a&gt;.
         /// </summary>
-        Values<IImageObject, Uri>? Image { get; set; }
+        Values<IImageObject, Uri> Image { get; set; }
 
         /// <summary>
         /// Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See &lt;a href="/docs/datamodel.html#mainEntityBackground"&gt;background notes&lt;/a&gt; for details.
         /// </summary>
-        Values<ICreativeWork, Uri>? MainEntityOfPage { get; set; }
+        Values<ICreativeWork, Uri> MainEntityOfPage { get; set; }
 
         /// <summary>
         /// Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
@@ -60,9 +60,9 @@ namespace Schema.NET
         OneOrMany<Uri> SameAs { get; set; }
 
         /// <summary>
-        /// A CreativeWork or Event about this Thing..
+        /// A CreativeWork or Event about this Thing.
         /// </summary>
-        Values<ICreativeWork, IEvent>? SubjectOf { get; set; }
+        Values<ICreativeWork, IEvent> SubjectOf { get; set; }
 
         /// <summary>
         /// URL of the item.
@@ -122,21 +122,21 @@ namespace Schema.NET
         /// </summary>
         [DataMember(Name = "identifier", Order = 11)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPropertyValue, string, Uri>? Identifier { get; set; }
+        public Values<IPropertyValue, string, Uri> Identifier { get; set; }
 
         /// <summary>
         /// An image of the item. This can be a &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt; or a fully described &lt;a class="localLink" href="http://schema.org/ImageObject"&gt;ImageObject&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "image", Order = 12)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Image { get; set; }
+        public Values<IImageObject, Uri> Image { get; set; }
 
         /// <summary>
         /// Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See &lt;a href="/docs/datamodel.html#mainEntityBackground"&gt;background notes&lt;/a&gt; for details.
         /// </summary>
         [DataMember(Name = "mainEntityOfPage", Order = 13)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? MainEntityOfPage { get; set; }
+        public Values<ICreativeWork, Uri> MainEntityOfPage { get; set; }
 
         /// <summary>
         /// Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
@@ -153,11 +153,11 @@ namespace Schema.NET
         public OneOrMany<Uri> SameAs { get; set; }
 
         /// <summary>
-        /// A CreativeWork or Event about this Thing..
+        /// A CreativeWork or Event about this Thing.
         /// </summary>
         [DataMember(Name = "subjectOf", Order = 16)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IEvent>? SubjectOf { get; set; }
+        public Values<ICreativeWork, IEvent> SubjectOf { get; set; }
 
         /// <summary>
         /// URL of the item.

--- a/Source/Schema.NET/core/Ticket.cs
+++ b/Source/Schema.NET/core/Ticket.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The date the ticket was issued.
         /// </summary>
-        OneOrMany<DateTimeOffset?> DateIssued { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DateIssued { get; set; }
 
         /// <summary>
         /// The organization issuing the ticket or permit.
@@ -38,7 +38,7 @@
         /// <summary>
         /// Reference to an asset (e.g., Barcode, QR code image or PDF) usable for entrance.
         /// </summary>
-        Values<string, Uri>? TicketToken { get; set; }
+        Values<string, Uri> TicketToken { get; set; }
 
         /// <summary>
         /// The total price for the reservation or ticket, including applicable taxes, shipping, etc.&lt;br/&gt;&lt;br/&gt;
@@ -48,12 +48,12 @@
         /// &lt;li&gt;Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<decimal?, IPriceSpecification, string>? TotalPrice { get; set; }
+        Values<decimal?, IPriceSpecification, string> TotalPrice { get; set; }
 
         /// <summary>
         /// The person or organization the reservation or ticket is for.
         /// </summary>
-        Values<IOrganization, IPerson>? UnderName { get; set; }
+        Values<IOrganization, IPerson> UnderName { get; set; }
     }
 
     /// <summary>
@@ -72,8 +72,8 @@
         /// The date the ticket was issued.
         /// </summary>
         [DataMember(Name = "dateIssued", Order = 206)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> DateIssued { get; set; }
+        [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+        public Values<int?, DateTime?, DateTimeOffset?> DateIssued { get; set; }
 
         /// <summary>
         /// The organization issuing the ticket or permit.
@@ -109,7 +109,7 @@
         /// </summary>
         [DataMember(Name = "ticketToken", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? TicketToken { get; set; }
+        public Values<string, Uri> TicketToken { get; set; }
 
         /// <summary>
         /// The total price for the reservation or ticket, including applicable taxes, shipping, etc.&lt;br/&gt;&lt;br/&gt;
@@ -121,13 +121,13 @@
         /// </summary>
         [DataMember(Name = "totalPrice", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, IPriceSpecification, string>? TotalPrice { get; set; }
+        public Values<decimal?, IPriceSpecification, string> TotalPrice { get; set; }
 
         /// <summary>
         /// The person or organization the reservation or ticket is for.
         /// </summary>
         [DataMember(Name = "underName", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? UnderName { get; set; }
+        public Values<IOrganization, IPerson> UnderName { get; set; }
     }
 }

--- a/Source/Schema.NET/core/TipAction.cs
+++ b/Source/Schema.NET/core/TipAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "recipient", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, IContactPoint, IOrganization, IPerson>? Recipient { get; set; }
+        public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
     }
 }

--- a/Source/Schema.NET/core/TouristAttraction.cs
+++ b/Source/Schema.NET/core/TouristAttraction.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// A language someone may use with or at the item, service or place. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/inLanguage"&gt;inLanguage&lt;/a&gt;
         /// </summary>
-        Values<ILanguage, string>? AvailableLanguage { get; set; }
+        Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// Attraction suitable for type(s) of tourist. eg. Children, visitors from a particular country, etc.
         /// </summary>
-        Values<IAudience, string>? TouristType { get; set; }
+        Values<IAudience, string> TouristType { get; set; }
     }
 
     /// <summary>
@@ -37,13 +37,13 @@
         /// </summary>
         [DataMember(Name = "availableLanguage", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? AvailableLanguage { get; set; }
+        public Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// Attraction suitable for type(s) of tourist. eg. Children, visitors from a particular country, etc.
         /// </summary>
         [DataMember(Name = "touristType", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudience, string>? TouristType { get; set; }
+        public Values<IAudience, string> TouristType { get; set; }
     }
 }

--- a/Source/Schema.NET/core/TradeAction.cs
+++ b/Source/Schema.NET/core/TradeAction.cs
@@ -19,7 +19,7 @@
         /// &lt;li&gt;Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        Values<decimal?, string>? Price { get; set; }
+        Values<decimal?, string> Price { get; set; }
 
         /// <summary>
         /// The currency of the price, or a price component when attached to &lt;a class="localLink" href="http://schema.org/PriceSpecification"&gt;PriceSpecification&lt;/a&gt; and its subtypes.&lt;br/&gt;&lt;br/&gt;
@@ -57,7 +57,7 @@
         /// </summary>
         [DataMember(Name = "price", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<decimal?, string>? Price { get; set; }
+        public Values<decimal?, string> Price { get; set; }
 
         /// <summary>
         /// The currency of the price, or a price component when attached to &lt;a class="localLink" href="http://schema.org/PriceSpecification"&gt;PriceSpecification&lt;/a&gt; and its subtypes.&lt;br/&gt;&lt;br/&gt;

--- a/Source/Schema.NET/core/Trip.cs
+++ b/Source/Schema.NET/core/Trip.cs
@@ -12,17 +12,17 @@
         /// <summary>
         /// The expected arrival time.
         /// </summary>
-        OneOrMany<DateTimeOffset?> ArrivalTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> ArrivalTime { get; set; }
 
         /// <summary>
         /// The expected departure time.
         /// </summary>
-        OneOrMany<DateTimeOffset?> DepartureTime { get; set; }
+        Values<DateTimeOffset?, TimeSpan?> DepartureTime { get; set; }
 
         /// <summary>
         /// Destination(s) ( &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; ) that make up a trip. For a trip where destination order is important use &lt;a class="localLink" href="http://schema.org/ItemList"&gt;ItemList&lt;/a&gt; to specify that order (see examples).
         /// </summary>
-        Values<IItemList, IPlace>? Itinerary { get; set; }
+        Values<IItemList, IPlace> Itinerary { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
@@ -37,7 +37,7 @@
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        Values<IOrganization, IPerson>? Provider { get; set; }
+        Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// Identifies a &lt;a class="localLink" href="http://schema.org/Trip"&gt;Trip&lt;/a&gt; that is a subTrip of this Trip.  For example Day 1, Day 2, etc. of a multi-day trip.
@@ -62,21 +62,21 @@
         /// </summary>
         [DataMember(Name = "arrivalTime", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> ArrivalTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> ArrivalTime { get; set; }
 
         /// <summary>
         /// The expected departure time.
         /// </summary>
         [DataMember(Name = "departureTime", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> DepartureTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> DepartureTime { get; set; }
 
         /// <summary>
         /// Destination(s) ( &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; ) that make up a trip. For a trip where destination order is important use &lt;a class="localLink" href="http://schema.org/ItemList"&gt;ItemList&lt;/a&gt; to specify that order (see examples).
         /// </summary>
         [DataMember(Name = "itinerary", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IItemList, IPlace>? Itinerary { get; set; }
+        public Values<IItemList, IPlace> Itinerary { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
@@ -97,7 +97,7 @@
         /// </summary>
         [DataMember(Name = "provider", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// Identifies a &lt;a class="localLink" href="http://schema.org/Trip"&gt;Trip&lt;/a&gt; that is a subTrip of this Trip.  For example Day 1, Day 2, etc. of a multi-day trip.

--- a/Source/Schema.NET/core/TypeAndQuantityNode.cs
+++ b/Source/Schema.NET/core/TypeAndQuantityNode.cs
@@ -22,12 +22,12 @@
         /// <summary>
         /// The product that this structured value is referring to.
         /// </summary>
-        Values<IProduct, IService>? TypeOfGood { get; set; }
+        Values<IProduct, IService> TypeOfGood { get; set; }
 
         /// <summary>
         /// The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon.
         /// </summary>
-        Values<string, Uri>? UnitCode { get; set; }
+        Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
@@ -67,14 +67,14 @@
         /// </summary>
         [DataMember(Name = "typeOfGood", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService>? TypeOfGood { get; set; }
+        public Values<IProduct, IService> TypeOfGood { get; set; }
 
         /// <summary>
         /// The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon.
         /// </summary>
         [DataMember(Name = "unitCode", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? UnitCode { get; set; }
+        public Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for

--- a/Source/Schema.NET/core/UnitPriceSpecification.cs
+++ b/Source/Schema.NET/core/UnitPriceSpecification.cs
@@ -27,7 +27,7 @@
         /// <summary>
         /// The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon.
         /// </summary>
-        Values<string, Uri>? UnitCode { get; set; }
+        Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
@@ -74,7 +74,7 @@
         /// </summary>
         [DataMember(Name = "unitCode", Order = 409)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? UnitCode { get; set; }
+        public Values<string, Uri> UnitCode { get; set; }
 
         /// <summary>
         /// A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for

--- a/Source/Schema.NET/core/Vehicle.cs
+++ b/Source/Schema.NET/core/Vehicle.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).
         /// </summary>
-        Values<string, Uri>? BodyType { get; set; }
+        Values<string, Uri> BodyType { get; set; }
 
         /// <summary>
         /// The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.&lt;br/&gt;&lt;br/&gt;
@@ -33,12 +33,12 @@
         /// <summary>
         /// The date of the first registration of the vehicle with the respective public authorities.
         /// </summary>
-        Values<int?, DateTime?>? DateVehicleFirstRegistered { get; set; }
+        Values<int?, DateTime?> DateVehicleFirstRegistered { get; set; }
 
         /// <summary>
         /// The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain.
         /// </summary>
-        Values<DriveWheelConfigurationValue?, string>? DriveWheelConfiguration { get; set; }
+        Values<DriveWheelConfigurationValue?, string> DriveWheelConfiguration { get; set; }
 
         /// <summary>
         /// The CO2 emissions in g/km. When used in combination with a QuantitativeValue, put "g/km" into the unitText property of that value, since there is no UN/CEFACT Common Code for "g/km".
@@ -74,7 +74,7 @@
         /// <summary>
         /// The type of fuel suitable for the engine or engines of the vehicle. If the vehicle has only one engine, this property can be attached directly to the vehicle.
         /// </summary>
-        Values<string, Uri>? FuelType { get; set; }
+        Values<string, Uri> FuelType { get; set; }
 
         /// <summary>
         /// A textual description of known damages, both repaired and unrepaired.
@@ -84,7 +84,7 @@
         /// <summary>
         /// Indicates that the vehicle meets the respective emission standard.
         /// </summary>
-        Values<string, Uri>? MeetsEmissionStandard { get; set; }
+        Values<string, Uri> MeetsEmissionStandard { get; set; }
 
         /// <summary>
         /// The total distance travelled by the particular vehicle since its initial production, as read from its odometer.&lt;br/&gt;&lt;br/&gt;
@@ -95,36 +95,36 @@
         /// <summary>
         /// The release date of a vehicle model (often used to differentiate versions of the same make and model).
         /// </summary>
-        Values<int?, DateTime?>? ModelDate { get; set; }
+        Values<int?, DateTime?> ModelDate { get; set; }
 
         /// <summary>
         /// The number or type of airbags in the vehicle.
         /// </summary>
-        Values<int?, string>? NumberOfAirbags { get; set; }
+        Values<int?, string> NumberOfAirbags { get; set; }
 
         /// <summary>
         /// The number of axles.&lt;br/&gt;&lt;br/&gt;
         /// Typical unit code(s): C62
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumberOfAxles { get; set; }
+        Values<int?, IQuantitativeValue> NumberOfAxles { get; set; }
 
         /// <summary>
         /// The number of doors.&lt;br/&gt;&lt;br/&gt;
         /// Typical unit code(s): C62
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumberOfDoors { get; set; }
+        Values<int?, IQuantitativeValue> NumberOfDoors { get; set; }
 
         /// <summary>
         /// The total number of forward gears available for the transmission system of the vehicle.&lt;br/&gt;&lt;br/&gt;
         /// Typical unit code(s): C62
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumberOfForwardGears { get; set; }
+        Values<int?, IQuantitativeValue> NumberOfForwardGears { get; set; }
 
         /// <summary>
         /// The number of owners of the vehicle, including the current one.&lt;br/&gt;&lt;br/&gt;
         /// Typical unit code(s): C62
         /// </summary>
-        Values<int?, IQuantitativeValue>? NumberOfPreviousOwners { get; set; }
+        Values<int?, IQuantitativeValue> NumberOfPreviousOwners { get; set; }
 
         /// <summary>
         /// The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle.&lt;br/&gt;&lt;br/&gt;
@@ -142,7 +142,7 @@
         /// The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.&lt;br/&gt;&lt;br/&gt;
         /// Typical unit code(s): C62 for persons
         /// </summary>
-        Values<double?, IQuantitativeValue>? SeatingCapacity { get; set; }
+        Values<double?, IQuantitativeValue> SeatingCapacity { get; set; }
 
         /// <summary>
         /// The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by &lt;a class="localLink" href="http://schema.org/maxValue"&gt;maxValue&lt;/a&gt; should be the maximum speed achievable under regular conditions.&lt;br/&gt;&lt;br/&gt;
@@ -210,23 +210,23 @@
         /// <summary>
         /// The release date of a vehicle model (often used to differentiate versions of the same make and model).
         /// </summary>
-        Values<int?, DateTime?>? VehicleModelDate { get; set; }
+        Values<int?, DateTime?> VehicleModelDate { get; set; }
 
         /// <summary>
         /// The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.&lt;br/&gt;&lt;br/&gt;
         /// Typical unit code(s): C62 for persons.
         /// </summary>
-        Values<double?, IQuantitativeValue>? VehicleSeatingCapacity { get; set; }
+        Values<double?, IQuantitativeValue> VehicleSeatingCapacity { get; set; }
 
         /// <summary>
         /// Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale.
         /// </summary>
-        Values<CarUsageType?, string>? VehicleSpecialUsage { get; set; }
+        Values<CarUsageType?, string> VehicleSpecialUsage { get; set; }
 
         /// <summary>
         /// The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) ("gearbox" for cars).
         /// </summary>
-        Values<string, Uri>? VehicleTransmission { get; set; }
+        Values<string, Uri> VehicleTransmission { get; set; }
 
         /// <summary>
         /// The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.&lt;br/&gt;&lt;br/&gt;
@@ -274,7 +274,7 @@
         /// </summary>
         [DataMember(Name = "bodyType", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? BodyType { get; set; }
+        public Values<string, Uri> BodyType { get; set; }
 
         /// <summary>
         /// The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.&lt;br/&gt;&lt;br/&gt;
@@ -290,14 +290,14 @@
         /// </summary>
         [DataMember(Name = "dateVehicleFirstRegistered", Order = 209)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DateVehicleFirstRegistered { get; set; }
+        public Values<int?, DateTime?> DateVehicleFirstRegistered { get; set; }
 
         /// <summary>
         /// The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain.
         /// </summary>
         [DataMember(Name = "driveWheelConfiguration", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DriveWheelConfigurationValue?, string>? DriveWheelConfiguration { get; set; }
+        public Values<DriveWheelConfigurationValue?, string> DriveWheelConfiguration { get; set; }
 
         /// <summary>
         /// The CO2 emissions in g/km. When used in combination with a QuantitativeValue, put "g/km" into the unitText property of that value, since there is no UN/CEFACT Common Code for "g/km".
@@ -343,7 +343,7 @@
         /// </summary>
         [DataMember(Name = "fuelType", Order = 215)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? FuelType { get; set; }
+        public Values<string, Uri> FuelType { get; set; }
 
         /// <summary>
         /// A textual description of known damages, both repaired and unrepaired.
@@ -357,7 +357,7 @@
         /// </summary>
         [DataMember(Name = "meetsEmissionStandard", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? MeetsEmissionStandard { get; set; }
+        public Values<string, Uri> MeetsEmissionStandard { get; set; }
 
         /// <summary>
         /// The total distance travelled by the particular vehicle since its initial production, as read from its odometer.&lt;br/&gt;&lt;br/&gt;
@@ -372,14 +372,14 @@
         /// </summary>
         [DataMember(Name = "modelDate", Order = 219)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? ModelDate { get; set; }
+        public Values<int?, DateTime?> ModelDate { get; set; }
 
         /// <summary>
         /// The number or type of airbags in the vehicle.
         /// </summary>
         [DataMember(Name = "numberOfAirbags", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? NumberOfAirbags { get; set; }
+        public Values<int?, string> NumberOfAirbags { get; set; }
 
         /// <summary>
         /// The number of axles.&lt;br/&gt;&lt;br/&gt;
@@ -387,7 +387,7 @@
         /// </summary>
         [DataMember(Name = "numberOfAxles", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumberOfAxles { get; set; }
+        public Values<int?, IQuantitativeValue> NumberOfAxles { get; set; }
 
         /// <summary>
         /// The number of doors.&lt;br/&gt;&lt;br/&gt;
@@ -395,7 +395,7 @@
         /// </summary>
         [DataMember(Name = "numberOfDoors", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumberOfDoors { get; set; }
+        public Values<int?, IQuantitativeValue> NumberOfDoors { get; set; }
 
         /// <summary>
         /// The total number of forward gears available for the transmission system of the vehicle.&lt;br/&gt;&lt;br/&gt;
@@ -403,7 +403,7 @@
         /// </summary>
         [DataMember(Name = "numberOfForwardGears", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumberOfForwardGears { get; set; }
+        public Values<int?, IQuantitativeValue> NumberOfForwardGears { get; set; }
 
         /// <summary>
         /// The number of owners of the vehicle, including the current one.&lt;br/&gt;&lt;br/&gt;
@@ -411,7 +411,7 @@
         /// </summary>
         [DataMember(Name = "numberOfPreviousOwners", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumberOfPreviousOwners { get; set; }
+        public Values<int?, IQuantitativeValue> NumberOfPreviousOwners { get; set; }
 
         /// <summary>
         /// The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle.&lt;br/&gt;&lt;br/&gt;
@@ -432,14 +432,14 @@
         /// </summary>
         [DataMember(Name = "productionDate", Order = 226)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public override Values<int?, DateTime?>? ProductionDate { get; set; }
+        public override Values<int?, DateTime?> ProductionDate { get; set; }
 
         /// <summary>
         /// The date the item e.g. vehicle was purchased by the current owner.
         /// </summary>
         [DataMember(Name = "purchaseDate", Order = 227)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public override Values<int?, DateTime?>? PurchaseDate { get; set; }
+        public override Values<int?, DateTime?> PurchaseDate { get; set; }
 
         /// <summary>
         /// The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.&lt;br/&gt;&lt;br/&gt;
@@ -447,7 +447,7 @@
         /// </summary>
         [DataMember(Name = "seatingCapacity", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, IQuantitativeValue>? SeatingCapacity { get; set; }
+        public Values<double?, IQuantitativeValue> SeatingCapacity { get; set; }
 
         /// <summary>
         /// The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by &lt;a class="localLink" href="http://schema.org/maxValue"&gt;maxValue&lt;/a&gt; should be the maximum speed achievable under regular conditions.&lt;br/&gt;&lt;br/&gt;
@@ -537,7 +537,7 @@
         /// </summary>
         [DataMember(Name = "vehicleModelDate", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? VehicleModelDate { get; set; }
+        public Values<int?, DateTime?> VehicleModelDate { get; set; }
 
         /// <summary>
         /// The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.&lt;br/&gt;&lt;br/&gt;
@@ -545,21 +545,21 @@
         /// </summary>
         [DataMember(Name = "vehicleSeatingCapacity", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, IQuantitativeValue>? VehicleSeatingCapacity { get; set; }
+        public Values<double?, IQuantitativeValue> VehicleSeatingCapacity { get; set; }
 
         /// <summary>
         /// Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale.
         /// </summary>
         [DataMember(Name = "vehicleSpecialUsage", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<CarUsageType?, string>? VehicleSpecialUsage { get; set; }
+        public Values<CarUsageType?, string> VehicleSpecialUsage { get; set; }
 
         /// <summary>
         /// The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) ("gearbox" for cars).
         /// </summary>
         [DataMember(Name = "vehicleTransmission", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? VehicleTransmission { get; set; }
+        public Values<string, Uri> VehicleTransmission { get; set; }
 
         /// <summary>
         /// The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.&lt;br/&gt;&lt;br/&gt;

--- a/Source/Schema.NET/core/Vein.cs
+++ b/Source/Schema.NET/core/Vein.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The anatomical or organ system drained by this vessel; generally refers to a specific part of an organ.
         /// </summary>
-        Values<IAnatomicalStructure, IAnatomicalSystem>? RegionDrained { get; set; }
+        Values<IAnatomicalStructure, IAnatomicalSystem> RegionDrained { get; set; }
 
         /// <summary>
         /// The anatomical or organ system that the vein flows into; a larger structure that the vein connects to.
@@ -49,7 +49,7 @@
         /// </summary>
         [DataMember(Name = "regionDrained", Order = 407)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, IAnatomicalSystem>? RegionDrained { get; set; }
+        public Values<IAnatomicalStructure, IAnatomicalSystem> RegionDrained { get; set; }
 
         /// <summary>
         /// The anatomical or organ system that the vein flows into; a larger structure that the vein connects to.

--- a/Source/Schema.NET/core/VideoGame.cs
+++ b/Source/Schema.NET/core/VideoGame.cs
@@ -27,7 +27,7 @@
         /// <summary>
         /// The electronic systems used to play &lt;a href="http://en.wikipedia.org/wiki/Category:Video_game_platforms"&gt;video games&lt;/a&gt;.
         /// </summary>
-        Values<string, IThing, Uri>? GamePlatform { get; set; }
+        Values<string, IThing, Uri> GamePlatform { get; set; }
 
         /// <summary>
         /// The server on which  it is possible to play the game.
@@ -42,7 +42,7 @@
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// Indicates whether this game is multi-player, co-op or single-player.  The game can be marked as multi-player, co-op and single-player at the same time.
@@ -93,7 +93,7 @@
         /// </summary>
         [DataMember(Name = "gamePlatform", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IThing, Uri>? GamePlatform { get; set; }
+        public Values<string, IThing, Uri> GamePlatform { get; set; }
 
         /// <summary>
         /// The server on which  it is possible to play the game.
@@ -114,7 +114,7 @@
         /// </summary>
         [DataMember(Name = "musicBy", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// Indicates whether this game is multi-player, co-op or single-player.  The game can be marked as multi-player, co-op and single-player at the same time.

--- a/Source/Schema.NET/core/VideoGameSeries.cs
+++ b/Source/Schema.NET/core/VideoGameSeries.cs
@@ -47,17 +47,17 @@
         /// <summary>
         /// Real or fictional location of the game (or part of game).
         /// </summary>
-        Values<IPlace, IPostalAddress, Uri>? GameLocation { get; set; }
+        Values<IPlace, IPostalAddress, Uri> GameLocation { get; set; }
 
         /// <summary>
         /// The electronic systems used to play &lt;a href="http://en.wikipedia.org/wiki/Category:Video_game_platforms"&gt;video games&lt;/a&gt;.
         /// </summary>
-        Values<string, IThing, Uri>? GamePlatform { get; set; }
+        Values<string, IThing, Uri> GamePlatform { get; set; }
 
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The number of episodes in this season or series.
@@ -161,21 +161,21 @@
         /// </summary>
         [DataMember(Name = "gameLocation", Order = 413)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPlace, IPostalAddress, Uri>? GameLocation { get; set; }
+        public Values<IPlace, IPostalAddress, Uri> GameLocation { get; set; }
 
         /// <summary>
         /// The electronic systems used to play &lt;a href="http://en.wikipedia.org/wiki/Category:Video_game_platforms"&gt;video games&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "gamePlatform", Order = 414)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IThing, Uri>? GamePlatform { get; set; }
+        public Values<string, IThing, Uri> GamePlatform { get; set; }
 
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
         [DataMember(Name = "musicBy", Order = 415)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// The number of episodes in this season or series.

--- a/Source/Schema.NET/core/VideoObject.cs
+++ b/Source/Schema.NET/core/VideoObject.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The caption for this object. For downloadable machine formats (closed caption, subtitles etc.) use MediaObject and indicate the &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt;.
         /// </summary>
-        Values<IMediaObject, string>? Caption { get; set; }
+        Values<IMediaObject, string> Caption { get; set; }
 
         /// <summary>
         /// A director of e.g. tv, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip.
@@ -27,7 +27,7 @@
         /// <summary>
         /// The composer of the soundtrack.
         /// </summary>
-        Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// Thumbnail image for an image or video.
@@ -74,7 +74,7 @@
         /// </summary>
         [DataMember(Name = "caption", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMediaObject, string>? Caption { get; set; }
+        public Values<IMediaObject, string> Caption { get; set; }
 
         /// <summary>
         /// A director of e.g. tv, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip.
@@ -88,7 +88,7 @@
         /// </summary>
         [DataMember(Name = "musicBy", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMusicGroup, IPerson>? MusicBy { get; set; }
+        public Values<IMusicGroup, IPerson> MusicBy { get; set; }
 
         /// <summary>
         /// Thumbnail image for an image or video.

--- a/Source/Schema.NET/core/VisualArtwork.cs
+++ b/Source/Schema.NET/core/VisualArtwork.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// The number of copies when multiple copies of a piece of artwork are produced - e.g. for a limited edition of 20 prints, 'artEdition' refers to the total number of copies (in this example "20").
         /// </summary>
-        Values<int?, string>? ArtEdition { get; set; }
+        Values<int?, string> ArtEdition { get; set; }
 
         /// <summary>
         /// e.g. Painting, Drawing, Sculpture, Print, Photograph, Assemblage, Collage, etc.
         /// </summary>
-        Values<string, Uri>? Artform { get; set; }
+        Values<string, Uri> Artform { get; set; }
 
         /// <summary>
         /// The primary artist for a work
@@ -29,12 +29,12 @@
         /// <summary>
         /// The material used. (e.g. Oil, Watercolour, Acrylic, Linoprint, Marble, Cyanotype, Digital, Lithograph, DryPoint, Intaglio, Pastel, Woodcut, Pencil, Mixed Media, etc.)
         /// </summary>
-        Values<string, Uri>? ArtMedium { get; set; }
+        Values<string, Uri> ArtMedium { get; set; }
 
         /// <summary>
         /// The supporting materials for the artwork, e.g. Canvas, Paper, Wood, Board, etc.
         /// </summary>
-        Values<string, Uri>? ArtworkSurface { get; set; }
+        Values<string, Uri> ArtworkSurface { get; set; }
 
         /// <summary>
         /// The individual who adds color to inked drawings.
@@ -44,12 +44,12 @@
         /// <summary>
         /// The depth of the item.
         /// </summary>
-        Values<string, IQuantitativeValue>? Depth { get; set; }
+        Values<string, IQuantitativeValue> Depth { get; set; }
 
         /// <summary>
         /// The height of the item.
         /// </summary>
-        Values<string, IQuantitativeValue>? Height { get; set; }
+        Values<string, IQuantitativeValue> Height { get; set; }
 
         /// <summary>
         /// The individual who traces over the pencil drawings in ink after pencils are complete.
@@ -69,7 +69,7 @@
         /// <summary>
         /// The width of the item.
         /// </summary>
-        Values<string, IQuantitativeValue>? Width { get; set; }
+        Values<string, IQuantitativeValue> Width { get; set; }
     }
 
     /// <summary>
@@ -89,14 +89,14 @@
         /// </summary>
         [DataMember(Name = "artEdition", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? ArtEdition { get; set; }
+        public Values<int?, string> ArtEdition { get; set; }
 
         /// <summary>
         /// e.g. Painting, Drawing, Sculpture, Print, Photograph, Assemblage, Collage, etc.
         /// </summary>
         [DataMember(Name = "artform", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Artform { get; set; }
+        public Values<string, Uri> Artform { get; set; }
 
         /// <summary>
         /// The primary artist for a work
@@ -112,14 +112,14 @@
         /// </summary>
         [DataMember(Name = "artMedium", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ArtMedium { get; set; }
+        public Values<string, Uri> ArtMedium { get; set; }
 
         /// <summary>
         /// The supporting materials for the artwork, e.g. Canvas, Paper, Wood, Board, etc.
         /// </summary>
         [DataMember(Name = "artworkSurface", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ArtworkSurface { get; set; }
+        public Values<string, Uri> ArtworkSurface { get; set; }
 
         /// <summary>
         /// The individual who adds color to inked drawings.
@@ -133,14 +133,14 @@
         /// </summary>
         [DataMember(Name = "depth", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue>? Depth { get; set; }
+        public Values<string, IQuantitativeValue> Depth { get; set; }
 
         /// <summary>
         /// The height of the item.
         /// </summary>
         [DataMember(Name = "height", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue>? Height { get; set; }
+        public Values<string, IQuantitativeValue> Height { get; set; }
 
         /// <summary>
         /// The individual who traces over the pencil drawings in ink after pencils are complete.
@@ -168,6 +168,6 @@
         /// </summary>
         [DataMember(Name = "width", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, IQuantitativeValue>? Width { get; set; }
+        public Values<string, IQuantitativeValue> Width { get; set; }
     }
 }

--- a/Source/Schema.NET/core/WebPage.cs
+++ b/Source/Schema.NET/core/WebPage.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// A set of links that can help a user understand and navigate a website hierarchy.
         /// </summary>
-        Values<IBreadcrumbList, string>? Breadcrumb { get; set; }
+        Values<IBreadcrumbList, string> Breadcrumb { get; set; }
 
         /// <summary>
         /// Date on which the content on this web page was last reviewed for accuracy and/or completeness.
         /// </summary>
-        Values<int?, DateTime?>? LastReviewed { get; set; }
+        Values<int?, DateTime?> LastReviewed { get; set; }
 
         /// <summary>
         /// Indicates if this web page element is the main subject of the page.
@@ -37,7 +37,7 @@
         /// <summary>
         /// People or organizations that have reviewed the content on this web page for accuracy and/or completeness.
         /// </summary>
-        Values<IOrganization, IPerson>? ReviewedBy { get; set; }
+        Values<IOrganization, IPerson> ReviewedBy { get; set; }
 
         /// <summary>
         /// One of the more significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most.
@@ -53,7 +53,7 @@
         /// For more sophisticated markup of speakable sections beyond simple ID references, either CSS selectors or XPath expressions to pick out document section(s) as speakable. For this
         /// we define a supporting type, &lt;a class="localLink" href="http://schema.org/SpeakableSpecification"&gt;SpeakableSpecification&lt;/a&gt;  which is defined to be a possible value of the &lt;em&gt;speakable&lt;/em&gt; property.
         /// </summary>
-        Values<ISpeakableSpecification, Uri>? Speakable { get; set; }
+        Values<ISpeakableSpecification, Uri> Speakable { get; set; }
 
         /// <summary>
         /// One of the domain specialities to which this web page's content applies.
@@ -78,14 +78,14 @@
         /// </summary>
         [DataMember(Name = "breadcrumb", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IBreadcrumbList, string>? Breadcrumb { get; set; }
+        public Values<IBreadcrumbList, string> Breadcrumb { get; set; }
 
         /// <summary>
         /// Date on which the content on this web page was last reviewed for accuracy and/or completeness.
         /// </summary>
         [DataMember(Name = "lastReviewed", Order = 207)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? LastReviewed { get; set; }
+        public Values<int?, DateTime?> LastReviewed { get; set; }
 
         /// <summary>
         /// Indicates if this web page element is the main subject of the page.
@@ -113,7 +113,7 @@
         /// </summary>
         [DataMember(Name = "reviewedBy", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? ReviewedBy { get; set; }
+        public Values<IOrganization, IPerson> ReviewedBy { get; set; }
 
         /// <summary>
         /// One of the more significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most.
@@ -133,7 +133,7 @@
         /// </summary>
         [DataMember(Name = "speakable", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ISpeakableSpecification, Uri>? Speakable { get; set; }
+        public Values<ISpeakableSpecification, Uri> Speakable { get; set; }
 
         /// <summary>
         /// One of the domain specialities to which this web page's content applies.

--- a/Source/Schema.NET/core/WriteAction.cs
+++ b/Source/Schema.NET/core/WriteAction.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        Values<ILanguage, string>? InLanguage { get; set; }
+        Values<ILanguage, string> InLanguage { get; set; }
     }
 
     /// <summary>
@@ -32,6 +32,6 @@
         /// </summary>
         [DataMember(Name = "inLanguage", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
     }
 }

--- a/Source/Schema.NET/core/combined/BankAccountAndInvestmentOrDeposit.cs
+++ b/Source/Schema.NET/core/combined/BankAccountAndInvestmentOrDeposit.cs
@@ -42,13 +42,13 @@
         /// </summary>
         [DataMember(Name = "amount", Order = 408)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMonetaryAmount, decimal?>? Amount { get; set; }
+        public Values<IMonetaryAmount, decimal?> Amount { get; set; }
 
         /// <summary>
         /// The type of a bank account.
         /// </summary>
         [DataMember(Name = "bankAccountType", Order = 409)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? BankAccountType { get; set; }
+        public Values<string, Uri> BankAccountType { get; set; }
     }
 }

--- a/Source/Schema.NET/core/combined/CivicStructureAndEmergencyService.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndEmergencyService.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, EmergencyService for more information.
     /// </summary>
-    public partial interface ICivicStructureAndEmergencyService : ICivicStructure, IEmergencyService
+    public partial interface ICivicStructureAndEmergencyService : IEmergencyService, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CivicStructureAndEmergencyServiceAndMedicalOrganization.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndEmergencyServiceAndMedicalOrganization.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, EmergencyService, MedicalOrganization for more information.
     /// </summary>
-    public partial interface ICivicStructureAndEmergencyServiceAndMedicalOrganization : ICivicStructure, IEmergencyService, IMedicalOrganization
+    public partial interface ICivicStructureAndEmergencyServiceAndMedicalOrganization : IEmergencyService, IMedicalOrganization, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CivicStructureAndEntertainmentBusiness.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndEntertainmentBusiness.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, EntertainmentBusiness for more information.
     /// </summary>
-    public partial interface ICivicStructureAndEntertainmentBusiness : ICivicStructure, IEntertainmentBusiness
+    public partial interface ICivicStructureAndEntertainmentBusiness : IEntertainmentBusiness, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CivicStructureAndLodgingBusiness.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndLodgingBusiness.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, LodgingBusiness for more information.
     /// </summary>
-    public partial interface ICivicStructureAndLodgingBusiness : ICivicStructure, ILodgingBusiness
+    public partial interface ICivicStructureAndLodgingBusiness : ILodgingBusiness, ICivicStructure
     {
     }
 
@@ -42,21 +42,21 @@
         /// </summary>
         [DataMember(Name = "availableLanguage", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? AvailableLanguage { get; set; }
+        public Values<ILanguage, string> AvailableLanguage { get; set; }
 
         /// <summary>
         /// The earliest someone may check into a lodging establishment.
         /// </summary>
         [DataMember(Name = "checkinTime", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> CheckinTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> CheckinTime { get; set; }
 
         /// <summary>
         /// The latest someone may check out of a lodging establishment.
         /// </summary>
         [DataMember(Name = "checkoutTime", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DateTimeOffset?> CheckoutTime { get; set; }
+        public Values<DateTimeOffset?, TimeSpan?> CheckoutTime { get; set; }
 
         /// <summary>
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
@@ -64,7 +64,7 @@
         /// </summary>
         [DataMember(Name = "numberOfRooms", Order = 311)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, IQuantitativeValue>? NumberOfRooms { get; set; }
+        public Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.&lt;br/&gt;&lt;br/&gt;
@@ -84,7 +84,7 @@
         /// </summary>
         [DataMember(Name = "petsAllowed", Order = 313)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<bool?, string>? PetsAllowed { get; set; }
+        public Values<bool?, string> PetsAllowed { get; set; }
 
         /// <summary>
         /// An official rating for a lodging business or food establishment, e.g. from national associations or standards bodies. Use the author property to indicate the rating organization, e.g. as an Organization with name such as (e.g. HOTREC, DEHOGA, WHR, or Hotelstars).

--- a/Source/Schema.NET/core/combined/CivicStructureAndSportsActivityLocation.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndSportsActivityLocation.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, SportsActivityLocation for more information.
     /// </summary>
-    public partial interface ICivicStructureAndSportsActivityLocation : ICivicStructure, ISportsActivityLocation
+    public partial interface ICivicStructureAndSportsActivityLocation : ISportsActivityLocation, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CreativeWorkAndItemListAndListItem.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndItemListAndListItem.cs
@@ -77,7 +77,7 @@
         /// </summary>
         [DataMember(Name = "accessModeSufficient", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> AccessModeSufficient { get; set; }
+        public OneOrMany<IItemList> AccessModeSufficient { get; set; }
 
         /// <summary>
         /// Specifies the Person that is legally accountable for the CreativeWork.
@@ -119,14 +119,14 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip>? Audio { get; set; }
+        public Values<IAudioObject, IClip> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
         [DataMember(Name = "author", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Author { get; set; }
+        public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -147,7 +147,7 @@
         /// </summary>
         [DataMember(Name = "citation", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, string>? Citation { get; set; }
+        public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
@@ -164,114 +164,129 @@
         public OneOrMany<int?> CommentCount { get; set; }
 
         /// <summary>
+        /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
+        /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+        /// </summary>
+        [DataMember(Name = "conditionsOfAccess", Order = 226)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> ConditionsOfAccess { get; set; }
+
+        /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 226)]
+        [DataMember(Name = "contentLocation", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 227)]
+        [DataMember(Name = "contentRating", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IRating, string>? ContentRating { get; set; }
+        public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 228)]
+        [DataMember(Name = "contentReferenceTime", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 229)]
+        [DataMember(Name = "contributor", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Contributor { get; set; }
+        public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 230)]
+        [DataMember(Name = "copyrightHolder", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? CopyrightHolder { get; set; }
+        public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 231)]
+        [DataMember(Name = "copyrightYear", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 232)]
+        [DataMember(Name = "correction", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Correction { get; set; }
+        public Values<string, Uri> Correction { get; set; }
+
+        /// <summary>
+        /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
+        /// </summary>
+        [DataMember(Name = "creativeWorkStatus", Order = 234)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 233)]
+        [DataMember(Name = "creator", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Creator { get; set; }
+        public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 234)]
+        [DataMember(Name = "dateCreated", Order = 236)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 235)]
+        [DataMember(Name = "dateModified", Order = 237)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 236)]
+        [DataMember(Name = "datePublished", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DatePublished { get; set; }
+        public Values<int?, DateTime?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 237)]
+        [DataMember(Name = "discussionUrl", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 238)]
+        [DataMember(Name = "editor", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 239)]
+        [DataMember(Name = "educationalAlignment", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 240)]
+        [DataMember(Name = "educationalUse", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 241)]
+        [DataMember(Name = "encoding", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -280,105 +295,105 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 242)]
+        [DataMember(Name = "encodingFormat", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? EncodingFormat { get; set; }
+        public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 243)]
+        [DataMember(Name = "exampleOfWork", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 244)]
+        [DataMember(Name = "expires", Order = 246)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? Expires { get; set; }
+        public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 245)]
+        [DataMember(Name = "funder", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 246)]
+        [DataMember(Name = "genre", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 247)]
+        [DataMember(Name = "hasPart", Order = 249)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 248)]
+        [DataMember(Name = "headline", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 249)]
+        [DataMember(Name = "inLanguage", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 250)]
+        [DataMember(Name = "interactionStatistic", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 251)]
+        [DataMember(Name = "interactivityType", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 252)]
+        [DataMember(Name = "isAccessibleForFree", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 253)]
+        [DataMember(Name = "isBasedOn", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IProduct, Uri>? IsBasedOn { get; set; }
+        public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 254)]
+        [DataMember(Name = "isFamilyFriendly", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 255)]
+        [DataMember(Name = "isPartOf", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> IsPartOf { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.
         /// </summary>
-        [DataMember(Name = "item", Order = 256)]
+        [DataMember(Name = "item", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Item { get; set; }
 
@@ -387,140 +402,140 @@
         /// Text values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.&lt;br/&gt;&lt;br/&gt;
         /// Note: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases.
         /// </summary>
-        [DataMember(Name = "itemListElement", Order = 257)]
+        [DataMember(Name = "itemListElement", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IListItem, string, IThing>? ItemListElement { get; set; }
+        public Values<IListItem, string, IThing> ItemListElement { get; set; }
 
         /// <summary>
         /// Type of ordering (e.g. Ascending, Descending, Unordered).
         /// </summary>
-        [DataMember(Name = "itemListOrder", Order = 258)]
+        [DataMember(Name = "itemListOrder", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ItemListOrderType?, string>? ItemListOrder { get; set; }
+        public Values<ItemListOrderType?, string> ItemListOrder { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 259)]
+        [DataMember(Name = "keywords", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 260)]
+        [DataMember(Name = "learningResourceType", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 261)]
+        [DataMember(Name = "license", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? License { get; set; }
+        public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 262)]
+        [DataMember(Name = "locationCreated", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 263)]
+        [DataMember(Name = "mainEntity", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 264)]
+        [DataMember(Name = "material", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string, Uri>? Material { get; set; }
+        public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 265)]
+        [DataMember(Name = "materialExtent", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? MaterialExtent { get; set; }
+        public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 266)]
+        [DataMember(Name = "mentions", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// A link to the ListItem that follows the current one.
         /// </summary>
-        [DataMember(Name = "nextItem", Order = 267)]
+        [DataMember(Name = "nextItem", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> NextItem { get; set; }
 
         /// <summary>
         /// The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list.
         /// </summary>
-        [DataMember(Name = "numberOfItems", Order = 268)]
+        [DataMember(Name = "numberOfItems", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> NumberOfItems { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
         /// </summary>
-        [DataMember(Name = "offers", Order = 269)]
+        [DataMember(Name = "offers", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 270)]
+        [DataMember(Name = "position", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? Position { get; set; }
+        public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.
         /// </summary>
-        [DataMember(Name = "previousItem", Order = 271)]
+        [DataMember(Name = "previousItem", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> PreviousItem { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 272)]
+        [DataMember(Name = "producer", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Producer { get; set; }
+        public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 273)]
+        [DataMember(Name = "provider", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 274)]
+        [DataMember(Name = "publication", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 275)]
+        [DataMember(Name = "publisher", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Publisher { get; set; }
+        public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 276)]
+        [DataMember(Name = "publisherImprint", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -528,64 +543,64 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 277)]
+        [DataMember(Name = "publishingPrinciples", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 278)]
+        [DataMember(Name = "recordedAt", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 279)]
+        [DataMember(Name = "releasedEvent", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 280)]
+        [DataMember(Name = "review", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 281)]
+        [DataMember(Name = "schemaVersion", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SchemaVersion { get; set; }
+        public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 282)]
+        [DataMember(Name = "sdDatePublished", Order = 284)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? SdDatePublished { get; set; }
+        public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 283)]
+        [DataMember(Name = "sdLicense", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? SdLicense { get; set; }
+        public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
         /// <summary>
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 284)]
+        [DataMember(Name = "sdPublisher", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? SdPublisher { get; set; }
+        public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 285)]
+        [DataMember(Name = "sourceOrganization", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -593,7 +608,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 286)]
+        [DataMember(Name = "spatial", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -602,24 +617,24 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 287)]
+        [DataMember(Name = "spatialCoverage", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 288)]
+        [DataMember(Name = "sponsor", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 289)]
+        [DataMember(Name = "temporal", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string>? Temporal { get; set; }
+        public Values<DateTimeOffset?, string> Temporal { get; set; }
 
         /// <summary>
         /// The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in &lt;a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals"&gt;ISO 8601 time interval format&lt;/a&gt;. In
@@ -627,77 +642,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 290)]
+        [DataMember(Name = "temporalCoverage", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string, Uri>? TemporalCoverage { get; set; }
+        public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 291)]
+        [DataMember(Name = "text", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 292)]
+        [DataMember(Name = "thumbnailUrl", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 293)]
+        [DataMember(Name = "timeRequired", Order = 295)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 294)]
+        [DataMember(Name = "translationOfWork", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 295)]
+        [DataMember(Name = "translator", Order = 297)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Translator { get; set; }
+        public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 296)]
+        [DataMember(Name = "typicalAgeRange", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 297)]
+        [DataMember(Name = "version", Order = 299)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Version { get; set; }
+        public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 298)]
+        [DataMember(Name = "video", Order = 300)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IClip, IVideoObject>? Video { get; set; }
+        public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 299)]
+        [DataMember(Name = "workExample", Order = 301)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 300)]
+        [DataMember(Name = "workTranslation", Order = 302)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
     }

--- a/Source/Schema.NET/core/combined/CreativeWorkAndLifestyleModification.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndLifestyleModification.cs
@@ -77,7 +77,7 @@
         /// </summary>
         [DataMember(Name = "accessModeSufficient", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> AccessModeSufficient { get; set; }
+        public OneOrMany<IItemList> AccessModeSufficient { get; set; }
 
         /// <summary>
         /// Specifies the Person that is legally accountable for the CreativeWork.
@@ -119,14 +119,14 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip>? Audio { get; set; }
+        public Values<IAudioObject, IClip> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
         [DataMember(Name = "author", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Author { get; set; }
+        public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -147,7 +147,7 @@
         /// </summary>
         [DataMember(Name = "citation", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, string>? Citation { get; set; }
+        public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
@@ -164,114 +164,129 @@
         public OneOrMany<int?> CommentCount { get; set; }
 
         /// <summary>
+        /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
+        /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+        /// </summary>
+        [DataMember(Name = "conditionsOfAccess", Order = 226)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> ConditionsOfAccess { get; set; }
+
+        /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 226)]
+        [DataMember(Name = "contentLocation", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 227)]
+        [DataMember(Name = "contentRating", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IRating, string>? ContentRating { get; set; }
+        public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 228)]
+        [DataMember(Name = "contentReferenceTime", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 229)]
+        [DataMember(Name = "contributor", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Contributor { get; set; }
+        public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 230)]
+        [DataMember(Name = "copyrightHolder", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? CopyrightHolder { get; set; }
+        public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 231)]
+        [DataMember(Name = "copyrightYear", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 232)]
+        [DataMember(Name = "correction", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Correction { get; set; }
+        public Values<string, Uri> Correction { get; set; }
+
+        /// <summary>
+        /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
+        /// </summary>
+        [DataMember(Name = "creativeWorkStatus", Order = 234)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 233)]
+        [DataMember(Name = "creator", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Creator { get; set; }
+        public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 234)]
+        [DataMember(Name = "dateCreated", Order = 236)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 235)]
+        [DataMember(Name = "dateModified", Order = 237)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 236)]
+        [DataMember(Name = "datePublished", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DatePublished { get; set; }
+        public Values<int?, DateTime?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 237)]
+        [DataMember(Name = "discussionUrl", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 238)]
+        [DataMember(Name = "editor", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 239)]
+        [DataMember(Name = "educationalAlignment", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 240)]
+        [DataMember(Name = "educationalUse", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 241)]
+        [DataMember(Name = "encoding", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -280,203 +295,203 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 242)]
+        [DataMember(Name = "encodingFormat", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? EncodingFormat { get; set; }
+        public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 243)]
+        [DataMember(Name = "exampleOfWork", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 244)]
+        [DataMember(Name = "expires", Order = 246)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? Expires { get; set; }
+        public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 245)]
+        [DataMember(Name = "funder", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 246)]
+        [DataMember(Name = "genre", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 247)]
+        [DataMember(Name = "hasPart", Order = 249)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 248)]
+        [DataMember(Name = "headline", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 249)]
+        [DataMember(Name = "inLanguage", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 250)]
+        [DataMember(Name = "interactionStatistic", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 251)]
+        [DataMember(Name = "interactivityType", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 252)]
+        [DataMember(Name = "isAccessibleForFree", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 253)]
+        [DataMember(Name = "isBasedOn", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IProduct, Uri>? IsBasedOn { get; set; }
+        public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 254)]
+        [DataMember(Name = "isFamilyFriendly", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 255)]
+        [DataMember(Name = "isPartOf", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 256)]
+        [DataMember(Name = "keywords", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 257)]
+        [DataMember(Name = "learningResourceType", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 258)]
+        [DataMember(Name = "license", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? License { get; set; }
+        public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 259)]
+        [DataMember(Name = "locationCreated", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 260)]
+        [DataMember(Name = "mainEntity", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 261)]
+        [DataMember(Name = "material", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string, Uri>? Material { get; set; }
+        public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 262)]
+        [DataMember(Name = "materialExtent", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? MaterialExtent { get; set; }
+        public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 263)]
+        [DataMember(Name = "mentions", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
         /// </summary>
-        [DataMember(Name = "offers", Order = 264)]
+        [DataMember(Name = "offers", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 265)]
+        [DataMember(Name = "position", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? Position { get; set; }
+        public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 266)]
+        [DataMember(Name = "producer", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Producer { get; set; }
+        public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 267)]
+        [DataMember(Name = "provider", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 268)]
+        [DataMember(Name = "publication", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 269)]
+        [DataMember(Name = "publisher", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Publisher { get; set; }
+        public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 270)]
+        [DataMember(Name = "publisherImprint", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -484,64 +499,64 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 271)]
+        [DataMember(Name = "publishingPrinciples", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 272)]
+        [DataMember(Name = "recordedAt", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 273)]
+        [DataMember(Name = "releasedEvent", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 274)]
+        [DataMember(Name = "review", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 275)]
+        [DataMember(Name = "schemaVersion", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SchemaVersion { get; set; }
+        public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 276)]
+        [DataMember(Name = "sdDatePublished", Order = 278)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? SdDatePublished { get; set; }
+        public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 277)]
+        [DataMember(Name = "sdLicense", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? SdLicense { get; set; }
+        public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
         /// <summary>
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 278)]
+        [DataMember(Name = "sdPublisher", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? SdPublisher { get; set; }
+        public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 279)]
+        [DataMember(Name = "sourceOrganization", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -549,7 +564,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 280)]
+        [DataMember(Name = "spatial", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -558,24 +573,24 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 281)]
+        [DataMember(Name = "spatialCoverage", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 282)]
+        [DataMember(Name = "sponsor", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 283)]
+        [DataMember(Name = "temporal", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string>? Temporal { get; set; }
+        public Values<DateTimeOffset?, string> Temporal { get; set; }
 
         /// <summary>
         /// The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in &lt;a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals"&gt;ISO 8601 time interval format&lt;/a&gt;. In
@@ -583,77 +598,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 284)]
+        [DataMember(Name = "temporalCoverage", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string, Uri>? TemporalCoverage { get; set; }
+        public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 285)]
+        [DataMember(Name = "text", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 286)]
+        [DataMember(Name = "thumbnailUrl", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 287)]
+        [DataMember(Name = "timeRequired", Order = 289)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 288)]
+        [DataMember(Name = "translationOfWork", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 289)]
+        [DataMember(Name = "translator", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Translator { get; set; }
+        public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 290)]
+        [DataMember(Name = "typicalAgeRange", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 291)]
+        [DataMember(Name = "version", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Version { get; set; }
+        public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 292)]
+        [DataMember(Name = "video", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IClip, IVideoObject>? Video { get; set; }
+        public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 293)]
+        [DataMember(Name = "workExample", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 294)]
+        [DataMember(Name = "workTranslation", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
     }

--- a/Source/Schema.NET/core/combined/CreativeWorkAndListItem.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndListItem.cs
@@ -77,7 +77,7 @@
         /// </summary>
         [DataMember(Name = "accessModeSufficient", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> AccessModeSufficient { get; set; }
+        public OneOrMany<IItemList> AccessModeSufficient { get; set; }
 
         /// <summary>
         /// Specifies the Person that is legally accountable for the CreativeWork.
@@ -119,14 +119,14 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip>? Audio { get; set; }
+        public Values<IAudioObject, IClip> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
         [DataMember(Name = "author", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Author { get; set; }
+        public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -147,7 +147,7 @@
         /// </summary>
         [DataMember(Name = "citation", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, string>? Citation { get; set; }
+        public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
@@ -164,114 +164,129 @@
         public OneOrMany<int?> CommentCount { get; set; }
 
         /// <summary>
+        /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
+        /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+        /// </summary>
+        [DataMember(Name = "conditionsOfAccess", Order = 226)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> ConditionsOfAccess { get; set; }
+
+        /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 226)]
+        [DataMember(Name = "contentLocation", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 227)]
+        [DataMember(Name = "contentRating", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IRating, string>? ContentRating { get; set; }
+        public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 228)]
+        [DataMember(Name = "contentReferenceTime", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 229)]
+        [DataMember(Name = "contributor", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Contributor { get; set; }
+        public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 230)]
+        [DataMember(Name = "copyrightHolder", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? CopyrightHolder { get; set; }
+        public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 231)]
+        [DataMember(Name = "copyrightYear", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 232)]
+        [DataMember(Name = "correction", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Correction { get; set; }
+        public Values<string, Uri> Correction { get; set; }
+
+        /// <summary>
+        /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
+        /// </summary>
+        [DataMember(Name = "creativeWorkStatus", Order = 234)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 233)]
+        [DataMember(Name = "creator", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Creator { get; set; }
+        public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 234)]
+        [DataMember(Name = "dateCreated", Order = 236)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 235)]
+        [DataMember(Name = "dateModified", Order = 237)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 236)]
+        [DataMember(Name = "datePublished", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DatePublished { get; set; }
+        public Values<int?, DateTime?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 237)]
+        [DataMember(Name = "discussionUrl", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 238)]
+        [DataMember(Name = "editor", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 239)]
+        [DataMember(Name = "educationalAlignment", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 240)]
+        [DataMember(Name = "educationalUse", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 241)]
+        [DataMember(Name = "encoding", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -280,224 +295,224 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 242)]
+        [DataMember(Name = "encodingFormat", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? EncodingFormat { get; set; }
+        public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 243)]
+        [DataMember(Name = "exampleOfWork", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 244)]
+        [DataMember(Name = "expires", Order = 246)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? Expires { get; set; }
+        public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 245)]
+        [DataMember(Name = "funder", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 246)]
+        [DataMember(Name = "genre", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 247)]
+        [DataMember(Name = "hasPart", Order = 249)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 248)]
+        [DataMember(Name = "headline", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 249)]
+        [DataMember(Name = "inLanguage", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 250)]
+        [DataMember(Name = "interactionStatistic", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 251)]
+        [DataMember(Name = "interactivityType", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 252)]
+        [DataMember(Name = "isAccessibleForFree", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 253)]
+        [DataMember(Name = "isBasedOn", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IProduct, Uri>? IsBasedOn { get; set; }
+        public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 254)]
+        [DataMember(Name = "isFamilyFriendly", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 255)]
+        [DataMember(Name = "isPartOf", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> IsPartOf { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.
         /// </summary>
-        [DataMember(Name = "item", Order = 256)]
+        [DataMember(Name = "item", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Item { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 257)]
+        [DataMember(Name = "keywords", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 258)]
+        [DataMember(Name = "learningResourceType", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 259)]
+        [DataMember(Name = "license", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? License { get; set; }
+        public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 260)]
+        [DataMember(Name = "locationCreated", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 261)]
+        [DataMember(Name = "mainEntity", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 262)]
+        [DataMember(Name = "material", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string, Uri>? Material { get; set; }
+        public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 263)]
+        [DataMember(Name = "materialExtent", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? MaterialExtent { get; set; }
+        public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 264)]
+        [DataMember(Name = "mentions", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// A link to the ListItem that follows the current one.
         /// </summary>
-        [DataMember(Name = "nextItem", Order = 265)]
+        [DataMember(Name = "nextItem", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> NextItem { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
         /// </summary>
-        [DataMember(Name = "offers", Order = 266)]
+        [DataMember(Name = "offers", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 267)]
+        [DataMember(Name = "position", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? Position { get; set; }
+        public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.
         /// </summary>
-        [DataMember(Name = "previousItem", Order = 268)]
+        [DataMember(Name = "previousItem", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> PreviousItem { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 269)]
+        [DataMember(Name = "producer", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Producer { get; set; }
+        public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 270)]
+        [DataMember(Name = "provider", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 271)]
+        [DataMember(Name = "publication", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 272)]
+        [DataMember(Name = "publisher", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Publisher { get; set; }
+        public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 273)]
+        [DataMember(Name = "publisherImprint", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -505,64 +520,64 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 274)]
+        [DataMember(Name = "publishingPrinciples", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 275)]
+        [DataMember(Name = "recordedAt", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 276)]
+        [DataMember(Name = "releasedEvent", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 277)]
+        [DataMember(Name = "review", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 278)]
+        [DataMember(Name = "schemaVersion", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SchemaVersion { get; set; }
+        public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 279)]
+        [DataMember(Name = "sdDatePublished", Order = 281)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? SdDatePublished { get; set; }
+        public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 280)]
+        [DataMember(Name = "sdLicense", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? SdLicense { get; set; }
+        public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
         /// <summary>
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 281)]
+        [DataMember(Name = "sdPublisher", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? SdPublisher { get; set; }
+        public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 282)]
+        [DataMember(Name = "sourceOrganization", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -570,7 +585,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 283)]
+        [DataMember(Name = "spatial", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -579,24 +594,24 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 284)]
+        [DataMember(Name = "spatialCoverage", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 285)]
+        [DataMember(Name = "sponsor", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 286)]
+        [DataMember(Name = "temporal", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string>? Temporal { get; set; }
+        public Values<DateTimeOffset?, string> Temporal { get; set; }
 
         /// <summary>
         /// The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in &lt;a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals"&gt;ISO 8601 time interval format&lt;/a&gt;. In
@@ -604,77 +619,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 287)]
+        [DataMember(Name = "temporalCoverage", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string, Uri>? TemporalCoverage { get; set; }
+        public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 288)]
+        [DataMember(Name = "text", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 289)]
+        [DataMember(Name = "thumbnailUrl", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 290)]
+        [DataMember(Name = "timeRequired", Order = 292)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 291)]
+        [DataMember(Name = "translationOfWork", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 292)]
+        [DataMember(Name = "translator", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Translator { get; set; }
+        public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 293)]
+        [DataMember(Name = "typicalAgeRange", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 294)]
+        [DataMember(Name = "version", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Version { get; set; }
+        public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 295)]
+        [DataMember(Name = "video", Order = 297)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IClip, IVideoObject>? Video { get; set; }
+        public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 296)]
+        [DataMember(Name = "workExample", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 297)]
+        [DataMember(Name = "workTranslation", Order = 299)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
     }

--- a/Source/Schema.NET/core/combined/CreativeWorkAndPhysicalActivity.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndPhysicalActivity.cs
@@ -77,7 +77,7 @@
         /// </summary>
         [DataMember(Name = "accessModeSufficient", Order = 313)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> AccessModeSufficient { get; set; }
+        public OneOrMany<IItemList> AccessModeSufficient { get; set; }
 
         /// <summary>
         /// Specifies the Person that is legally accountable for the CreativeWork.
@@ -105,7 +105,7 @@
         /// </summary>
         [DataMember(Name = "associatedAnatomy", Order = 317)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy>? AssociatedAnatomy { get; set; }
+        public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for encoding.
@@ -126,14 +126,14 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 320)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip>? Audio { get; set; }
+        public Values<IAudioObject, IClip> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
         [DataMember(Name = "author", Order = 321)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Author { get; set; }
+        public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -147,7 +147,7 @@
         /// </summary>
         [DataMember(Name = "category", Order = 323)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<PhysicalActivityCategory?, string, IThing>? Category { get; set; }
+        public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// Fictional person connected with a creative work.
@@ -161,7 +161,7 @@
         /// </summary>
         [DataMember(Name = "citation", Order = 325)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, string>? Citation { get; set; }
+        public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
@@ -178,114 +178,129 @@
         public OneOrMany<int?> CommentCount { get; set; }
 
         /// <summary>
+        /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
+        /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+        /// </summary>
+        [DataMember(Name = "conditionsOfAccess", Order = 328)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> ConditionsOfAccess { get; set; }
+
+        /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 328)]
+        [DataMember(Name = "contentLocation", Order = 329)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 329)]
+        [DataMember(Name = "contentRating", Order = 330)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IRating, string>? ContentRating { get; set; }
+        public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 330)]
+        [DataMember(Name = "contentReferenceTime", Order = 331)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 331)]
+        [DataMember(Name = "contributor", Order = 332)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Contributor { get; set; }
+        public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 332)]
+        [DataMember(Name = "copyrightHolder", Order = 333)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? CopyrightHolder { get; set; }
+        public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 333)]
+        [DataMember(Name = "copyrightYear", Order = 334)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 334)]
+        [DataMember(Name = "correction", Order = 335)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Correction { get; set; }
+        public Values<string, Uri> Correction { get; set; }
+
+        /// <summary>
+        /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
+        /// </summary>
+        [DataMember(Name = "creativeWorkStatus", Order = 336)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 335)]
+        [DataMember(Name = "creator", Order = 337)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Creator { get; set; }
+        public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 336)]
+        [DataMember(Name = "dateCreated", Order = 338)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 337)]
+        [DataMember(Name = "dateModified", Order = 339)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 338)]
+        [DataMember(Name = "datePublished", Order = 340)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DatePublished { get; set; }
+        public Values<int?, DateTime?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 339)]
+        [DataMember(Name = "discussionUrl", Order = 341)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 340)]
+        [DataMember(Name = "editor", Order = 342)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 341)]
+        [DataMember(Name = "educationalAlignment", Order = 343)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 342)]
+        [DataMember(Name = "educationalUse", Order = 344)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 343)]
+        [DataMember(Name = "encoding", Order = 345)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -294,217 +309,217 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 344)]
+        [DataMember(Name = "encodingFormat", Order = 346)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? EncodingFormat { get; set; }
+        public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// The characteristics of associated patients, such as age, gender, race etc.
         /// </summary>
-        [DataMember(Name = "epidemiology", Order = 345)]
+        [DataMember(Name = "epidemiology", Order = 347)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Epidemiology { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 346)]
+        [DataMember(Name = "exampleOfWork", Order = 348)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 347)]
+        [DataMember(Name = "expires", Order = 349)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? Expires { get; set; }
+        public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 348)]
+        [DataMember(Name = "funder", Order = 350)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 349)]
+        [DataMember(Name = "genre", Order = 351)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 350)]
+        [DataMember(Name = "hasPart", Order = 352)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 351)]
+        [DataMember(Name = "headline", Order = 353)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 352)]
+        [DataMember(Name = "inLanguage", Order = 354)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 353)]
+        [DataMember(Name = "interactionStatistic", Order = 355)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 354)]
+        [DataMember(Name = "interactivityType", Order = 356)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 355)]
+        [DataMember(Name = "isAccessibleForFree", Order = 357)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 356)]
+        [DataMember(Name = "isBasedOn", Order = 358)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IProduct, Uri>? IsBasedOn { get; set; }
+        public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 357)]
+        [DataMember(Name = "isFamilyFriendly", Order = 359)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 358)]
+        [DataMember(Name = "isPartOf", Order = 360)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 359)]
+        [DataMember(Name = "keywords", Order = 361)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 360)]
+        [DataMember(Name = "learningResourceType", Order = 362)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 361)]
+        [DataMember(Name = "license", Order = 363)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? License { get; set; }
+        public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 362)]
+        [DataMember(Name = "locationCreated", Order = 364)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 363)]
+        [DataMember(Name = "mainEntity", Order = 365)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 364)]
+        [DataMember(Name = "material", Order = 366)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string, Uri>? Material { get; set; }
+        public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 365)]
+        [DataMember(Name = "materialExtent", Order = 367)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? MaterialExtent { get; set; }
+        public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 366)]
+        [DataMember(Name = "mentions", Order = 368)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
         /// </summary>
-        [DataMember(Name = "offers", Order = 367)]
+        [DataMember(Name = "offers", Order = 369)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> Offers { get; set; }
 
         /// <summary>
         /// Changes in the normal mechanical, physical, and biochemical functions that are associated with this activity or condition.
         /// </summary>
-        [DataMember(Name = "pathophysiology", Order = 368)]
+        [DataMember(Name = "pathophysiology", Order = 370)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Pathophysiology { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 369)]
+        [DataMember(Name = "position", Order = 371)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? Position { get; set; }
+        public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 370)]
+        [DataMember(Name = "producer", Order = 372)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Producer { get; set; }
+        public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 371)]
+        [DataMember(Name = "provider", Order = 373)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 372)]
+        [DataMember(Name = "publication", Order = 374)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 373)]
+        [DataMember(Name = "publisher", Order = 375)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Publisher { get; set; }
+        public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 374)]
+        [DataMember(Name = "publisherImprint", Order = 376)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -512,64 +527,64 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 375)]
+        [DataMember(Name = "publishingPrinciples", Order = 377)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 376)]
+        [DataMember(Name = "recordedAt", Order = 378)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 377)]
+        [DataMember(Name = "releasedEvent", Order = 379)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 378)]
+        [DataMember(Name = "review", Order = 380)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 379)]
+        [DataMember(Name = "schemaVersion", Order = 381)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SchemaVersion { get; set; }
+        public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 380)]
+        [DataMember(Name = "sdDatePublished", Order = 382)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? SdDatePublished { get; set; }
+        public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 381)]
+        [DataMember(Name = "sdLicense", Order = 383)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? SdLicense { get; set; }
+        public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
         /// <summary>
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 382)]
+        [DataMember(Name = "sdPublisher", Order = 384)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? SdPublisher { get; set; }
+        public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 383)]
+        [DataMember(Name = "sourceOrganization", Order = 385)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -577,7 +592,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 384)]
+        [DataMember(Name = "spatial", Order = 386)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -586,24 +601,24 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 385)]
+        [DataMember(Name = "spatialCoverage", Order = 387)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 386)]
+        [DataMember(Name = "sponsor", Order = 388)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 387)]
+        [DataMember(Name = "temporal", Order = 389)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string>? Temporal { get; set; }
+        public Values<DateTimeOffset?, string> Temporal { get; set; }
 
         /// <summary>
         /// The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in &lt;a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals"&gt;ISO 8601 time interval format&lt;/a&gt;. In
@@ -611,77 +626,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 388)]
+        [DataMember(Name = "temporalCoverage", Order = 390)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string, Uri>? TemporalCoverage { get; set; }
+        public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 389)]
+        [DataMember(Name = "text", Order = 391)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 390)]
+        [DataMember(Name = "thumbnailUrl", Order = 392)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 391)]
+        [DataMember(Name = "timeRequired", Order = 393)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 392)]
+        [DataMember(Name = "translationOfWork", Order = 394)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 393)]
+        [DataMember(Name = "translator", Order = 395)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Translator { get; set; }
+        public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 394)]
+        [DataMember(Name = "typicalAgeRange", Order = 396)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 395)]
+        [DataMember(Name = "version", Order = 397)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Version { get; set; }
+        public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 396)]
+        [DataMember(Name = "video", Order = 398)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IClip, IVideoObject>? Video { get; set; }
+        public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 397)]
+        [DataMember(Name = "workExample", Order = 399)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 398)]
+        [DataMember(Name = "workTranslation", Order = 400)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
     }

--- a/Source/Schema.NET/core/combined/CreativeWorkAndSeries.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndSeries.cs
@@ -77,7 +77,7 @@
         /// </summary>
         [DataMember(Name = "accessModeSufficient", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> AccessModeSufficient { get; set; }
+        public OneOrMany<IItemList> AccessModeSufficient { get; set; }
 
         /// <summary>
         /// Specifies the Person that is legally accountable for the CreativeWork.
@@ -119,14 +119,14 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip>? Audio { get; set; }
+        public Values<IAudioObject, IClip> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
         [DataMember(Name = "author", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Author { get; set; }
+        public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -147,7 +147,7 @@
         /// </summary>
         [DataMember(Name = "citation", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, string>? Citation { get; set; }
+        public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
@@ -164,114 +164,129 @@
         public OneOrMany<int?> CommentCount { get; set; }
 
         /// <summary>
+        /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
+        /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+        /// </summary>
+        [DataMember(Name = "conditionsOfAccess", Order = 226)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> ConditionsOfAccess { get; set; }
+
+        /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 226)]
+        [DataMember(Name = "contentLocation", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 227)]
+        [DataMember(Name = "contentRating", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IRating, string>? ContentRating { get; set; }
+        public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 228)]
+        [DataMember(Name = "contentReferenceTime", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 229)]
+        [DataMember(Name = "contributor", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Contributor { get; set; }
+        public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 230)]
+        [DataMember(Name = "copyrightHolder", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? CopyrightHolder { get; set; }
+        public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 231)]
+        [DataMember(Name = "copyrightYear", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 232)]
+        [DataMember(Name = "correction", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Correction { get; set; }
+        public Values<string, Uri> Correction { get; set; }
+
+        /// <summary>
+        /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
+        /// </summary>
+        [DataMember(Name = "creativeWorkStatus", Order = 234)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 233)]
+        [DataMember(Name = "creator", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Creator { get; set; }
+        public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 234)]
+        [DataMember(Name = "dateCreated", Order = 236)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateCreated { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 235)]
+        [DataMember(Name = "dateModified", Order = 237)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?, DateTimeOffset?>? DateModified { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 236)]
+        [DataMember(Name = "datePublished", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? DatePublished { get; set; }
+        public Values<int?, DateTime?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 237)]
+        [DataMember(Name = "discussionUrl", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 238)]
+        [DataMember(Name = "editor", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 239)]
+        [DataMember(Name = "educationalAlignment", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 240)]
+        [DataMember(Name = "educationalUse", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 241)]
+        [DataMember(Name = "encoding", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -280,203 +295,203 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 242)]
+        [DataMember(Name = "encodingFormat", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? EncodingFormat { get; set; }
+        public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 243)]
+        [DataMember(Name = "exampleOfWork", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 244)]
+        [DataMember(Name = "expires", Order = 246)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? Expires { get; set; }
+        public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 245)]
+        [DataMember(Name = "funder", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Funder { get; set; }
+        public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 246)]
+        [DataMember(Name = "genre", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? Genre { get; set; }
+        public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 247)]
+        [DataMember(Name = "hasPart", Order = 249)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 248)]
+        [DataMember(Name = "headline", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 249)]
+        [DataMember(Name = "inLanguage", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ILanguage, string>? InLanguage { get; set; }
+        public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 250)]
+        [DataMember(Name = "interactionStatistic", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 251)]
+        [DataMember(Name = "interactivityType", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 252)]
+        [DataMember(Name = "isAccessibleForFree", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 253)]
+        [DataMember(Name = "isBasedOn", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, IProduct, Uri>? IsBasedOn { get; set; }
+        public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 254)]
+        [DataMember(Name = "isFamilyFriendly", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 255)]
+        [DataMember(Name = "isPartOf", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 256)]
+        [DataMember(Name = "keywords", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 257)]
+        [DataMember(Name = "learningResourceType", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 258)]
+        [DataMember(Name = "license", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? License { get; set; }
+        public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 259)]
+        [DataMember(Name = "locationCreated", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 260)]
+        [DataMember(Name = "mainEntity", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 261)]
+        [DataMember(Name = "material", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, string, Uri>? Material { get; set; }
+        public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 262)]
+        [DataMember(Name = "materialExtent", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IQuantitativeValue, string>? MaterialExtent { get; set; }
+        public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 263)]
+        [DataMember(Name = "mentions", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
         /// </summary>
-        [DataMember(Name = "offers", Order = 264)]
+        [DataMember(Name = "offers", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 265)]
+        [DataMember(Name = "position", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<int?, string>? Position { get; set; }
+        public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 266)]
+        [DataMember(Name = "producer", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Producer { get; set; }
+        public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 267)]
+        [DataMember(Name = "provider", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Provider { get; set; }
+        public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 268)]
+        [DataMember(Name = "publication", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 269)]
+        [DataMember(Name = "publisher", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Publisher { get; set; }
+        public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 270)]
+        [DataMember(Name = "publisherImprint", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -484,64 +499,64 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 271)]
+        [DataMember(Name = "publishingPrinciples", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 272)]
+        [DataMember(Name = "recordedAt", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 273)]
+        [DataMember(Name = "releasedEvent", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 274)]
+        [DataMember(Name = "review", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 275)]
+        [DataMember(Name = "schemaVersion", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SchemaVersion { get; set; }
+        public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 276)]
+        [DataMember(Name = "sdDatePublished", Order = 278)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?>? SdDatePublished { get; set; }
+        public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 277)]
+        [DataMember(Name = "sdLicense", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<ICreativeWork, Uri>? SdLicense { get; set; }
+        public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
         /// <summary>
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 278)]
+        [DataMember(Name = "sdPublisher", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? SdPublisher { get; set; }
+        public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 279)]
+        [DataMember(Name = "sourceOrganization", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -549,7 +564,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 280)]
+        [DataMember(Name = "spatial", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -558,24 +573,24 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 281)]
+        [DataMember(Name = "spatialCoverage", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 282)]
+        [DataMember(Name = "sponsor", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 283)]
+        [DataMember(Name = "temporal", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string>? Temporal { get; set; }
+        public Values<DateTimeOffset?, string> Temporal { get; set; }
 
         /// <summary>
         /// The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in &lt;a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals"&gt;ISO 8601 time interval format&lt;/a&gt;. In
@@ -583,77 +598,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 284)]
+        [DataMember(Name = "temporalCoverage", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<DateTimeOffset?, string, Uri>? TemporalCoverage { get; set; }
+        public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 285)]
+        [DataMember(Name = "text", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 286)]
+        [DataMember(Name = "thumbnailUrl", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 287)]
+        [DataMember(Name = "timeRequired", Order = 289)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 288)]
+        [DataMember(Name = "translationOfWork", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 289)]
+        [DataMember(Name = "translator", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IOrganization, IPerson>? Translator { get; set; }
+        public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 290)]
+        [DataMember(Name = "typicalAgeRange", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 291)]
+        [DataMember(Name = "version", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<double?, string>? Version { get; set; }
+        public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 292)]
+        [DataMember(Name = "video", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IClip, IVideoObject>? Video { get; set; }
+        public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 293)]
+        [DataMember(Name = "workExample", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 294)]
+        [DataMember(Name = "workTranslation", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
     }

--- a/Source/Schema.NET/core/combined/GameAndSoftwareApplication.cs
+++ b/Source/Schema.NET/core/combined/GameAndSoftwareApplication.cs
@@ -28,14 +28,14 @@
         /// </summary>
         [DataMember(Name = "applicationCategory", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ApplicationCategory { get; set; }
+        public Values<string, Uri> ApplicationCategory { get; set; }
 
         /// <summary>
         /// Subcategory of the application, e.g. 'Arcade Game'.
         /// </summary>
         [DataMember(Name = "applicationSubCategory", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ApplicationSubCategory { get; set; }
+        public Values<string, Uri> ApplicationSubCategory { get; set; }
 
         /// <summary>
         /// The name of the application suite to which the application belongs (e.g. Excel belongs to Office).
@@ -84,7 +84,7 @@
         /// </summary>
         [DataMember(Name = "featureList", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? FeatureList { get; set; }
+        public Values<string, Uri> FeatureList { get; set; }
 
         /// <summary>
         /// Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed.
@@ -105,7 +105,7 @@
         /// </summary>
         [DataMember(Name = "gameLocation", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IPlace, IPostalAddress, Uri>? GameLocation { get; set; }
+        public Values<IPlace, IPostalAddress, Uri> GameLocation { get; set; }
 
         /// <summary>
         /// URL at which the app may be installed, if different from the URL of the item.
@@ -119,7 +119,7 @@
         /// </summary>
         [DataMember(Name = "memoryRequirements", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? MemoryRequirements { get; set; }
+        public Values<string, Uri> MemoryRequirements { get; set; }
 
         /// <summary>
         /// Indicate how many people can play this game (minimum, maximum, or range).
@@ -161,14 +161,14 @@
         /// </summary>
         [DataMember(Name = "releaseNotes", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? ReleaseNotes { get; set; }
+        public Values<string, Uri> ReleaseNotes { get; set; }
 
         /// <summary>
         /// A link to a screenshot image of the app.
         /// </summary>
         [DataMember(Name = "screenshot", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IImageObject, Uri>? Screenshot { get; set; }
+        public Values<IImageObject, Uri> Screenshot { get; set; }
 
         /// <summary>
         /// Additional content for a software application.
@@ -189,7 +189,7 @@
         /// </summary>
         [DataMember(Name = "softwareRequirements", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? SoftwareRequirements { get; set; }
+        public Values<string, Uri> SoftwareRequirements { get; set; }
 
         /// <summary>
         /// Version of the software instance.
@@ -203,7 +203,7 @@
         /// </summary>
         [DataMember(Name = "storageRequirements", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<string, Uri>? StorageRequirements { get; set; }
+        public Values<string, Uri> StorageRequirements { get; set; }
 
         /// <summary>
         /// Supporting data for a SoftwareApplication.

--- a/Source/Schema.NET/core/combined/LocalBusinessAndOrganization.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndOrganization.cs
@@ -28,14 +28,14 @@
         /// </summary>
         [DataMember(Name = "actionableFeedbackPolicy", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? ActionableFeedbackPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> ActionableFeedbackPolicy { get; set; }
 
         /// <summary>
         /// Physical address of the item.
         /// </summary>
         [DataMember(Name = "address", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IPostalAddress, string>? Address { get; set; }
+        public override Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -56,7 +56,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public override Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -70,7 +70,7 @@
         /// </summary>
         [DataMember(Name = "brand", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IBrand, IOrganization>? Brand { get; set; }
+        public override Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A contact point for a person or organization.
@@ -84,7 +84,7 @@
         /// </summary>
         [DataMember(Name = "correctionsPolicy", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? CorrectionsPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> CorrectionsPolicy { get; set; }
 
         /// <summary>
         /// The currency accepted.&lt;br/&gt;&lt;br/&gt;
@@ -106,21 +106,21 @@
         /// </summary>
         [DataMember(Name = "dissolutionDate", Order = 217)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public override Values<int?, DateTime?>? DissolutionDate { get; set; }
+        public override Values<int?, DateTime?> DissolutionDate { get; set; }
 
         /// <summary>
         /// Statement on diversity policy by an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; e.g. a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;. For a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;, a statement describing the newsroom’s diversity policy on both staffing and sources, typically providing staffing data.
         /// </summary>
         [DataMember(Name = "diversityPolicy", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? DiversityPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> DiversityPolicy { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a report on staffing diversity issues. In a news context this might be for example ASNE or RTDNA (US) reports, or self-reported.
         /// </summary>
         [DataMember(Name = "diversityStaffingReport", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IArticle, Uri>? DiversityStaffingReport { get; set; }
+        public override Values<IArticle, Uri> DiversityStaffingReport { get; set; }
 
         /// <summary>
         /// The Dun &amp;amp; Bradstreet DUNS number for identifying an organization or business person.
@@ -148,7 +148,7 @@
         /// </summary>
         [DataMember(Name = "ethicsPolicy", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? EthicsPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> EthicsPolicy { get; set; }
 
         /// <summary>
         /// Upcoming or past event associated with this place, organization, or action.
@@ -176,7 +176,7 @@
         /// </summary>
         [DataMember(Name = "foundingDate", Order = 227)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public override Values<int?, DateTime?>? FoundingDate { get; set; }
+        public override Values<int?, DateTime?> FoundingDate { get; set; }
 
         /// <summary>
         /// The place where the Organization was founded.
@@ -190,7 +190,7 @@
         /// </summary>
         [DataMember(Name = "funder", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IPerson>? Funder { get; set; }
+        public override Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// The &lt;a href="http://www.gs1.org/gln"&gt;Global Location Number&lt;/a&gt; (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.
@@ -221,18 +221,18 @@
         public override OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
-        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or yet relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
+        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
         [DataMember(Name = "knowsAbout", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<string, IThing, Uri>? KnowsAbout { get; set; }
+        public override Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "knowsLanguage", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ILanguage, string>? KnowsLanguage { get; set; }
+        public override Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
@@ -253,14 +253,14 @@
         /// </summary>
         [DataMember(Name = "location", Order = 238)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        public override Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
         [DataMember(Name = "logo", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IImageObject, Uri>? Logo { get; set; }
+        public override Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
@@ -274,14 +274,14 @@
         /// </summary>
         [DataMember(Name = "member", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IPerson>? Member { get; set; }
+        public override Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
         [DataMember(Name = "memberOf", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IProgramMembership>? MemberOf { get; set; }
+        public override Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
@@ -315,14 +315,14 @@
         /// </summary>
         [DataMember(Name = "ownershipFundingInfo", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IAboutPage, ICreativeWork, string, Uri>? OwnershipFundingInfo { get; set; }
+        public override Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
         [DataMember(Name = "owns", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOwnershipInfo, IProduct>? Owns { get; set; }
+        public override Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
@@ -351,7 +351,7 @@
         /// </summary>
         [DataMember(Name = "publishingPrinciples", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public override Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -379,7 +379,7 @@
         /// </summary>
         [DataMember(Name = "sponsor", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public override Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
@@ -407,7 +407,7 @@
         /// </summary>
         [DataMember(Name = "unnamedSourcesPolicy", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? UnnamedSourcesPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.

--- a/Source/Schema.NET/core/combined/LocalBusinessAndOrganizationAndPlace.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndOrganizationAndPlace.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See LocalBusiness, Organization, Place for more information.
     /// </summary>
-    public partial interface ILocalBusinessAndOrganizationAndPlace : IPlace, ILocalBusiness, IOrganization
+    public partial interface ILocalBusinessAndOrganizationAndPlace : ILocalBusiness, IOrganization, IPlace
     {
     }
 
@@ -28,7 +28,7 @@
         /// </summary>
         [DataMember(Name = "actionableFeedbackPolicy", Order = 206)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? ActionableFeedbackPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> ActionableFeedbackPolicy { get; set; }
 
         /// <summary>
         /// A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.&lt;br/&gt;&lt;br/&gt;
@@ -43,7 +43,7 @@
         /// </summary>
         [DataMember(Name = "address", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IPostalAddress, string>? Address { get; set; }
+        public override Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -71,7 +71,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public override Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -93,7 +93,7 @@
         /// </summary>
         [DataMember(Name = "brand", Order = 215)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IBrand, IOrganization>? Brand { get; set; }
+        public override Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A contact point for a person or organization.
@@ -121,7 +121,7 @@
         /// </summary>
         [DataMember(Name = "correctionsPolicy", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? CorrectionsPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> CorrectionsPolicy { get; set; }
 
         /// <summary>
         /// The currency accepted.&lt;br/&gt;&lt;br/&gt;
@@ -143,21 +143,21 @@
         /// </summary>
         [DataMember(Name = "dissolutionDate", Order = 222)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public override Values<int?, DateTime?>? DissolutionDate { get; set; }
+        public override Values<int?, DateTime?> DissolutionDate { get; set; }
 
         /// <summary>
         /// Statement on diversity policy by an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; e.g. a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;. For a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;, a statement describing the newsroom’s diversity policy on both staffing and sources, typically providing staffing data.
         /// </summary>
         [DataMember(Name = "diversityPolicy", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? DiversityPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> DiversityPolicy { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a report on staffing diversity issues. In a news context this might be for example ASNE or RTDNA (US) reports, or self-reported.
         /// </summary>
         [DataMember(Name = "diversityStaffingReport", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IArticle, Uri>? DiversityStaffingReport { get; set; }
+        public override Values<IArticle, Uri> DiversityStaffingReport { get; set; }
 
         /// <summary>
         /// The Dun &amp;amp; Bradstreet DUNS number for identifying an organization or business person.
@@ -185,7 +185,7 @@
         /// </summary>
         [DataMember(Name = "ethicsPolicy", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? EthicsPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> EthicsPolicy { get; set; }
 
         /// <summary>
         /// Upcoming or past event associated with this place, organization, or action.
@@ -213,7 +213,7 @@
         /// </summary>
         [DataMember(Name = "foundingDate", Order = 232)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public override Values<int?, DateTime?>? FoundingDate { get; set; }
+        public override Values<int?, DateTime?> FoundingDate { get; set; }
 
         /// <summary>
         /// The place where the Organization was founded.
@@ -227,14 +227,14 @@
         /// </summary>
         [DataMember(Name = "funder", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IPerson>? Funder { get; set; }
+        public override Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// The geo coordinates of the place.
         /// </summary>
         [DataMember(Name = "geo", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IGeoCoordinates, IGeoShape>? Geo { get; set; }
+        public override Values<IGeoCoordinates, IGeoShape> Geo { get; set; }
 
         /// <summary>
         /// Represents a relationship between two geometries (or the places they represent), relating a containing geometry to a contained geometry. "a contains b iff no points of b lie in the exterior of a, and at least one point of the interior of b lies in the interior of a". As defined in &lt;a href="https://en.wikipedia.org/wiki/DE-9IM"&gt;DE-9IM&lt;/a&gt;.
@@ -318,7 +318,7 @@
         /// </summary>
         [DataMember(Name = "hasMap", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IMap, Uri>? HasMap { get; set; }
+        public override Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// Indicates an OfferCatalog listing for this Organization, Person, or Service.
@@ -349,18 +349,18 @@
         public override OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
-        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or yet relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
+        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
         [DataMember(Name = "knowsAbout", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<string, IThing, Uri>? KnowsAbout { get; set; }
+        public override Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "knowsLanguage", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ILanguage, string>? KnowsLanguage { get; set; }
+        public override Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
@@ -381,14 +381,14 @@
         /// </summary>
         [DataMember(Name = "location", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        public override Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
         [DataMember(Name = "logo", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IImageObject, Uri>? Logo { get; set; }
+        public override Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
@@ -409,14 +409,14 @@
         /// </summary>
         [DataMember(Name = "member", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IPerson>? Member { get; set; }
+        public override Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
         [DataMember(Name = "memberOf", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IProgramMembership>? MemberOf { get; set; }
+        public override Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
@@ -457,14 +457,14 @@
         /// </summary>
         [DataMember(Name = "ownershipFundingInfo", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IAboutPage, ICreativeWork, string, Uri>? OwnershipFundingInfo { get; set; }
+        public override Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
         [DataMember(Name = "owns", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOwnershipInfo, IProduct>? Owns { get; set; }
+        public override Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
@@ -485,7 +485,7 @@
         /// </summary>
         [DataMember(Name = "photo", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IImageObject, IPhotograph>? Photo { get; set; }
+        public override Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// The price range of the business, for example &lt;code&gt;$$$&lt;/code&gt;.
@@ -507,7 +507,7 @@
         /// </summary>
         [DataMember(Name = "publishingPrinciples", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public override Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -550,7 +550,7 @@
         /// </summary>
         [DataMember(Name = "sponsor", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public override Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
@@ -578,7 +578,7 @@
         /// </summary>
         [DataMember(Name = "unnamedSourcesPolicy", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<ICreativeWork, Uri>? UnnamedSourcesPolicy { get; set; }
+        public override Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.

--- a/Source/Schema.NET/core/combined/LocalBusinessAndPlace.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndPlace.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See LocalBusiness, Place for more information.
     /// </summary>
-    public partial interface ILocalBusinessAndPlace : IPlace, ILocalBusiness
+    public partial interface ILocalBusinessAndPlace : ILocalBusiness, IPlace
     {
     }
 
@@ -36,7 +36,7 @@
         /// </summary>
         [DataMember(Name = "address", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IPostalAddress, string>? Address { get; set; }
+        public override Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -101,7 +101,7 @@
         /// </summary>
         [DataMember(Name = "geo", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IGeoCoordinates, IGeoShape>? Geo { get; set; }
+        public override Values<IGeoCoordinates, IGeoShape> Geo { get; set; }
 
         /// <summary>
         /// Represents a relationship between two geometries (or the places they represent), relating a containing geometry to a contained geometry. "a contains b iff no points of b lie in the exterior of a, and at least one point of the interior of b lies in the interior of a". As defined in &lt;a href="https://en.wikipedia.org/wiki/DE-9IM"&gt;DE-9IM&lt;/a&gt;.
@@ -185,7 +185,7 @@
         /// </summary>
         [DataMember(Name = "hasMap", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IMap, Uri>? HasMap { get; set; }
+        public override Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
@@ -206,7 +206,7 @@
         /// </summary>
         [DataMember(Name = "logo", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IImageObject, Uri>? Logo { get; set; }
+        public override Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
@@ -247,7 +247,7 @@
         /// </summary>
         [DataMember(Name = "photo", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public override Values<IImageObject, IPhotograph>? Photo { get; set; }
+        public override Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// The price range of the business, for example &lt;code&gt;$$$&lt;/code&gt;.

--- a/Source/Schema.NET/core/combined/OrganizationAndPlace.cs
+++ b/Source/Schema.NET/core/combined/OrganizationAndPlace.cs
@@ -28,7 +28,7 @@
         /// </summary>
         [DataMember(Name = "actionableFeedbackPolicy", Order = 106)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<ICreativeWork, Uri>? ActionableFeedbackPolicy { get; set; }
+        public virtual Values<ICreativeWork, Uri> ActionableFeedbackPolicy { get; set; }
 
         /// <summary>
         /// A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.&lt;br/&gt;&lt;br/&gt;
@@ -43,7 +43,7 @@
         /// </summary>
         [DataMember(Name = "address", Order = 108)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IPostalAddress, string>? Address { get; set; }
+        public virtual Values<IPostalAddress, string> Address { get; set; }
 
         /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
@@ -71,7 +71,7 @@
         /// </summary>
         [DataMember(Name = "areaServed", Order = 112)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IAdministrativeArea, IGeoShape, IPlace, string>? AreaServed { get; set; }
+        public virtual Values<IAdministrativeArea, IGeoShape, IPlace, string> AreaServed { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
@@ -93,7 +93,7 @@
         /// </summary>
         [DataMember(Name = "brand", Order = 115)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IBrand, IOrganization>? Brand { get; set; }
+        public virtual Values<IBrand, IOrganization> Brand { get; set; }
 
         /// <summary>
         /// A contact point for a person or organization.
@@ -121,7 +121,7 @@
         /// </summary>
         [DataMember(Name = "correctionsPolicy", Order = 119)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<ICreativeWork, Uri>? CorrectionsPolicy { get; set; }
+        public virtual Values<ICreativeWork, Uri> CorrectionsPolicy { get; set; }
 
         /// <summary>
         /// A relationship between an organization and a department of that organization, also described as an organization (allowing different urls, logos, opening hours). For example: a store with a pharmacy, or a bakery with a cafe.
@@ -135,21 +135,21 @@
         /// </summary>
         [DataMember(Name = "dissolutionDate", Order = 121)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public virtual Values<int?, DateTime?>? DissolutionDate { get; set; }
+        public virtual Values<int?, DateTime?> DissolutionDate { get; set; }
 
         /// <summary>
         /// Statement on diversity policy by an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; e.g. a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;. For a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;, a statement describing the newsroom’s diversity policy on both staffing and sources, typically providing staffing data.
         /// </summary>
         [DataMember(Name = "diversityPolicy", Order = 122)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<ICreativeWork, Uri>? DiversityPolicy { get; set; }
+        public virtual Values<ICreativeWork, Uri> DiversityPolicy { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a report on staffing diversity issues. In a news context this might be for example ASNE or RTDNA (US) reports, or self-reported.
         /// </summary>
         [DataMember(Name = "diversityStaffingReport", Order = 123)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IArticle, Uri>? DiversityStaffingReport { get; set; }
+        public virtual Values<IArticle, Uri> DiversityStaffingReport { get; set; }
 
         /// <summary>
         /// The Dun &amp;amp; Bradstreet DUNS number for identifying an organization or business person.
@@ -177,7 +177,7 @@
         /// </summary>
         [DataMember(Name = "ethicsPolicy", Order = 127)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<ICreativeWork, Uri>? EthicsPolicy { get; set; }
+        public virtual Values<ICreativeWork, Uri> EthicsPolicy { get; set; }
 
         /// <summary>
         /// Upcoming or past event associated with this place, organization, or action.
@@ -205,7 +205,7 @@
         /// </summary>
         [DataMember(Name = "foundingDate", Order = 131)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public virtual Values<int?, DateTime?>? FoundingDate { get; set; }
+        public virtual Values<int?, DateTime?> FoundingDate { get; set; }
 
         /// <summary>
         /// The place where the Organization was founded.
@@ -219,14 +219,14 @@
         /// </summary>
         [DataMember(Name = "funder", Order = 133)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IOrganization, IPerson>? Funder { get; set; }
+        public virtual Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// The geo coordinates of the place.
         /// </summary>
         [DataMember(Name = "geo", Order = 134)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IGeoCoordinates, IGeoShape>? Geo { get; set; }
+        public virtual Values<IGeoCoordinates, IGeoShape> Geo { get; set; }
 
         /// <summary>
         /// Represents a relationship between two geometries (or the places they represent), relating a containing geometry to a contained geometry. "a contains b iff no points of b lie in the exterior of a, and at least one point of the interior of b lies in the interior of a". As defined in &lt;a href="https://en.wikipedia.org/wiki/DE-9IM"&gt;DE-9IM&lt;/a&gt;.
@@ -310,7 +310,7 @@
         /// </summary>
         [DataMember(Name = "hasMap", Order = 146)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IMap, Uri>? HasMap { get; set; }
+        public virtual Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// Indicates an OfferCatalog listing for this Organization, Person, or Service.
@@ -341,18 +341,18 @@
         public virtual OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
-        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or yet relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
+        /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
         [DataMember(Name = "knowsAbout", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<string, IThing, Uri>? KnowsAbout { get; set; }
+        public virtual Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
         [DataMember(Name = "knowsLanguage", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<ILanguage, string>? KnowsLanguage { get; set; }
+        public virtual Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
@@ -373,14 +373,14 @@
         /// </summary>
         [DataMember(Name = "location", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IPlace, IPostalAddress, string>? Location { get; set; }
+        public virtual Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
         [DataMember(Name = "logo", Order = 156)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IImageObject, Uri>? Logo { get; set; }
+        public virtual Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
@@ -401,14 +401,14 @@
         /// </summary>
         [DataMember(Name = "member", Order = 159)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IOrganization, IPerson>? Member { get; set; }
+        public virtual Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
         [DataMember(Name = "memberOf", Order = 160)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IOrganization, IProgramMembership>? MemberOf { get; set; }
+        public virtual Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
@@ -436,14 +436,14 @@
         /// </summary>
         [DataMember(Name = "ownershipFundingInfo", Order = 164)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IAboutPage, ICreativeWork, string, Uri>? OwnershipFundingInfo { get; set; }
+        public virtual Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
         [DataMember(Name = "owns", Order = 165)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IOwnershipInfo, IProduct>? Owns { get; set; }
+        public virtual Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
@@ -457,7 +457,7 @@
         /// </summary>
         [DataMember(Name = "photo", Order = 167)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IImageObject, IPhotograph>? Photo { get; set; }
+        public virtual Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
@@ -472,7 +472,7 @@
         /// </summary>
         [DataMember(Name = "publishingPrinciples", Order = 169)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<ICreativeWork, Uri>? PublishingPrinciples { get; set; }
+        public virtual Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
@@ -515,7 +515,7 @@
         /// </summary>
         [DataMember(Name = "sponsor", Order = 175)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<IOrganization, IPerson>? Sponsor { get; set; }
+        public virtual Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
@@ -543,7 +543,7 @@
         /// </summary>
         [DataMember(Name = "unnamedSourcesPolicy", Order = 179)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual Values<ICreativeWork, Uri>? UnnamedSourcesPolicy { get; set; }
+        public virtual Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.

--- a/Tests/Schema.NET.Test/MixedTypesTest.cs
+++ b/Tests/Schema.NET.Test/MixedTypesTest.cs
@@ -47,14 +47,14 @@ namespace Schema.NET.Test
             var book = JsonConvert.DeserializeObject<Book>(this.json, TestDefaults.DefaultJsonSerializerSettings);
 
             Assert.True(book.Author.HasValue);
-            Assert.True(book.Author.Value.HasValue1);
-            Assert.True(book.Author.Value.HasValue2);
-            Assert.True(book.Author.Value.Value1.HasOne);
-            Assert.True(book.Author.Value.Value2.HasOne);
-            Assert.False(book.Author.Value.Value1.HasMany);
-            Assert.False(book.Author.Value.Value2.HasMany);
-            Assert.Single(book.Author.Value.Value1);
-            Assert.Single(book.Author.Value.Value2);
+            Assert.True(book.Author.HasValue1);
+            Assert.True(book.Author.HasValue2);
+            Assert.True(book.Author.Value1.HasOne);
+            Assert.True(book.Author.Value2.HasOne);
+            Assert.False(book.Author.Value1.HasMany);
+            Assert.False(book.Author.Value2.HasMany);
+            Assert.Single(book.Author.Value1);
+            Assert.Single(book.Author.Value2);
 
             List<IPerson> people = book.Author;
             List<IOrganization> organizations = book.Author;
@@ -82,7 +82,7 @@ namespace Schema.NET.Test
             Assert.True(bankAccount.BankAccountType.HasValue);
             Assert.Equal(
                 new List<object>() { "http://example.com/1", new Uri("http://example.com/1") },
-                bankAccount.BankAccountType.Value);
+                bankAccount.BankAccountType);
         }
 
         [Fact]

--- a/Tests/Schema.NET.Test/OneOrManyTest.cs
+++ b/Tests/Schema.NET.Test/OneOrManyTest.cs
@@ -254,6 +254,17 @@ namespace Schema.NET.Test
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("  ")]
+        public void ToString_NullEmptyOrWhiteSpace_OrganizationOmitsAddressProperty(string address)
+        {
+            var organization = new Organization() { Address = address };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
         public void ToString_NullEmptyOrWhiteSpace_BookOmitsNamePropertyFromList(string name)
         {
             var book = new Book() { Name = new List<string> { "Hamlet", name } };
@@ -269,6 +280,17 @@ namespace Schema.NET.Test
         {
             var book = new Book() { Name = new string[] { "Hamlet", name } };
             Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        public void ToString_EmptyOrWhiteSpace_OrganizationOmitsAddressProperty(string address)
+        {
+            var organization = new Organization() { Address = address };
+            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
         }
 
         [Theory]

--- a/Tests/Schema.NET.Test/SerializationTest.cs
+++ b/Tests/Schema.NET.Test/SerializationTest.cs
@@ -85,7 +85,7 @@ namespace Schema.NET.Test
             var localBusiness = new LocalBusiness()
             {
                 PriceRange = "$$$",
-                Address = null
+                Address = (string)null
             };
             var actual = localBusiness.ToString();
             var expected =

--- a/Tests/Schema.NET.Test/core/BookTest.cs
+++ b/Tests/Schema.NET.Test/core/BookTest.cs
@@ -172,7 +172,7 @@ namespace Schema.NET.Test
             Assert.Equal(new Uri("http://www.barnesandnoble.com/store/info/offer/JDSalinger"), (Uri)book.Url);
             Assert.True(book.Author.HasValue);
 
-            List<IPerson> people = book.Author.Value;
+            List<IPerson> people = book.Author;
             var person = Assert.Single(people);
             Assert.Equal("J.D. Salinger", person.Name);
 
@@ -210,8 +210,8 @@ namespace Schema.NET.Test
                 "}";
             var book = JsonConvert.DeserializeObject<Book>(json, TestDefaults.DefaultJsonSerializerSettings);
 
-            Assert.Empty(book.Author.Value.Value1);
-            var person = Assert.Single(book.Author.Value.Value2);
+            Assert.Empty(book.Author.Value1);
+            var person = Assert.Single(book.Author.Value2);
             Assert.Equal("NameOfPerson1", person.Name);
         }
     }

--- a/Tests/Schema.NET.Test/core/CarTest.cs
+++ b/Tests/Schema.NET.Test/core/CarTest.cs
@@ -18,7 +18,7 @@ namespace Schema.NET.Test
             Offers = new Offer // Recommended
             {
                 Url = (Uri)null, // Recommended
-                ItemOffered = null, // Recommended
+                ItemOffered = (Product)null, // Recommended
                 PriceCurrency = "USD", // Required
                 Price = 47200M, // Required
                 PriceValidUntil = new DateTime(2020, 11, 5), // Recommended

--- a/Tests/Schema.NET.Test/core/EventTest.cs
+++ b/Tests/Schema.NET.Test/core/EventTest.cs
@@ -40,6 +40,7 @@ namespace Schema.NET.Test
                     PriceCurrency = "USD", // Recommended
                     Availability = ItemAvailability.InStock, // Recommended
                     ValidFrom = new DateTimeOffset(2017, 1, 20, 16, 20, 0, TimeSpan.FromHours(-8)), // Recommended
+                    Category = NullString,
                 },
                 new Offer
                 {

--- a/Tests/Schema.NET.Test/core/ItemListTest.cs
+++ b/Tests/Schema.NET.Test/core/ItemListTest.cs
@@ -192,9 +192,9 @@ namespace Schema.NET.Test
 
             Assert.Equal("ItemList", itemList.Type);
             Assert.True(itemList.ItemListElement.HasValue);
-            Assert.Equal(2, itemList.ItemListElement.Value.Count);
-            var listItems = (List<IListItem>)itemList.ItemListElement.Value;
-            var things = (List<IThing>)itemList.ItemListElement.Value;
+            Assert.Equal(2, itemList.ItemListElement.Count);
+            var listItems = (List<IListItem>)itemList.ItemListElement;
+            var things = (List<IThing>)itemList.ItemListElement;
             Assert.Empty(listItems);
             Assert.Equal(2, things.Count);
             var thing1 = things.First();

--- a/Tests/Schema.NET.Test/core/ProductTest.cs
+++ b/Tests/Schema.NET.Test/core/ProductTest.cs
@@ -26,7 +26,7 @@ namespace Schema.NET.Test
             Offers = new Offer() // Recommended
             {
                 Url = (Uri)null, // Recommended
-                ItemOffered = null, // Recommended
+                ItemOffered = (Product)null, // Recommended
                 PriceCurrency = "USD", // Required
                 Price = 119.99M, // Required
                 PriceValidUntil = new DateTime(2020, 11, 5), // Recommended


### PR DESCRIPTION
Based from the original [null Values<T> fix attempt](https://github.com/RehanSaeed/Schema.NET/pull/55) from @nickevansuk, this PR just adds minor changes to solve the problem. Also see the [problem origin](https://github.com/RehanSaeed/Schema.NET/issues/29).

Json.net has an internal method Newtonsoft.Json.Utilities.MiscellaneousUtils.ValueEquals(object objA, object objB) which utilises IEquatable to determine whether or not to write a property when DefaultValueHandling is specified.

The bulk of this fix occurs in Values{T1,T2}, Values{T1,T2, T3}, Values{T1,T2, T3, T4}, which contain method overrides specific to the issue.

I have also added an additional test that was previously removed.
