### PR TITLE
Switch to https://schema.org

### DIFF
--- a/Source/Schema.NET.Tool/ViewModels/Enumeration.cs
+++ b/Source/Schema.NET.Tool/ViewModels/Enumeration.cs
@@ -45,8 +45,18 @@ namespace Schema.NET.Tool.ViewModels
                 {
                     var isLast = i == (this.Values.Count - 1);
 
+                    // Convert enumeration values to https for future proofing
+                    // https://schema.org/docs/faq.html#19
+                    // "Over time we will migrate the schema.org site itself towards using https:
+                    //  as the default version of the site and our preferred form in examples."
+                    var httpsValueUri = new System.UriBuilder(value.Uri)
+                    {
+                        Scheme = System.Uri.UriSchemeHttps,
+                        Port = value.Uri.IsDefaultPort ? -1 : value.Uri.Port // -1 => default port for scheme
+                    }.Uri;
+
                     stringBuilder.AppendCommentSummary(8, value.Description);
-                    stringBuilder.AppendIndentLine(8, $"[EnumMember(Value = \"{value.Uri}\")]");
+                    stringBuilder.AppendIndentLine(8, $"[EnumMember(Value = \"{httpsValueUri}\")]");
                     stringBuilder.AppendIndent(8, value.Name);
                     if (!isLast)
                     {

--- a/Source/Schema.NET/JsonLdContext.cs
+++ b/Source/Schema.NET/JsonLdContext.cs
@@ -13,7 +13,7 @@ namespace Schema.NET
         /// Gets or sets the name.
         /// </summary>
         [DataMember(Name = "name", Order = 0)]
-        public string Name { get; set; } = "http://schema.org";
+        public string Name { get; set; } = "https://schema.org";
 
         /// <summary>
         /// Gets or sets the language.

--- a/Source/Schema.NET/Thing.Partial.cs
+++ b/Source/Schema.NET/Thing.Partial.cs
@@ -7,7 +7,7 @@ namespace Schema.NET
 
     public partial class Thing : JsonLdObject
     {
-        private const string ContextPropertyJson = "\"@context\":\"http://schema.org\",";
+        private const string ContextPropertyJson = "\"@context\":\"https://schema.org\",";
 
         /// <summary>
         /// Default serializer settings used.

--- a/Source/Schema.NET/ValuesJsonConverter.cs
+++ b/Source/Schema.NET/ValuesJsonConverter.cs
@@ -226,12 +226,15 @@ namespace Schema.NET
         {
             const string SCHEMA_ORG = "http://schema.org/";
             const int SCHEMA_ORG_LENGTH = 18; // equivalent to "http://schema.org/".Length
+            const string SCHEMA_ORG_HTTPS = "https://schema.org/";
+            const int SCHEMA_ORG_HTTPS_LENGTH = 19; // equivalent to "https://schema.org/".Length
             object args;
             var unwrappedType = type.GetUnderlyingTypeFromNullable();
             if (unwrappedType.GetTypeInfo().IsEnum)
             {
                 var en = token.ToString();
-                var enumString = en.Contains(SCHEMA_ORG) ? en.Substring(SCHEMA_ORG_LENGTH) : en;
+                var enumString = en.Contains(SCHEMA_ORG) ? en.Substring(SCHEMA_ORG_LENGTH) :
+                    en.Contains(SCHEMA_ORG_HTTPS) ? en.Substring(SCHEMA_ORG_HTTPS_LENGTH) : en;
                 args = Enum.Parse(unwrappedType, enumString);
             }
             else

--- a/Source/Schema.NET/auto/enumerations/CarUsageType.cs
+++ b/Source/Schema.NET/auto/enumerations/CarUsageType.cs
@@ -13,19 +13,19 @@
         /// <summary>
         /// Indicates the usage of the vehicle for driving school.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DrivingSchoolVehicleUsage")]
+        [EnumMember(Value = "https://schema.org/DrivingSchoolVehicleUsage")]
         DrivingSchoolVehicleUsage,
 
         /// <summary>
         /// Indicates the usage of the vehicle as a rental car.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RentalVehicleUsage")]
+        [EnumMember(Value = "https://schema.org/RentalVehicleUsage")]
         RentalVehicleUsage,
 
         /// <summary>
         /// Indicates the usage of the car as a taxi.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/TaxiVehicleUsage")]
+        [EnumMember(Value = "https://schema.org/TaxiVehicleUsage")]
         TaxiVehicleUsage
     }
 }

--- a/Source/Schema.NET/core/enumerations/ActionStatusType.cs
+++ b/Source/Schema.NET/core/enumerations/ActionStatusType.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// An in-progress action (e.g, while watching the movie, or driving to a location).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ActiveActionStatus")]
+        [EnumMember(Value = "https://schema.org/ActiveActionStatus")]
         ActiveActionStatus,
 
         /// <summary>
         /// An action that has already taken place.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CompletedActionStatus")]
+        [EnumMember(Value = "https://schema.org/CompletedActionStatus")]
         CompletedActionStatus,
 
         /// <summary>
         /// An action that failed to complete. The action's error property and the HTTP return code contain more information about the failure.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FailedActionStatus")]
+        [EnumMember(Value = "https://schema.org/FailedActionStatus")]
         FailedActionStatus,
 
         /// <summary>
         /// A description of an action that is supported.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PotentialActionStatus")]
+        [EnumMember(Value = "https://schema.org/PotentialActionStatus")]
         PotentialActionStatus
     }
 }

--- a/Source/Schema.NET/core/enumerations/BoardingPolicyType.cs
+++ b/Source/Schema.NET/core/enumerations/BoardingPolicyType.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// The airline boards by groups based on check-in time, priority, etc.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/GroupBoardingPolicy")]
+        [EnumMember(Value = "https://schema.org/GroupBoardingPolicy")]
         GroupBoardingPolicy,
 
         /// <summary>
         /// The airline boards by zones of the plane.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ZoneBoardingPolicy")]
+        [EnumMember(Value = "https://schema.org/ZoneBoardingPolicy")]
         ZoneBoardingPolicy
     }
 }

--- a/Source/Schema.NET/core/enumerations/BookFormatType.cs
+++ b/Source/Schema.NET/core/enumerations/BookFormatType.cs
@@ -13,31 +13,31 @@
         /// <summary>
         /// Book format: Audiobook. This is an enumerated value for use with the bookFormat property. There is also a type 'Audiobook' in the bib extension which includes Audiobook specific properties.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/AudiobookFormat")]
+        [EnumMember(Value = "https://schema.org/AudiobookFormat")]
         AudiobookFormat,
 
         /// <summary>
         /// Book format: Ebook.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EBook")]
+        [EnumMember(Value = "https://schema.org/EBook")]
         EBook,
 
         /// <summary>
         /// Book format: GraphicNovel. May represent a bound collection of ComicIssue instances.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/GraphicNovel")]
+        [EnumMember(Value = "https://schema.org/GraphicNovel")]
         GraphicNovel,
 
         /// <summary>
         /// Book format: Hardcover.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Hardcover")]
+        [EnumMember(Value = "https://schema.org/Hardcover")]
         Hardcover,
 
         /// <summary>
         /// Book format: Paperback.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Paperback")]
+        [EnumMember(Value = "https://schema.org/Paperback")]
         Paperback
     }
 }

--- a/Source/Schema.NET/core/enumerations/ContactPointOption.cs
+++ b/Source/Schema.NET/core/enumerations/ContactPointOption.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// Uses devices to support users with hearing impairments.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/HearingImpairedSupported")]
+        [EnumMember(Value = "https://schema.org/HearingImpairedSupported")]
         HearingImpairedSupported,
 
         /// <summary>
         /// The associated telephone number is toll free.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/TollFree")]
+        [EnumMember(Value = "https://schema.org/TollFree")]
         TollFree
     }
 }

--- a/Source/Schema.NET/core/enumerations/DayOfWeek.cs
+++ b/Source/Schema.NET/core/enumerations/DayOfWeek.cs
@@ -14,49 +14,49 @@
         /// <summary>
         /// The day of the week between Saturday and Monday.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Sunday")]
+        [EnumMember(Value = "https://schema.org/Sunday")]
         Sunday,
 
         /// <summary>
         /// The day of the week between Sunday and Tuesday.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Monday")]
+        [EnumMember(Value = "https://schema.org/Monday")]
         Monday,
 
         /// <summary>
         /// The day of the week between Monday and Wednesday.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Tuesday")]
+        [EnumMember(Value = "https://schema.org/Tuesday")]
         Tuesday,
 
         /// <summary>
         /// The day of the week between Tuesday and Thursday.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Wednesday")]
+        [EnumMember(Value = "https://schema.org/Wednesday")]
         Wednesday,
 
         /// <summary>
         /// The day of the week between Wednesday and Friday.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Thursday")]
+        [EnumMember(Value = "https://schema.org/Thursday")]
         Thursday,
 
         /// <summary>
         /// The day of the week between Thursday and Saturday.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Friday")]
+        [EnumMember(Value = "https://schema.org/Friday")]
         Friday,
 
         /// <summary>
         /// The day of the week between Friday and Sunday.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Saturday")]
+        [EnumMember(Value = "https://schema.org/Saturday")]
         Saturday,
 
         /// <summary>
         /// This stands for any day that is a public holiday; it is a placeholder for all official public holidays in some particular location. While not technically a "day of the week", it can be used with &lt;a class="localLink" href="http://schema.org/OpeningHoursSpecification"&gt;OpeningHoursSpecification&lt;/a&gt;. In the context of an opening hours specification it can be used to indicate opening hours on public holidays, overriding general opening hours for the day of the week on which a public holiday occurs.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PublicHolidays")]
+        [EnumMember(Value = "https://schema.org/PublicHolidays")]
         PublicHolidays
     }
 }

--- a/Source/Schema.NET/core/enumerations/DeliveryMethod.cs
+++ b/Source/Schema.NET/core/enumerations/DeliveryMethod.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// A DeliveryMethod in which an item is collected on site, e.g. in a store or at a box office.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OnSitePickup")]
+        [EnumMember(Value = "https://schema.org/OnSitePickup")]
         OnSitePickup
     }
 }

--- a/Source/Schema.NET/core/enumerations/DigitalDocumentPermissionType.cs
+++ b/Source/Schema.NET/core/enumerations/DigitalDocumentPermissionType.cs
@@ -13,19 +13,19 @@
         /// <summary>
         /// Permission to add comments to the document.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CommentPermission")]
+        [EnumMember(Value = "https://schema.org/CommentPermission")]
         CommentPermission,
 
         /// <summary>
         /// Permission to read or view the document.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ReadPermission")]
+        [EnumMember(Value = "https://schema.org/ReadPermission")]
         ReadPermission,
 
         /// <summary>
         /// Permission to write or edit the document.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/WritePermission")]
+        [EnumMember(Value = "https://schema.org/WritePermission")]
         WritePermission
     }
 }

--- a/Source/Schema.NET/core/enumerations/DriveWheelConfigurationValue.cs
+++ b/Source/Schema.NET/core/enumerations/DriveWheelConfigurationValue.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// All-wheel Drive is a transmission layout where the engine drives all four wheels.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/AllWheelDriveConfiguration")]
+        [EnumMember(Value = "https://schema.org/AllWheelDriveConfiguration")]
         AllWheelDriveConfiguration,
 
         /// <summary>
         /// Four-wheel drive is a transmission layout where the engine primarily drives two wheels with a part-time four-wheel drive capability.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FourWheelDriveConfiguration")]
+        [EnumMember(Value = "https://schema.org/FourWheelDriveConfiguration")]
         FourWheelDriveConfiguration,
 
         /// <summary>
         /// Front-wheel drive is a transmission layout where the engine drives the front wheels.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FrontWheelDriveConfiguration")]
+        [EnumMember(Value = "https://schema.org/FrontWheelDriveConfiguration")]
         FrontWheelDriveConfiguration,
 
         /// <summary>
         /// Real-wheel drive is a transmission layout where the engine drives the rear wheels.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RearWheelDriveConfiguration")]
+        [EnumMember(Value = "https://schema.org/RearWheelDriveConfiguration")]
         RearWheelDriveConfiguration
     }
 }

--- a/Source/Schema.NET/core/enumerations/DrugCostCategory.cs
+++ b/Source/Schema.NET/core/enumerations/DrugCostCategory.cs
@@ -13,19 +13,19 @@
         /// <summary>
         /// The drug's cost represents the maximum reimbursement paid by an insurer for the drug.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ReimbursementCap")]
+        [EnumMember(Value = "https://schema.org/ReimbursementCap")]
         ReimbursementCap,
 
         /// <summary>
         /// The drug's cost represents the retail cost of the drug.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Retail")]
+        [EnumMember(Value = "https://schema.org/Retail")]
         Retail,
 
         /// <summary>
         /// The drug's cost represents the wholesale acquisition cost of the drug.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Wholesale")]
+        [EnumMember(Value = "https://schema.org/Wholesale")]
         Wholesale
     }
 }

--- a/Source/Schema.NET/core/enumerations/DrugPregnancyCategory.cs
+++ b/Source/Schema.NET/core/enumerations/DrugPregnancyCategory.cs
@@ -13,37 +13,37 @@
         /// <summary>
         /// A designation by the US FDA signifying that adequate and well-controlled studies have failed to demonstrate a risk to the fetus in the first trimester of pregnancy (and there is no evidence of risk in later trimesters).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FDAcategoryA")]
+        [EnumMember(Value = "https://schema.org/FDAcategoryA")]
         FDAcategoryA,
 
         /// <summary>
         /// A designation by the US FDA signifying that animal reproduction studies have failed to demonstrate a risk to the fetus and there are no adequate and well-controlled studies in pregnant women.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FDAcategoryB")]
+        [EnumMember(Value = "https://schema.org/FDAcategoryB")]
         FDAcategoryB,
 
         /// <summary>
         /// A designation by the US FDA signifying that animal reproduction studies have shown an adverse effect on the fetus and there are no adequate and well-controlled studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FDAcategoryC")]
+        [EnumMember(Value = "https://schema.org/FDAcategoryC")]
         FDAcategoryC,
 
         /// <summary>
         /// A designation by the US FDA signifying that there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience or studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FDAcategoryD")]
+        [EnumMember(Value = "https://schema.org/FDAcategoryD")]
         FDAcategoryD,
 
         /// <summary>
         /// A designation by the US FDA signifying that studies in animals or humans have demonstrated fetal abnormalities and/or there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience, and the risks involved in use of the drug in pregnant women clearly outweigh potential benefits.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FDAcategoryX")]
+        [EnumMember(Value = "https://schema.org/FDAcategoryX")]
         FDAcategoryX,
 
         /// <summary>
         /// A designation that the drug in question has not been assigned a pregnancy category designation by the US FDA.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/FDAnotEvaluated")]
+        [EnumMember(Value = "https://schema.org/FDAnotEvaluated")]
         FDAnotEvaluated
     }
 }

--- a/Source/Schema.NET/core/enumerations/DrugPrescriptionStatus.cs
+++ b/Source/Schema.NET/core/enumerations/DrugPrescriptionStatus.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// The character of a medical substance, typically a medicine, of being available over the counter or not.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OTC")]
+        [EnumMember(Value = "https://schema.org/OTC")]
         OTC,
 
         /// <summary>
         /// Available by prescription only.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PrescriptionOnly")]
+        [EnumMember(Value = "https://schema.org/PrescriptionOnly")]
         PrescriptionOnly
     }
 }

--- a/Source/Schema.NET/core/enumerations/EventStatusType.cs
+++ b/Source/Schema.NET/core/enumerations/EventStatusType.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// The event has been cancelled. If the event has multiple startDate values, all are assumed to be cancelled. Either startDate or previousStartDate may be used to specify the event's cancelled date(s).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EventCancelled")]
+        [EnumMember(Value = "https://schema.org/EventCancelled")]
         EventCancelled,
 
         /// <summary>
         /// The event has been postponed and no new date has been set. The event's previousStartDate should be set.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EventPostponed")]
+        [EnumMember(Value = "https://schema.org/EventPostponed")]
         EventPostponed,
 
         /// <summary>
         /// The event has been rescheduled. The event's previousStartDate should be set to the old date and the startDate should be set to the event's new date. (If the event has been rescheduled multiple times, the previousStartDate property may be repeated).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EventRescheduled")]
+        [EnumMember(Value = "https://schema.org/EventRescheduled")]
         EventRescheduled,
 
         /// <summary>
         /// The event is taking place or has taken place on the startDate as scheduled. Use of this value is optional, as it is assumed by default.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EventScheduled")]
+        [EnumMember(Value = "https://schema.org/EventScheduled")]
         EventScheduled
     }
 }

--- a/Source/Schema.NET/core/enumerations/GamePlayMode.cs
+++ b/Source/Schema.NET/core/enumerations/GamePlayMode.cs
@@ -13,19 +13,19 @@
         /// <summary>
         /// Play mode: CoOp. Co-operative games, where you play on the same team with friends.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CoOp")]
+        [EnumMember(Value = "https://schema.org/CoOp")]
         CoOp,
 
         /// <summary>
         /// Play mode: MultiPlayer. Requiring or allowing multiple human players to play simultaneously.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/MultiPlayer")]
+        [EnumMember(Value = "https://schema.org/MultiPlayer")]
         MultiPlayer,
 
         /// <summary>
         /// Play mode: SinglePlayer. Which is played by a lone player.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SinglePlayer")]
+        [EnumMember(Value = "https://schema.org/SinglePlayer")]
         SinglePlayer
     }
 }

--- a/Source/Schema.NET/core/enumerations/GameServerStatus.cs
+++ b/Source/Schema.NET/core/enumerations/GameServerStatus.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// Game server status: OfflinePermanently. Server is offline and not available.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OfflinePermanently")]
+        [EnumMember(Value = "https://schema.org/OfflinePermanently")]
         OfflinePermanently,
 
         /// <summary>
         /// Game server status: OfflineTemporarily. Server is offline now but it can be online soon.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OfflineTemporarily")]
+        [EnumMember(Value = "https://schema.org/OfflineTemporarily")]
         OfflineTemporarily,
 
         /// <summary>
         /// Game server status: Online. Server is available.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Online")]
+        [EnumMember(Value = "https://schema.org/Online")]
         Online,
 
         /// <summary>
         /// Game server status: OnlineFull. Server is online but unavailable. The maximum number of players has reached.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OnlineFull")]
+        [EnumMember(Value = "https://schema.org/OnlineFull")]
         OnlineFull
     }
 }

--- a/Source/Schema.NET/core/enumerations/GenderType.cs
+++ b/Source/Schema.NET/core/enumerations/GenderType.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// The female gender.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Female")]
+        [EnumMember(Value = "https://schema.org/Female")]
         Female,
 
         /// <summary>
         /// The male gender.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Male")]
+        [EnumMember(Value = "https://schema.org/Male")]
         Male
     }
 }

--- a/Source/Schema.NET/core/enumerations/InfectiousAgentClass.cs
+++ b/Source/Schema.NET/core/enumerations/InfectiousAgentClass.cs
@@ -13,37 +13,37 @@
         /// <summary>
         /// Pathogenic bacteria that cause bacterial infection.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Bacteria")]
+        [EnumMember(Value = "https://schema.org/Bacteria")]
         Bacteria,
 
         /// <summary>
         /// Pathogenic fungus.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Fungus")]
+        [EnumMember(Value = "https://schema.org/Fungus")]
         Fungus,
 
         /// <summary>
         /// Multicellular parasite that causes an infection.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/MulticellularParasite")]
+        [EnumMember(Value = "https://schema.org/MulticellularParasite")]
         MulticellularParasite,
 
         /// <summary>
         /// A prion is an infectious agent composed of protein in a misfolded form.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Prion")]
+        [EnumMember(Value = "https://schema.org/Prion")]
         Prion,
 
         /// <summary>
         /// Single-celled organism that causes an infection.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Protozoa")]
+        [EnumMember(Value = "https://schema.org/Protozoa")]
         Protozoa,
 
         /// <summary>
         /// Pathogenic virus that causes viral infection.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Virus")]
+        [EnumMember(Value = "https://schema.org/Virus")]
         Virus
     }
 }

--- a/Source/Schema.NET/core/enumerations/ItemAvailability.cs
+++ b/Source/Schema.NET/core/enumerations/ItemAvailability.cs
@@ -13,55 +13,55 @@
         /// <summary>
         /// Indicates that the item has been discontinued.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Discontinued")]
+        [EnumMember(Value = "https://schema.org/Discontinued")]
         Discontinued,
 
         /// <summary>
         /// Indicates that the item is in stock.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/InStock")]
+        [EnumMember(Value = "https://schema.org/InStock")]
         InStock,
 
         /// <summary>
         /// Indicates that the item is available only at physical locations.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/InStoreOnly")]
+        [EnumMember(Value = "https://schema.org/InStoreOnly")]
         InStoreOnly,
 
         /// <summary>
         /// Indicates that the item has limited availability.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LimitedAvailability")]
+        [EnumMember(Value = "https://schema.org/LimitedAvailability")]
         LimitedAvailability,
 
         /// <summary>
         /// Indicates that the item is available only online.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OnlineOnly")]
+        [EnumMember(Value = "https://schema.org/OnlineOnly")]
         OnlineOnly,
 
         /// <summary>
         /// Indicates that the item is out of stock.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OutOfStock")]
+        [EnumMember(Value = "https://schema.org/OutOfStock")]
         OutOfStock,
 
         /// <summary>
         /// Indicates that the item is available for pre-order, but will be delivered when generally available.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PreOrder")]
+        [EnumMember(Value = "https://schema.org/PreOrder")]
         PreOrder,
 
         /// <summary>
         /// Indicates that the item is available for ordering and delivery before general availability.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PreSale")]
+        [EnumMember(Value = "https://schema.org/PreSale")]
         PreSale,
 
         /// <summary>
         /// Indicates that the item has sold out.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SoldOut")]
+        [EnumMember(Value = "https://schema.org/SoldOut")]
         SoldOut
     }
 }

--- a/Source/Schema.NET/core/enumerations/ItemListOrderType.cs
+++ b/Source/Schema.NET/core/enumerations/ItemListOrderType.cs
@@ -13,19 +13,19 @@
         /// <summary>
         /// An ItemList ordered with lower values listed first.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ItemListOrderAscending")]
+        [EnumMember(Value = "https://schema.org/ItemListOrderAscending")]
         ItemListOrderAscending,
 
         /// <summary>
         /// An ItemList ordered with higher values listed first.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ItemListOrderDescending")]
+        [EnumMember(Value = "https://schema.org/ItemListOrderDescending")]
         ItemListOrderDescending,
 
         /// <summary>
         /// An ItemList ordered with no explicit order.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ItemListUnordered")]
+        [EnumMember(Value = "https://schema.org/ItemListUnordered")]
         ItemListUnordered
     }
 }

--- a/Source/Schema.NET/core/enumerations/MapCategoryType.cs
+++ b/Source/Schema.NET/core/enumerations/MapCategoryType.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// A parking map.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ParkingMap")]
+        [EnumMember(Value = "https://schema.org/ParkingMap")]
         ParkingMap,
 
         /// <summary>
         /// A seating map.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SeatingMap")]
+        [EnumMember(Value = "https://schema.org/SeatingMap")]
         SeatingMap,
 
         /// <summary>
         /// A transit map.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/TransitMap")]
+        [EnumMember(Value = "https://schema.org/TransitMap")]
         TransitMap,
 
         /// <summary>
         /// A venue map (e.g. for malls, auditoriums, museums, etc.).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/VenueMap")]
+        [EnumMember(Value = "https://schema.org/VenueMap")]
         VenueMap
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalAudience.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalAudience.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// Medical clinicians, including practicing physicians and other medical professionals involved in clinical practice.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Clinician")]
+        [EnumMember(Value = "https://schema.org/Clinician")]
         Clinician,
 
         /// <summary>
         /// Medical researchers.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/MedicalResearcher")]
+        [EnumMember(Value = "https://schema.org/MedicalResearcher")]
         MedicalResearcher
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalDevicePurpose.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalDevicePurpose.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// A medical device used for diagnostic purposes.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Diagnostic")]
+        [EnumMember(Value = "https://schema.org/Diagnostic")]
         Diagnostic,
 
         /// <summary>
         /// A medical device used for therapeutic purposes.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Therapeutic")]
+        [EnumMember(Value = "https://schema.org/Therapeutic")]
         Therapeutic
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalEvidenceLevel.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalEvidenceLevel.cs
@@ -13,19 +13,19 @@
         /// <summary>
         /// Data derived from multiple randomized clinical trials or meta-analyses.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EvidenceLevelA")]
+        [EnumMember(Value = "https://schema.org/EvidenceLevelA")]
         EvidenceLevelA,
 
         /// <summary>
         /// Data derived from a single randomized trial, or nonrandomized studies.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EvidenceLevelB")]
+        [EnumMember(Value = "https://schema.org/EvidenceLevelB")]
         EvidenceLevelB,
 
         /// <summary>
         /// Only consensus opinion of experts, case studies, or standard-of-care.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EvidenceLevelC")]
+        [EnumMember(Value = "https://schema.org/EvidenceLevelC")]
         EvidenceLevelC
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalImagingTechnique.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalImagingTechnique.cs
@@ -13,37 +13,37 @@
         /// <summary>
         /// X-ray computed tomography imaging.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CT")]
+        [EnumMember(Value = "https://schema.org/CT")]
         CT,
 
         /// <summary>
         /// Magnetic resonance imaging.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/MRI")]
+        [EnumMember(Value = "https://schema.org/MRI")]
         MRI,
 
         /// <summary>
         /// Positron emission tomography imaging.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PET")]
+        [EnumMember(Value = "https://schema.org/PET")]
         PET,
 
         /// <summary>
         /// Radiography is an imaging technique that uses electromagnetic radiation other than visible light, especially X-rays, to view the internal structure of a non-uniformly composed and opaque object such as the human body.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Radiography")]
+        [EnumMember(Value = "https://schema.org/Radiography")]
         Radiography,
 
         /// <summary>
         /// Ultrasound imaging.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Ultrasound")]
+        [EnumMember(Value = "https://schema.org/Ultrasound")]
         Ultrasound,
 
         /// <summary>
         /// X-ray imaging.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/XRay")]
+        [EnumMember(Value = "https://schema.org/XRay")]
         XRay
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalObservationalStudyDesign.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalObservationalStudyDesign.cs
@@ -13,37 +13,37 @@
         /// <summary>
         /// A case series (also known as a clinical series) is a medical research study that tracks patients with a known exposure given similar treatment or examines their medical records for exposure and outcome. A case series can be retrospective or prospective and usually involves a smaller number of patients than the more powerful case-control studies or randomized controlled trials. Case series may be consecutive or non-consecutive, depending on whether all cases presenting to the reporting authors over a period of time were included, or only a selection.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CaseSeries")]
+        [EnumMember(Value = "https://schema.org/CaseSeries")]
         CaseSeries,
 
         /// <summary>
         /// Also known as a panel study. A cohort study is a form of longitudinal study used in medicine and social science. It is one type of study design and should be compared with a cross-sectional study.  A cohort is a group of people who share a common characteristic or experience within a defined period (e.g., are born, leave school, lose their job, are exposed to a drug or a vaccine, etc.). The comparison group may be the general population from which the cohort is drawn, or it may be another cohort of persons thought to have had little or no exposure to the substance under investigation, but otherwise similar. Alternatively, subgroups within the cohort may be compared with each other.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CohortStudy")]
+        [EnumMember(Value = "https://schema.org/CohortStudy")]
         CohortStudy,
 
         /// <summary>
         /// Studies carried out on pre-existing data (usually from 'snapshot' surveys), such as that collected by the Census Bureau. Sometimes called Prevalence Studies.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CrossSectional")]
+        [EnumMember(Value = "https://schema.org/CrossSectional")]
         CrossSectional,
 
         /// <summary>
         /// Unlike cross-sectional studies, longitudinal studies track the same people, and therefore the differences observed in those people are less likely to be the result of cultural differences across generations. Longitudinal studies are also used in medicine to uncover predictors of certain diseases.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Longitudinal")]
+        [EnumMember(Value = "https://schema.org/Longitudinal")]
         Longitudinal,
 
         /// <summary>
         /// An observational study design.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Observational")]
+        [EnumMember(Value = "https://schema.org/Observational")]
         Observational,
 
         /// <summary>
         /// A registry-based study design.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Registry")]
+        [EnumMember(Value = "https://schema.org/Registry")]
         Registry
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalProcedureType.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalProcedureType.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// A type of medical procedure that involves noninvasive techniques.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/NoninvasiveProcedure")]
+        [EnumMember(Value = "https://schema.org/NoninvasiveProcedure")]
         NoninvasiveProcedure,
 
         /// <summary>
         /// A type of medical procedure that involves percutaneous techniques, where access to organs or tissue is achieved via needle-puncture of the skin. For example, catheter-based procedures like stent delivery.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PercutaneousProcedure")]
+        [EnumMember(Value = "https://schema.org/PercutaneousProcedure")]
         PercutaneousProcedure
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalSpecialty.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalSpecialty.cs
@@ -13,247 +13,247 @@
         /// <summary>
         /// A specific branch of medical science that pertains to study of anesthetics and their application.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Anesthesia")]
+        [EnumMember(Value = "https://schema.org/Anesthesia")]
         Anesthesia,
 
         /// <summary>
         /// A specific branch of medical science that pertains to diagnosis and treatment of disorders of heart and vasculature.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Cardiovascular")]
+        [EnumMember(Value = "https://schema.org/Cardiovascular")]
         Cardiovascular,
 
         /// <summary>
         /// A field of public health focusing on improving health characteristics of a defined population in relation with their geographical or environment areas
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CommunityHealth")]
+        [EnumMember(Value = "https://schema.org/CommunityHealth")]
         CommunityHealth,
 
         /// <summary>
         /// A branch of medicine that is involved in the dental care.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Dentistry")]
+        [EnumMember(Value = "https://schema.org/Dentistry")]
         Dentistry,
 
         /// <summary>
         /// A specific branch of medical science that pertains to diagnosis and treatment of disorders of skin.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Dermatology")]
+        [EnumMember(Value = "https://schema.org/Dermatology")]
         Dermatology,
 
         /// <summary>
         /// Dietetic and nutrition as a medical speciality.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DietNutrition")]
+        [EnumMember(Value = "https://schema.org/DietNutrition")]
         DietNutrition,
 
         /// <summary>
         /// A specific branch of medical science that deals with the evaluation and initial treatment of medical conditions caused by trauma or sudden illness.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Emergency")]
+        [EnumMember(Value = "https://schema.org/Emergency")]
         Emergency,
 
         /// <summary>
         /// A specific branch of medical science that pertains to diagnosis and treatment of disorders of endocrine glands and their secretions.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Endocrine")]
+        [EnumMember(Value = "https://schema.org/Endocrine")]
         Endocrine,
 
         /// <summary>
         /// A specific branch of medical science that pertains to diagnosis and treatment of disorders of digestive system.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Gastroenterologic")]
+        [EnumMember(Value = "https://schema.org/Gastroenterologic")]
         Gastroenterologic,
 
         /// <summary>
         /// A specific branch of medical science that pertains to hereditary transmission and the variation of inherited characteristics and disorders.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Genetic")]
+        [EnumMember(Value = "https://schema.org/Genetic")]
         Genetic,
 
         /// <summary>
         /// A specific branch of medical science that is concerned with the diagnosis and treatment of diseases, debilities and provision of care to the aged.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Geriatric")]
+        [EnumMember(Value = "https://schema.org/Geriatric")]
         Geriatric,
 
         /// <summary>
         /// A specific branch of medical science that pertains to the health care of women, particularly in the diagnosis and treatment of disorders affecting the female reproductive system.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Gynecologic")]
+        [EnumMember(Value = "https://schema.org/Gynecologic")]
         Gynecologic,
 
         /// <summary>
         /// A specific branch of medical science that pertains to diagnosis and treatment of disorders of blood and blood producing organs.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Hematologic")]
+        [EnumMember(Value = "https://schema.org/Hematologic")]
         Hematologic,
 
         /// <summary>
         /// Something in medical science that pertains to infectious diseases i.e caused by bacterial, viral, fungal or parasitic infections.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Infectious")]
+        [EnumMember(Value = "https://schema.org/Infectious")]
         Infectious,
 
         /// <summary>
         /// A medical science pertaining to chemical, hematological, immunologic, microscopic, or bacteriological diagnostic analyses or research
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LaboratoryScience")]
+        [EnumMember(Value = "https://schema.org/LaboratoryScience")]
         LaboratoryScience,
 
         /// <summary>
         /// A nurse-like health profession that deals with pregnancy, childbirth, and the postpartum period (including care of the newborn), besides sexual and reproductive health of women throughout their lives.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Midwifery")]
+        [EnumMember(Value = "https://schema.org/Midwifery")]
         Midwifery,
 
         /// <summary>
         /// A specific branch of medical science that pertains to diagnosis and treatment of disorders of muscles, ligaments and skeletal system.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Musculoskeletal")]
+        [EnumMember(Value = "https://schema.org/Musculoskeletal")]
         Musculoskeletal,
 
         /// <summary>
         /// A specific branch of medical science that studies the nerves and nervous system and its respective disease states.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Neurologic")]
+        [EnumMember(Value = "https://schema.org/Neurologic")]
         Neurologic,
 
         /// <summary>
         /// A health profession of a person formally educated and trained in the care of the sick or infirm person.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Nursing")]
+        [EnumMember(Value = "https://schema.org/Nursing")]
         Nursing,
 
         /// <summary>
         /// A specific branch of medical science that specializes in the care of women during the prenatal and postnatal care and with the delivery of the child.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Obstetric")]
+        [EnumMember(Value = "https://schema.org/Obstetric")]
         Obstetric,
 
         /// <summary>
         /// A specific branch of medical science that deals with benign and malignant tumors, including the study of their development, diagnosis, treatment and prevention.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Oncologic")]
+        [EnumMember(Value = "https://schema.org/Oncologic")]
         Oncologic,
 
         /// <summary>
         /// The science or practice of testing visual acuity and prescribing corrective lenses.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Optometric")]
+        [EnumMember(Value = "https://schema.org/Optometric")]
         Optometric,
 
         /// <summary>
         /// A specific branch of medical science that is concerned with the ear, nose and throat and their respective disease states.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Otolaryngologic")]
+        [EnumMember(Value = "https://schema.org/Otolaryngologic")]
         Otolaryngologic,
 
         /// <summary>
         /// A specific branch of medical science that is concerned with the study of the cause, origin and nature of a disease state, including its consequences as a result of manifestation of the disease. In clinical care, the term is used to designate a branch of medicine using laboratory tests to diagnose and determine the prognostic significance of illness.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Pathology")]
+        [EnumMember(Value = "https://schema.org/Pathology")]
         Pathology,
 
         /// <summary>
         /// A specific branch of medical science that specializes in the care of infants, children and adolescents.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Pediatric")]
+        [EnumMember(Value = "https://schema.org/Pediatric")]
         Pediatric,
 
         /// <summary>
         /// The practice or art and science of preparing and dispensing drugs and medicines.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PharmacySpecialty")]
+        [EnumMember(Value = "https://schema.org/PharmacySpecialty")]
         PharmacySpecialty,
 
         /// <summary>
         /// The practice of treatment of disease, injury, or deformity by physical methods such as massage, heat treatment, and exercise rather than by drugs or surgery..
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Physiotherapy")]
+        [EnumMember(Value = "https://schema.org/Physiotherapy")]
         Physiotherapy,
 
         /// <summary>
         /// A specific branch of medical science that pertains to therapeutic or cosmetic repair or re-formation of missing, injured or malformed tissues or body parts by manual and instrumental means.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PlasticSurgery")]
+        [EnumMember(Value = "https://schema.org/PlasticSurgery")]
         PlasticSurgery,
 
         /// <summary>
         /// Podiatry is the care of the human foot, especially the diagnosis and treatment of foot disorders.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Podiatric")]
+        [EnumMember(Value = "https://schema.org/Podiatric")]
         Podiatric,
 
         /// <summary>
         /// The medical care by a physician, or other health-care professional, who is the patient's first contact with the health-care system and who may recommend a specialist if necessary.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PrimaryCare")]
+        [EnumMember(Value = "https://schema.org/PrimaryCare")]
         PrimaryCare,
 
         /// <summary>
         /// A specific branch of medical science that is concerned with the study, treatment, and prevention of mental illness, using both medical and psychological therapies.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Psychiatric")]
+        [EnumMember(Value = "https://schema.org/Psychiatric")]
         Psychiatric,
 
         /// <summary>
         /// Branch of medicine that pertains to the health services to improve and protect community health, especially epidemiology, sanitation, immunization, and preventive medicine.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PublicHealth")]
+        [EnumMember(Value = "https://schema.org/PublicHealth")]
         PublicHealth,
 
         /// <summary>
         /// A specific branch of medical science that pertains to the study of the respiratory system and its respective disease states.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Pulmonary")]
+        [EnumMember(Value = "https://schema.org/Pulmonary")]
         Pulmonary,
 
         /// <summary>
         /// Radiography is an imaging technique that uses electromagnetic radiation other than visible light, especially X-rays, to view the internal structure of a non-uniformly composed and opaque object such as the human body.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Radiography")]
+        [EnumMember(Value = "https://schema.org/Radiography")]
         Radiography,
 
         /// <summary>
         /// A specific branch of medical science that pertains to the study of the kidneys and its respective disease states.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Renal")]
+        [EnumMember(Value = "https://schema.org/Renal")]
         Renal,
 
         /// <summary>
         /// The therapy that is concerned with the maintenance or improvement of respiratory function (as in patients with pulmonary disease).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RespiratoryTherapy")]
+        [EnumMember(Value = "https://schema.org/RespiratoryTherapy")]
         RespiratoryTherapy,
 
         /// <summary>
         /// A specific branch of medical science that deals with the study and treatment of rheumatic, autoimmune or joint diseases.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Rheumatologic")]
+        [EnumMember(Value = "https://schema.org/Rheumatologic")]
         Rheumatologic,
 
         /// <summary>
         /// The scientific study and treatment of defects, disorders, and malfunctions of speech and voice, as stuttering, lisping, or lalling, and of language disturbances, as aphasia or delayed language acquisition.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SpeechPathology")]
+        [EnumMember(Value = "https://schema.org/SpeechPathology")]
         SpeechPathology,
 
         /// <summary>
         /// A specific branch of medical science that pertains to treating diseases, injuries and deformities by manual and instrumental means.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Surgical")]
+        [EnumMember(Value = "https://schema.org/Surgical")]
         Surgical,
 
         /// <summary>
         /// A specific branch of medical science that is concerned with poisons, their nature, effects and detection and involved in the treatment of poisoning.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Toxicologic")]
+        [EnumMember(Value = "https://schema.org/Toxicologic")]
         Toxicologic,
 
         /// <summary>
         /// A specific branch of medical science that is concerned with the diagnosis and treatment of diseases pertaining to the urinary tract and the urogenital system.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Urologic")]
+        [EnumMember(Value = "https://schema.org/Urologic")]
         Urologic
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalStudyStatus.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalStudyStatus.cs
@@ -13,61 +13,61 @@
         /// <summary>
         /// Active, but not recruiting new participants.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ActiveNotRecruiting")]
+        [EnumMember(Value = "https://schema.org/ActiveNotRecruiting")]
         ActiveNotRecruiting,
 
         /// <summary>
         /// Completed.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Completed")]
+        [EnumMember(Value = "https://schema.org/Completed")]
         Completed,
 
         /// <summary>
         /// Enrolling participants by invitation only.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EnrollingByInvitation")]
+        [EnumMember(Value = "https://schema.org/EnrollingByInvitation")]
         EnrollingByInvitation,
 
         /// <summary>
         /// Not yet recruiting.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/NotYetRecruiting")]
+        [EnumMember(Value = "https://schema.org/NotYetRecruiting")]
         NotYetRecruiting,
 
         /// <summary>
         /// Recruiting participants.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Recruiting")]
+        [EnumMember(Value = "https://schema.org/Recruiting")]
         Recruiting,
 
         /// <summary>
         /// Results are available.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ResultsAvailable")]
+        [EnumMember(Value = "https://schema.org/ResultsAvailable")]
         ResultsAvailable,
 
         /// <summary>
         /// Results are not available.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ResultsNotAvailable")]
+        [EnumMember(Value = "https://schema.org/ResultsNotAvailable")]
         ResultsNotAvailable,
 
         /// <summary>
         /// Suspended.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Suspended")]
+        [EnumMember(Value = "https://schema.org/Suspended")]
         Suspended,
 
         /// <summary>
         /// Terminated.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Terminated")]
+        [EnumMember(Value = "https://schema.org/Terminated")]
         Terminated,
 
         /// <summary>
         /// Withdrawn.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Withdrawn")]
+        [EnumMember(Value = "https://schema.org/Withdrawn")]
         Withdrawn
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicalTrialDesign.cs
+++ b/Source/Schema.NET/core/enumerations/MedicalTrialDesign.cs
@@ -13,55 +13,55 @@
         /// <summary>
         /// A trial design in which neither the researcher nor the patient knows the details of the treatment the patient was randomly assigned to.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DoubleBlindedTrial")]
+        [EnumMember(Value = "https://schema.org/DoubleBlindedTrial")]
         DoubleBlindedTrial,
 
         /// <summary>
         /// An international trial.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/InternationalTrial")]
+        [EnumMember(Value = "https://schema.org/InternationalTrial")]
         InternationalTrial,
 
         /// <summary>
         /// A trial that takes place at multiple centers.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/MultiCenterTrial")]
+        [EnumMember(Value = "https://schema.org/MultiCenterTrial")]
         MultiCenterTrial,
 
         /// <summary>
         /// A trial design in which the researcher knows the full details of the treatment, and so does the patient.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OpenTrial")]
+        [EnumMember(Value = "https://schema.org/OpenTrial")]
         OpenTrial,
 
         /// <summary>
         /// A placebo-controlled trial design.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PlaceboControlledTrial")]
+        [EnumMember(Value = "https://schema.org/PlaceboControlledTrial")]
         PlaceboControlledTrial,
 
         /// <summary>
         /// A randomized trial design.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RandomizedTrial")]
+        [EnumMember(Value = "https://schema.org/RandomizedTrial")]
         RandomizedTrial,
 
         /// <summary>
         /// A trial design in which the researcher knows which treatment the patient was randomly assigned to but the patient does not.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SingleBlindedTrial")]
+        [EnumMember(Value = "https://schema.org/SingleBlindedTrial")]
         SingleBlindedTrial,
 
         /// <summary>
         /// A trial that takes place at a single center.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SingleCenterTrial")]
+        [EnumMember(Value = "https://schema.org/SingleCenterTrial")]
         SingleCenterTrial,
 
         /// <summary>
         /// A trial design in which neither the researcher, the person administering the therapy nor the patient knows the details of the treatment the patient was randomly assigned to.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/TripleBlindedTrial")]
+        [EnumMember(Value = "https://schema.org/TripleBlindedTrial")]
         TripleBlindedTrial
     }
 }

--- a/Source/Schema.NET/core/enumerations/MedicineSystem.cs
+++ b/Source/Schema.NET/core/enumerations/MedicineSystem.cs
@@ -13,37 +13,37 @@
         /// <summary>
         /// A system of medicine that originated in India over thousands of years and that focuses on integrating and balancing the body, mind, and spirit.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Ayurvedic")]
+        [EnumMember(Value = "https://schema.org/Ayurvedic")]
         Ayurvedic,
 
         /// <summary>
         /// A system of medicine focused on the relationship between the body's structure, mainly the spine, and its functioning.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Chiropractic")]
+        [EnumMember(Value = "https://schema.org/Chiropractic")]
         Chiropractic,
 
         /// <summary>
         /// A system of medicine based on the principle that a disease can be cured by a substance that produces similar symptoms in healthy people.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Homeopathic")]
+        [EnumMember(Value = "https://schema.org/Homeopathic")]
         Homeopathic,
 
         /// <summary>
         /// A system of medicine focused on promoting the body's innate ability to heal itself.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Osteopathic")]
+        [EnumMember(Value = "https://schema.org/Osteopathic")]
         Osteopathic,
 
         /// <summary>
         /// A system of medicine based on common theoretical concepts that originated in China and evolved over thousands of years, that uses herbs, acupuncture, exercise, massage, dietary therapy, and other methods to treat a wide range of conditions.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/TraditionalChinese")]
+        [EnumMember(Value = "https://schema.org/TraditionalChinese")]
         TraditionalChinese,
 
         /// <summary>
         /// The conventional Western system of medicine, that aims to apply the best available evidence gained from the scientific method to clinical decision making. Also known as conventional or Western medicine.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/WesternConventional")]
+        [EnumMember(Value = "https://schema.org/WesternConventional")]
         WesternConventional
     }
 }

--- a/Source/Schema.NET/core/enumerations/MusicAlbumProductionType.cs
+++ b/Source/Schema.NET/core/enumerations/MusicAlbumProductionType.cs
@@ -13,55 +13,55 @@
         /// <summary>
         /// CompilationAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CompilationAlbum")]
+        [EnumMember(Value = "https://schema.org/CompilationAlbum")]
         CompilationAlbum,
 
         /// <summary>
         /// DemoAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DemoAlbum")]
+        [EnumMember(Value = "https://schema.org/DemoAlbum")]
         DemoAlbum,
 
         /// <summary>
         /// DJMixAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DJMixAlbum")]
+        [EnumMember(Value = "https://schema.org/DJMixAlbum")]
         DJMixAlbum,
 
         /// <summary>
         /// LiveAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LiveAlbum")]
+        [EnumMember(Value = "https://schema.org/LiveAlbum")]
         LiveAlbum,
 
         /// <summary>
         /// MixtapeAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/MixtapeAlbum")]
+        [EnumMember(Value = "https://schema.org/MixtapeAlbum")]
         MixtapeAlbum,
 
         /// <summary>
         /// RemixAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RemixAlbum")]
+        [EnumMember(Value = "https://schema.org/RemixAlbum")]
         RemixAlbum,
 
         /// <summary>
         /// SoundtrackAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SoundtrackAlbum")]
+        [EnumMember(Value = "https://schema.org/SoundtrackAlbum")]
         SoundtrackAlbum,
 
         /// <summary>
         /// SpokenWordAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SpokenWordAlbum")]
+        [EnumMember(Value = "https://schema.org/SpokenWordAlbum")]
         SpokenWordAlbum,
 
         /// <summary>
         /// StudioAlbum.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/StudioAlbum")]
+        [EnumMember(Value = "https://schema.org/StudioAlbum")]
         StudioAlbum
     }
 }

--- a/Source/Schema.NET/core/enumerations/MusicAlbumReleaseType.cs
+++ b/Source/Schema.NET/core/enumerations/MusicAlbumReleaseType.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// AlbumRelease.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/AlbumRelease")]
+        [EnumMember(Value = "https://schema.org/AlbumRelease")]
         AlbumRelease,
 
         /// <summary>
         /// BroadcastRelease.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/BroadcastRelease")]
+        [EnumMember(Value = "https://schema.org/BroadcastRelease")]
         BroadcastRelease,
 
         /// <summary>
         /// EPRelease.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/EPRelease")]
+        [EnumMember(Value = "https://schema.org/EPRelease")]
         EPRelease,
 
         /// <summary>
         /// SingleRelease.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/SingleRelease")]
+        [EnumMember(Value = "https://schema.org/SingleRelease")]
         SingleRelease
     }
 }

--- a/Source/Schema.NET/core/enumerations/MusicReleaseFormatType.cs
+++ b/Source/Schema.NET/core/enumerations/MusicReleaseFormatType.cs
@@ -13,43 +13,43 @@
         /// <summary>
         /// CassetteFormat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CassetteFormat")]
+        [EnumMember(Value = "https://schema.org/CassetteFormat")]
         CassetteFormat,
 
         /// <summary>
         /// CDFormat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CDFormat")]
+        [EnumMember(Value = "https://schema.org/CDFormat")]
         CDFormat,
 
         /// <summary>
         /// DigitalAudioTapeFormat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DigitalAudioTapeFormat")]
+        [EnumMember(Value = "https://schema.org/DigitalAudioTapeFormat")]
         DigitalAudioTapeFormat,
 
         /// <summary>
         /// DigitalFormat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DigitalFormat")]
+        [EnumMember(Value = "https://schema.org/DigitalFormat")]
         DigitalFormat,
 
         /// <summary>
         /// DVDFormat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DVDFormat")]
+        [EnumMember(Value = "https://schema.org/DVDFormat")]
         DVDFormat,
 
         /// <summary>
         /// LaserDiscFormat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LaserDiscFormat")]
+        [EnumMember(Value = "https://schema.org/LaserDiscFormat")]
         LaserDiscFormat,
 
         /// <summary>
         /// VinylFormat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/VinylFormat")]
+        [EnumMember(Value = "https://schema.org/VinylFormat")]
         VinylFormat
     }
 }

--- a/Source/Schema.NET/core/enumerations/OfferItemCondition.cs
+++ b/Source/Schema.NET/core/enumerations/OfferItemCondition.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// Indicates that the item is damaged.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DamagedCondition")]
+        [EnumMember(Value = "https://schema.org/DamagedCondition")]
         DamagedCondition,
 
         /// <summary>
         /// Indicates that the item is new.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/NewCondition")]
+        [EnumMember(Value = "https://schema.org/NewCondition")]
         NewCondition,
 
         /// <summary>
         /// Indicates that the item is refurbished.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RefurbishedCondition")]
+        [EnumMember(Value = "https://schema.org/RefurbishedCondition")]
         RefurbishedCondition,
 
         /// <summary>
         /// Indicates that the item is used.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/UsedCondition")]
+        [EnumMember(Value = "https://schema.org/UsedCondition")]
         UsedCondition
     }
 }

--- a/Source/Schema.NET/core/enumerations/OrderStatus.cs
+++ b/Source/Schema.NET/core/enumerations/OrderStatus.cs
@@ -13,49 +13,49 @@
         /// <summary>
         /// OrderStatus representing cancellation of an order.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderCancelled")]
+        [EnumMember(Value = "https://schema.org/OrderCancelled")]
         OrderCancelled,
 
         /// <summary>
         /// OrderStatus representing successful delivery of an order.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderDelivered")]
+        [EnumMember(Value = "https://schema.org/OrderDelivered")]
         OrderDelivered,
 
         /// <summary>
         /// OrderStatus representing that an order is in transit.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderInTransit")]
+        [EnumMember(Value = "https://schema.org/OrderInTransit")]
         OrderInTransit,
 
         /// <summary>
         /// OrderStatus representing that payment is due on an order.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderPaymentDue")]
+        [EnumMember(Value = "https://schema.org/OrderPaymentDue")]
         OrderPaymentDue,
 
         /// <summary>
         /// OrderStatus representing availability of an order for pickup.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderPickupAvailable")]
+        [EnumMember(Value = "https://schema.org/OrderPickupAvailable")]
         OrderPickupAvailable,
 
         /// <summary>
         /// OrderStatus representing that there is a problem with the order.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderProblem")]
+        [EnumMember(Value = "https://schema.org/OrderProblem")]
         OrderProblem,
 
         /// <summary>
         /// OrderStatus representing that an order is being processed.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderProcessing")]
+        [EnumMember(Value = "https://schema.org/OrderProcessing")]
         OrderProcessing,
 
         /// <summary>
         /// OrderStatus representing that an order has been returned.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OrderReturned")]
+        [EnumMember(Value = "https://schema.org/OrderReturned")]
         OrderReturned
     }
 }

--- a/Source/Schema.NET/core/enumerations/PaymentStatusType.cs
+++ b/Source/Schema.NET/core/enumerations/PaymentStatusType.cs
@@ -13,31 +13,31 @@
         /// <summary>
         /// An automatic payment system is in place and will be used.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PaymentAutomaticallyApplied")]
+        [EnumMember(Value = "https://schema.org/PaymentAutomaticallyApplied")]
         PaymentAutomaticallyApplied,
 
         /// <summary>
         /// The payment has been received and processed.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PaymentComplete")]
+        [EnumMember(Value = "https://schema.org/PaymentComplete")]
         PaymentComplete,
 
         /// <summary>
         /// The payee received the payment, but it was declined for some reason.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PaymentDeclined")]
+        [EnumMember(Value = "https://schema.org/PaymentDeclined")]
         PaymentDeclined,
 
         /// <summary>
         /// The payment is due, but still within an acceptable time to be received.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PaymentDue")]
+        [EnumMember(Value = "https://schema.org/PaymentDue")]
         PaymentDue,
 
         /// <summary>
         /// The payment is due and considered late.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/PaymentPastDue")]
+        [EnumMember(Value = "https://schema.org/PaymentPastDue")]
         PaymentPastDue
     }
 }

--- a/Source/Schema.NET/core/enumerations/PhysicalActivityCategory.cs
+++ b/Source/Schema.NET/core/enumerations/PhysicalActivityCategory.cs
@@ -13,43 +13,43 @@
         /// <summary>
         /// Physical activity of relatively low intensity that depends primarily on the aerobic energy-generating process; during activity, the aerobic metabolism uses oxygen to adequately meet energy demands during exercise.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/AerobicActivity")]
+        [EnumMember(Value = "https://schema.org/AerobicActivity")]
         AerobicActivity,
 
         /// <summary>
         /// Physical activity that is of high-intensity which utilizes the anaerobic metabolism of the body.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/AnaerobicActivity")]
+        [EnumMember(Value = "https://schema.org/AnaerobicActivity")]
         AnaerobicActivity,
 
         /// <summary>
         /// Physical activity that is engaged to help maintain posture and balance.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Balance")]
+        [EnumMember(Value = "https://schema.org/Balance")]
         Balance,
 
         /// <summary>
         /// Physical activity that is engaged in to improve joint and muscle flexibility.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Flexibility")]
+        [EnumMember(Value = "https://schema.org/Flexibility")]
         Flexibility,
 
         /// <summary>
         /// Any physical activity engaged in for recreational purposes. Examples may include ballroom dancing, roller skating, canoeing, fishing, etc.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LeisureTimeActivity")]
+        [EnumMember(Value = "https://schema.org/LeisureTimeActivity")]
         LeisureTimeActivity,
 
         /// <summary>
         /// Any physical activity engaged in for job-related purposes. Examples may include waiting tables, maid service, carrying a mailbag, picking fruits or vegetables, construction work, etc.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/OccupationalActivity")]
+        [EnumMember(Value = "https://schema.org/OccupationalActivity")]
         OccupationalActivity,
 
         /// <summary>
         /// Physical activity that is engaged in to improve muscle and bone strength. Also referred to as resistance training.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/StrengthTraining")]
+        [EnumMember(Value = "https://schema.org/StrengthTraining")]
         StrengthTraining
     }
 }

--- a/Source/Schema.NET/core/enumerations/PhysicalExam.cs
+++ b/Source/Schema.NET/core/enumerations/PhysicalExam.cs
@@ -13,85 +13,85 @@
         /// <summary>
         /// Abdomen clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Abdomen")]
+        [EnumMember(Value = "https://schema.org/Abdomen")]
         Abdomen,
 
         /// <summary>
         /// Appearance assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Appearance")]
+        [EnumMember(Value = "https://schema.org/Appearance")]
         Appearance,
 
         /// <summary>
         /// Cardiovascular system assessment withclinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/CardiovascularExam")]
+        [EnumMember(Value = "https://schema.org/CardiovascularExam")]
         CardiovascularExam,
 
         /// <summary>
         /// Ear function assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Ear")]
+        [EnumMember(Value = "https://schema.org/Ear")]
         Ear,
 
         /// <summary>
         /// Eye or ophtalmological function assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Eye")]
+        [EnumMember(Value = "https://schema.org/Eye")]
         Eye,
 
         /// <summary>
         /// Genitourinary system function assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Genitourinary")]
+        [EnumMember(Value = "https://schema.org/Genitourinary")]
         Genitourinary,
 
         /// <summary>
         /// Head assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Head")]
+        [EnumMember(Value = "https://schema.org/Head")]
         Head,
 
         /// <summary>
         /// Lung and respiratory system clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Lung")]
+        [EnumMember(Value = "https://schema.org/Lung")]
         Lung,
 
         /// <summary>
         /// Musculoskeletal system clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/MusculoskeletalExam")]
+        [EnumMember(Value = "https://schema.org/MusculoskeletalExam")]
         MusculoskeletalExam,
 
         /// <summary>
         /// Neck assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Neck")]
+        [EnumMember(Value = "https://schema.org/Neck")]
         Neck,
 
         /// <summary>
         /// Neurological system clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Neuro")]
+        [EnumMember(Value = "https://schema.org/Neuro")]
         Neuro,
 
         /// <summary>
         /// Nose function assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Nose")]
+        [EnumMember(Value = "https://schema.org/Nose")]
         Nose,
 
         /// <summary>
         /// Skin assessment with clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Skin")]
+        [EnumMember(Value = "https://schema.org/Skin")]
         Skin,
 
         /// <summary>
         /// Throat assessment with  clinical examination.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/Throat")]
+        [EnumMember(Value = "https://schema.org/Throat")]
         Throat
     }
 }

--- a/Source/Schema.NET/core/enumerations/ReservationStatusType.cs
+++ b/Source/Schema.NET/core/enumerations/ReservationStatusType.cs
@@ -13,25 +13,25 @@
         /// <summary>
         /// The status for a previously confirmed reservation that is now cancelled.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ReservationCancelled")]
+        [EnumMember(Value = "https://schema.org/ReservationCancelled")]
         ReservationCancelled,
 
         /// <summary>
         /// The status of a confirmed reservation.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ReservationConfirmed")]
+        [EnumMember(Value = "https://schema.org/ReservationConfirmed")]
         ReservationConfirmed,
 
         /// <summary>
         /// The status of a reservation on hold pending an update like credit card number or flight changes.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ReservationHold")]
+        [EnumMember(Value = "https://schema.org/ReservationHold")]
         ReservationHold,
 
         /// <summary>
         /// The status of a reservation when a request has been sent, but not confirmed.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/ReservationPending")]
+        [EnumMember(Value = "https://schema.org/ReservationPending")]
         ReservationPending
     }
 }

--- a/Source/Schema.NET/core/enumerations/RestrictedDiet.cs
+++ b/Source/Schema.NET/core/enumerations/RestrictedDiet.cs
@@ -13,67 +13,67 @@
         /// <summary>
         /// A diet appropriate for people with diabetes.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/DiabeticDiet")]
+        [EnumMember(Value = "https://schema.org/DiabeticDiet")]
         DiabeticDiet,
 
         /// <summary>
         /// A diet exclusive of gluten.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/GlutenFreeDiet")]
+        [EnumMember(Value = "https://schema.org/GlutenFreeDiet")]
         GlutenFreeDiet,
 
         /// <summary>
         /// A diet conforming to Islamic dietary practices.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/HalalDiet")]
+        [EnumMember(Value = "https://schema.org/HalalDiet")]
         HalalDiet,
 
         /// <summary>
         /// A diet conforming to Hindu dietary practices, in particular, beef-free.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/HinduDiet")]
+        [EnumMember(Value = "https://schema.org/HinduDiet")]
         HinduDiet,
 
         /// <summary>
         /// A diet conforming to Jewish dietary practices.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/KosherDiet")]
+        [EnumMember(Value = "https://schema.org/KosherDiet")]
         KosherDiet,
 
         /// <summary>
         /// A diet focused on reduced calorie intake.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LowCalorieDiet")]
+        [EnumMember(Value = "https://schema.org/LowCalorieDiet")]
         LowCalorieDiet,
 
         /// <summary>
         /// A diet focused on reduced fat and cholesterol intake.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LowFatDiet")]
+        [EnumMember(Value = "https://schema.org/LowFatDiet")]
         LowFatDiet,
 
         /// <summary>
         /// A diet appropriate for people with lactose intolerance.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LowLactoseDiet")]
+        [EnumMember(Value = "https://schema.org/LowLactoseDiet")]
         LowLactoseDiet,
 
         /// <summary>
         /// A diet focused on reduced sodium intake.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LowSaltDiet")]
+        [EnumMember(Value = "https://schema.org/LowSaltDiet")]
         LowSaltDiet,
 
         /// <summary>
         /// A diet exclusive of all animal products.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/VeganDiet")]
+        [EnumMember(Value = "https://schema.org/VeganDiet")]
         VeganDiet,
 
         /// <summary>
         /// A diet exclusive of animal meat.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/VegetarianDiet")]
+        [EnumMember(Value = "https://schema.org/VegetarianDiet")]
         VegetarianDiet
     }
 }

--- a/Source/Schema.NET/core/enumerations/RsvpResponseType.cs
+++ b/Source/Schema.NET/core/enumerations/RsvpResponseType.cs
@@ -13,19 +13,19 @@
         /// <summary>
         /// The invitee may or may not attend.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RsvpResponseMaybe")]
+        [EnumMember(Value = "https://schema.org/RsvpResponseMaybe")]
         RsvpResponseMaybe,
 
         /// <summary>
         /// The invitee will not attend.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RsvpResponseNo")]
+        [EnumMember(Value = "https://schema.org/RsvpResponseNo")]
         RsvpResponseNo,
 
         /// <summary>
         /// The invitee will attend.
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RsvpResponseYes")]
+        [EnumMember(Value = "https://schema.org/RsvpResponseYes")]
         RsvpResponseYes
     }
 }

--- a/Source/Schema.NET/core/enumerations/SteeringPositionValue.cs
+++ b/Source/Schema.NET/core/enumerations/SteeringPositionValue.cs
@@ -13,13 +13,13 @@
         /// <summary>
         /// The steering position is on the left side of the vehicle (viewed from the main direction of driving).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/LeftHandDriving")]
+        [EnumMember(Value = "https://schema.org/LeftHandDriving")]
         LeftHandDriving,
 
         /// <summary>
         /// The steering position is on the right side of the vehicle (viewed from the main direction of driving).
         /// </summary>
-        [EnumMember(Value = "http://schema.org/RightHandDriving")]
+        [EnumMember(Value = "https://schema.org/RightHandDriving")]
         RightHandDriving
     }
 }

--- a/Tests/Schema.NET.Test/ContextJsonConverterTest.cs
+++ b/Tests/Schema.NET.Test/ContextJsonConverterTest.cs
@@ -46,7 +46,7 @@ namespace Schema.NET.Test
         {
             var json = new Thing().ToString();
 
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Thing\"}", json);
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Thing\"}", json);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Schema.NET.Test
 
             var json = thing.ToString();
 
-            Assert.Equal("{\"@context\":{\"name\":\"http://schema.org\",\"@language\":\"en\"},\"@type\":\"Thing\"}", json);
+            Assert.Equal("{\"@context\":{\"name\":\"https://schema.org\",\"@language\":\"en\"},\"@type\":\"Thing\"}", json);
         }
     }
 }

--- a/Tests/Schema.NET.Test/JsonLdContextTest.cs
+++ b/Tests/Schema.NET.Test/JsonLdContextTest.cs
@@ -31,7 +31,7 @@ namespace Schema.NET.Test
 
         public static IEnumerable<object[]> ToStringContexts => new List<object[]>
         {
-            new object[] { new JsonLdContext(), "http://schema.org" },
+            new object[] { new JsonLdContext(), "https://schema.org" },
             new object[] { new JsonLdContext() { Name = "a" }, "a" },
         };
 

--- a/Tests/Schema.NET.Test/MixedTypesTest.cs
+++ b/Tests/Schema.NET.Test/MixedTypesTest.cs
@@ -26,7 +26,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"Book\"," +
                 "\"@id\":\"http://example.com/book/1\"," +
                 "\"author\":[" +
@@ -70,7 +70,7 @@ namespace Schema.NET.Test
         {
             var json =
                 @"{" +
-                    "\"@context\":\"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\":\"BankAccount\"," +
                     "\"bankAccountType\":[" +
                         "\"http://example.com/1\"," +
@@ -102,7 +102,7 @@ namespace Schema.NET.Test
             };
             var json =
                 @"{" +
-                    "\"@context\":\"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\":\"BankAccount\"," +
                     "\"bankAccountType\":[" +
                         "\"http://example.com/1\"," +

--- a/Tests/Schema.NET.Test/OneOrManyTest.cs
+++ b/Tests/Schema.NET.Test/OneOrManyTest.cs
@@ -246,7 +246,7 @@ namespace Schema.NET.Test
         public void ToString_NullEmptyOrWhiteSpace_BookOmitsNameProperty(string name)
         {
             var book = new Book() { Name = name };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\"}", book.ToString());
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Book\"}", book.ToString());
         }
 
         [Theory]
@@ -257,7 +257,7 @@ namespace Schema.NET.Test
         public void ToString_NullEmptyOrWhiteSpace_OrganizationOmitsAddressProperty(string address)
         {
             var organization = new Organization() { Address = address };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
         }
 
         [Theory]
@@ -268,7 +268,7 @@ namespace Schema.NET.Test
         public void ToString_NullEmptyOrWhiteSpace_BookOmitsNamePropertyFromList(string name)
         {
             var book = new Book() { Name = new List<string> { "Hamlet", name } };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
         }
 
         [Theory]
@@ -279,7 +279,7 @@ namespace Schema.NET.Test
         public void ToString_NullEmptyOrWhiteSpace_BookOmitsNamePropertyFromArray(string name)
         {
             var book = new Book() { Name = new string[] { "Hamlet", name } };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Book\",\"name\":\"Hamlet\"}", book.ToString());
         }
 
         [Theory]
@@ -290,7 +290,7 @@ namespace Schema.NET.Test
         public void ToString_EmptyOrWhiteSpace_OrganizationOmitsAddressProperty(string address)
         {
             var organization = new Organization() { Address = address };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Organization\"}", organization.ToString());
         }
 
         [Theory]
@@ -301,7 +301,7 @@ namespace Schema.NET.Test
         public void ToString_NullEmptyOrWhiteSpace_OrganizationOmitsNamePropertyFromList(string address)
         {
             var organization = new Organization() { Name = new List<string> { "Cardiff, UK", address } };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\",\"name\":\"Cardiff, UK\"}", organization.ToString());
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Organization\",\"name\":\"Cardiff, UK\"}", organization.ToString());
         }
 
         [Theory]
@@ -312,7 +312,7 @@ namespace Schema.NET.Test
         public void ToString_NullEmptyOrWhiteSpace_OrganizationOmitsNamePropertyFromArray(string address)
         {
             var organization = new Organization() { Name = new string[] { "Cardiff, UK", address } };
-            Assert.Equal("{\"@context\":\"http://schema.org\",\"@type\":\"Organization\",\"name\":\"Cardiff, UK\"}", organization.ToString());
+            Assert.Equal("{\"@context\":\"https://schema.org\",\"@type\":\"Organization\",\"name\":\"Cardiff, UK\"}", organization.ToString());
         }
     }
 }

--- a/Tests/Schema.NET.Test/SerializationTest.cs
+++ b/Tests/Schema.NET.Test/SerializationTest.cs
@@ -11,7 +11,7 @@ namespace Schema.NET.Test
     {
         private const string Json =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"Book\"," +
                 "\"@id\":\"http://example.com/book/1\"," +
                 "\"name\":\"The Catcher in the Rye</script><script>alert('gotcha');</script>\"," +
@@ -23,7 +23,7 @@ namespace Schema.NET.Test
 
         private const string JsonHtmlEscaped =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"Book\"," +
                 "\"@id\":\"http://example.com/book/1\"," +
                 "\"name\":\"The Catcher in the Rye\\u003c/script\\u003e\\u003cscript\\u003ealert(\\u0027gotcha\\u0027);\\u003c/script\\u003e\"," +
@@ -35,7 +35,7 @@ namespace Schema.NET.Test
 
         private const string JsonCustom =
             "{\r\n" +
-                "  \"@context\": \"http://schema.org\",\r\n" +
+                "  \"@context\": \"https://schema.org\",\r\n" +
                 "  \"@type\": \"Person\",\r\n" +
                 "  \"name\": \"J.D. Salinger\\u003c/script\\u003e\\u003cscript\\u003ealert(\\u0027gotcha\\u0027);\\u003c/script\\u003e\"\r\n" +
             "}";
@@ -90,7 +90,7 @@ namespace Schema.NET.Test
             var actual = localBusiness.ToString();
             var expected =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"LocalBusiness\"," +
                 "\"priceRange\":\"$$$\"" +
             "}";

--- a/Tests/Schema.NET.Test/ThingTest.cs
+++ b/Tests/Schema.NET.Test/ThingTest.cs
@@ -15,7 +15,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
             "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"NewObject\"," +
             "\"name\":\"New Object\"," +
             "\"description\":\"This is the description of a new object we can't deserialize\"," +

--- a/Tests/Schema.NET.Test/core/BookTest.cs
+++ b/Tests/Schema.NET.Test/core/BookTest.cs
@@ -32,9 +32,9 @@ namespace Schema.NET.Test
                             UrlTemplate = "http://www.barnesandnoble.com/store/info/offer/0316769487?purchase=true",
                             ActionPlatform = new List<Uri>()
                             {
-                                new Uri("http://schema.org/DesktopWebPlatform"),
-                                new Uri("http://schema.org/IOSPlatform"),
-                                new Uri("http://schema.org/AndroidPlatform")
+                                new Uri("https://schema.org/DesktopWebPlatform"),
+                                new Uri("https://schema.org/IOSPlatform"),
+                                new Uri("https://schema.org/AndroidPlatform")
                             }
                         },
                         ExpectsAcceptanceOf = new Offer()
@@ -61,9 +61,9 @@ namespace Schema.NET.Test
                             UrlTemplate = "http://www.barnesandnoble.com/store/info/offer/031676947?purchase=true",
                             ActionPlatform = new List<Uri>()
                             {
-                                new Uri("http://schema.org/DesktopWebPlatform"),
-                                new Uri("http://schema.org/IOSPlatform"),
-                                new Uri("http://schema.org/AndroidPlatform")
+                                new Uri("https://schema.org/DesktopWebPlatform"),
+                                new Uri("https://schema.org/IOSPlatform"),
+                                new Uri("https://schema.org/AndroidPlatform")
                             }
                         },
                         ExpectsAcceptanceOf = new Offer()
@@ -83,7 +83,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"Book\"," +
             "\"@id\":\"http://example.com/book/1\"," +
             "\"name\":\"The Catcher in the Rye\"," +
@@ -100,15 +100,15 @@ namespace Schema.NET.Test
                         "\"target\":{" +
                             "\"@type\":\"EntryPoint\"," +
                             "\"actionPlatform\":[" +
-                                "\"http://schema.org/DesktopWebPlatform\"," +
-                                "\"http://schema.org/IOSPlatform\"," +
-                                "\"http://schema.org/AndroidPlatform\"" +
+                                "\"https://schema.org/DesktopWebPlatform\"," +
+                                "\"https://schema.org/IOSPlatform\"," +
+                                "\"https://schema.org/AndroidPlatform\"" +
                             "]," +
                             "\"urlTemplate\":\"http://www.barnesandnoble.com/store/info/offer/0316769487?purchase=true\"" +
                         "}," +
                         "\"expectsAcceptanceOf\":{" +
                             "\"@type\":\"Offer\"," +
-                            "\"availability\":\"http://schema.org/InStock\"," +
+                            "\"availability\":\"https://schema.org/InStock\"," +
                             "\"eligibleRegion\":{" +
                                 "\"@type\":\"Country\"," +
                                 "\"name\":\"US\"" +
@@ -118,7 +118,7 @@ namespace Schema.NET.Test
                         "}" +
                     "}," +
                     "\"bookEdition\":\"2nd Edition\"," +
-                    "\"bookFormat\":\"http://schema.org/Hardcover\"," +
+                    "\"bookFormat\":\"https://schema.org/Hardcover\"," +
                     "\"isbn\":\"031676948\"" +
                 "}," +
                 "{" +
@@ -128,15 +128,15 @@ namespace Schema.NET.Test
                         "\"target\":{" +
                             "\"@type\":\"EntryPoint\"," +
                             "\"actionPlatform\":[" +
-                                "\"http://schema.org/DesktopWebPlatform\"," +
-                                "\"http://schema.org/IOSPlatform\"," +
-                                "\"http://schema.org/AndroidPlatform\"" +
+                                "\"https://schema.org/DesktopWebPlatform\"," +
+                                "\"https://schema.org/IOSPlatform\"," +
+                                "\"https://schema.org/AndroidPlatform\"" +
                             "]," +
                             "\"urlTemplate\":\"http://www.barnesandnoble.com/store/info/offer/031676947?purchase=true\"" +
                         "}," +
                         "\"expectsAcceptanceOf\":{" +
                             "\"@type\":\"Offer\"," +
-                            "\"availability\":\"http://schema.org/InStock\"," +
+                            "\"availability\":\"https://schema.org/InStock\"," +
                             "\"eligibleRegion\":{" +
                                 "\"@type\":\"Country\"," +
                                 "\"name\":\"UK\"" +
@@ -146,7 +146,7 @@ namespace Schema.NET.Test
                         "}" +
                     "}," +
                     "\"bookEdition\":\"1st Edition\"," +
-                    "\"bookFormat\":\"http://schema.org/EBook\"," +
+                    "\"bookFormat\":\"https://schema.org/EBook\"," +
                     "\"isbn\":\"031676947\"" +
                 "}" +
             "]" +

--- a/Tests/Schema.NET.Test/core/BreadcrumbListTest.cs
+++ b/Tests/Schema.NET.Test/core/BreadcrumbListTest.cs
@@ -37,7 +37,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"BreadcrumbList\"," +
             "\"itemListElement\":[" +
                 "{" +

--- a/Tests/Schema.NET.Test/core/CarTest.cs
+++ b/Tests/Schema.NET.Test/core/CarTest.cs
@@ -35,7 +35,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"Car\"," +
                 "\"name\":\"Volvo XC90\"," +
                 "\"description\":\"The XC90 is pure reflection of luxury that embodies Swedish design heritage. See everything this luxury SUV has to offer.\"," +
@@ -46,8 +46,8 @@ namespace Schema.NET.Test
                 "}," +
                 "\"offers\":{" +
                     "\"@type\":\"Offer\"," +
-                    "\"availability\":\"http://schema.org/InStock\"," +
-                    "\"itemCondition\":\"http://schema.org/NewCondition\"," +
+                    "\"availability\":\"https://schema.org/InStock\"," +
+                    "\"itemCondition\":\"https://schema.org/NewCondition\"," +
                     "\"price\":47200.0," +
                     "\"priceCurrency\":\"USD\"," +
                     "\"priceValidUntil\":\"2020-11-05\"," +

--- a/Tests/Schema.NET.Test/core/ClaimReviewTest.cs
+++ b/Tests/Schema.NET.Test/core/ClaimReviewTest.cs
@@ -36,7 +36,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"ClaimReview\"," +
             "\"url\":\"http://example.com/news/science/worldisflat.html\"," +
             "\"author\":{" +

--- a/Tests/Schema.NET.Test/core/CourseTest.cs
+++ b/Tests/Schema.NET.Test/core/CourseTest.cs
@@ -20,7 +20,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"Course\"," +
             "\"name\":\"Introduction to Computer Science and Programming\"," +
             "\"description\":\"Introductory CS course laying out the basics.\"," +

--- a/Tests/Schema.NET.Test/core/EventTest.cs
+++ b/Tests/Schema.NET.Test/core/EventTest.cs
@@ -60,7 +60,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"Event\"," +
             "\"name\":\"Jan Lieberman Concert Series: Journey in Jazz\"," +
             "\"description\":\"Join us for an afternoon of Jazz with Santa Clara resident and pianist Andy Lagunoff. Complimentary food and beverages will be served.\"," +
@@ -81,7 +81,7 @@ namespace Schema.NET.Test
                 "{" +
                     "\"@type\":\"Offer\"," +
                     "\"url\":\"https://www.example.com/event_offer/12345_201803180430\"," +
-                    "\"availability\":\"http://schema.org/InStock\"," +
+                    "\"availability\":\"https://schema.org/InStock\"," +
                     "\"price\":30.0," +
                     "\"priceCurrency\":\"USD\"," +
                     "\"validFrom\":\"2017-01-20T16:20:00-08:00\"" +

--- a/Tests/Schema.NET.Test/core/ItemListTest.cs
+++ b/Tests/Schema.NET.Test/core/ItemListTest.cs
@@ -33,7 +33,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"ItemList\"," +
             "\"itemListElement\":[" +
                 "{" +
@@ -85,7 +85,7 @@ namespace Schema.NET.Test
             };
             var expectedJson =
                 "{" +
-                    "\"@context\":\"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\":\"ItemList\"," +
                     "\"itemListElement\":[" +
                         "{" +
@@ -135,7 +135,7 @@ namespace Schema.NET.Test
             };
             var expectedJson =
                 "{" +
-                    "\"@context\":\"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\":\"ItemList\"," +
                     "\"itemListElement\":[" +
                         "{" +
@@ -167,7 +167,7 @@ namespace Schema.NET.Test
         {
             var json =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"ItemList\"," +
                 "\"itemListElement\":[" +
                     "{" +

--- a/Tests/Schema.NET.Test/core/JobPostingTest.cs
+++ b/Tests/Schema.NET.Test/core/JobPostingTest.cs
@@ -48,7 +48,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"JobPosting\"," +
             "\"title\":\"Fitter and Turner\"," +
             "\"description\":\"<p>Widget assembly role for pressing wheel assemblies.</p><p><strong>Educational Requirements:</strong> Completed level 2 ISTA Machinist Apprenticeship.</p><p><strong>Required Experience:</strong> At least 3 years in a machinist role.</p>\"," +

--- a/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
@@ -52,18 +52,18 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\": \"http://schema.org\"," +
+            "\"@context\": \"https://schema.org\"," +
             "\"@type\": \"MusicAlbum\"," +
             "\"name\": \"Hail to the Thief\"," +
             "\"identifier\": \"1oW3v5Har9mvXnGk0x4fHm\"," +
             "\"image\": [{" +
                     "\"$type\": \"Schema.NET.ImageObject, Schema.NET\"," +
-                    "\"@context\": \"http://schema.org\"," +
+                    "\"@context\": \"https://schema.org\"," +
                     "\"@type\": \"ImageObject\"," +
                     "\"contentUrl\": \"https://i.scdn.co/image/5ded47fd3d05325dd0faaf4619481e1f25a21ec7\"" +
                 "}, {" +
                     "\"$type\": \"Schema.NET.ImageObject, Schema.NET\"," +
-                    "\"@context\": \"http://schema.org\"," +
+                    "\"@context\": \"https://schema.org\"," +
                     "\"@type\": \"ImageObject\"," +
                     "\"contentUrl\": \"https://is4-ssl.mzstatic.com/image/thumb/Music69/v4/cc/1c/90/cc1c9039-c3ba-4256-e251-1687df46cb0a/cover.jpg/1400x1400bb.jpeg\"" +
                 "}" +
@@ -71,7 +71,7 @@ namespace Schema.NET.Test
             "\"sameAs\": \"https://music.apple.com/us/album/hail-to-the-thief/1097863576\"," +
             "\"url\": \"https://open.spotify.com/album/1oW3v5Har9mvXnGk0x4fHm\"," +
             "\"aggregateRating\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\": \"https://schema.org\"," +
                 "\"@type\": \"AggregateRating\"," +
                 "\"bestRating\": 100," +
                 "\"ratingValue\": 60," +
@@ -79,22 +79,22 @@ namespace Schema.NET.Test
             "}," +
             "\"datePublished\": \"2003-05-26\"," +
             "\"offers\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\": \"https://schema.org\"," +
                 "\"@type\": \"Offer\"," +
                 "\"gtin12\": \"634904078560\"" +
             "}," +
             "\"numTracks\": 14," +
             "\"albumRelease\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\": \"https://schema.org\"," +
                 "\"@type\": \"MusicRelease\"," +
                 "\"recordLabel\": {" +
-                    "\"@context\": \"http://schema.org\"," +
+                    "\"@context\": \"https://schema.org\"," +
                     "\"@type\": \"Organization\"," +
                     "\"name\": \"XL Recordings\"" +
                 "}" +
             "}," +
             "\"byArtist\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\": \"https://schema.org\"," +
                 "\"@type\": \"MusicGroup\"," +
                 "\"name\": \"Radiohead\"," +
                 "\"identifier\": \"4Z8W4fKeB5YxbusRsdQVPb\"" +

--- a/Tests/Schema.NET.Test/core/MusicEventTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicEventTest.cs
@@ -47,25 +47,25 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\": \"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\": \"MusicEvent\"," +
             "\"name\": \"Arash & Tohi\"," +
             "\"identifier\": \"vv1AaZAQ8Gkds-P77\"," +
             "\"url\": \"https://www.ticketmaster.com/arash-tohi-hollywood-california-06-22-2019/event/09005690F1865104\"," +
             "\"location\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"MusicVenue\"," +
                 "\"name\": \"Dolby Theatre\"," +
                 "\"identifier\": \"KovZpZAdtaEA\"" +
             "}," +
             "\"offers\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"Offer\"," +
                 "\"url\": \"https://www.ticketmaster.com/arash-tohi-hollywood-california-06-22-2019/event/09005690F1865104\"," +
                 "\"availabilityEnds\": \"2019-06-23T01:00:00-07:00\"," +
                 "\"availabilityStarts\": \"2019-04-24T21:00:00-07:00\"," +
                 "\"priceSpecification\": {" +
-                    "\"@context\": \"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\": \"PriceSpecification\"," +
                     "\"maxPrice\": 295," +
                     "\"minPrice\": 80," +
@@ -75,14 +75,14 @@ namespace Schema.NET.Test
             "\"performer\": [" +
                 "{" +
                     "\"$type\": \"Schema.NET.MusicGroup, Schema.NET\"," +
-                    "\"@context\": \"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\": \"MusicGroup\"," +
                     "\"name\": \"Arash\"," +
                     "\"identifier\": \"K8vZ917ukD7\"" +
                 "}," +
                 "{" +
                     "\"$type\": \"Schema.NET.MusicGroup, Schema.NET\"," +
-                    "\"@context\": \"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\": \"MusicGroup\"," +
                     "\"name\": \"Tohi\"," +
                     "\"identifier\": \"K8vZ917bA70\"" +

--- a/Tests/Schema.NET.Test/core/MusicGroupTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicGroupTest.cs
@@ -20,12 +20,12 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\": \"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\": \"MusicGroup\"," +
             "\"name\": \"Radiohead\"," +
             "\"identifier\": \"4Z8W4fKeB5YxbusRsdQVPb\"," +
             "\"image\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"ImageObject\"," +
                 "\"contentUrl\": \"https://i.scdn.co/image/afcd616e1ef2d2786f47b3b4a8a6aeea24a72adc\"" +
             "}," +

--- a/Tests/Schema.NET.Test/core/MusicRecordingTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicRecordingTest.cs
@@ -35,12 +35,12 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\": \"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\": \"MusicRecording\"," +
             "\"name\": \"2 + 2 = 5\"," +
             "\"identifier\": \"37kUGdEJJ7NaMl5LFW4EA4\"," +
             "\"image\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"ImageObject\"," +
                 "\"contentUrl\": \"https://is4-ssl.mzstatic.com/image/thumb/Music69/v4/cc/1c/90/cc1c9039-c3ba-4256-e251-1687df46cb0a/cover.jpg/1400x1400bb.jpeg\"" +
             "}," +
@@ -50,14 +50,14 @@ namespace Schema.NET.Test
             "\"isFamilyFriendly\": true," +
             "\"position\": \"1.1\"," +
             "\"byArtist\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"MusicGroup\"," +
                 "\"name\": \"Radiohead\"," +
                 "\"identifier\": \"4Z8W4fKeB5YxbusRsdQVPb\"" +
             "}," +
             "\"duration\": \"PT3M19.36S\"," +
             "\"inAlbum\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"MusicAlbum\"," +
                 "\"name\": \"Hail To the Thief\"," +
                 "\"identifier\": \"1oW3v5Har9mvXnGk0x4fHm\"" +

--- a/Tests/Schema.NET.Test/core/MusicVenueTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicVenueTest.cs
@@ -40,13 +40,13 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\": \"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\": \"MusicVenue\"," +
             "\"name\": \"Dolby Theatre\"," +
             "\"description\": \"Host to a range of prestigious events including movie premieres, concerts & the Oscars http://www.dolbytheatre.com\"," +
             "\"identifier\": \"KovZpZAdtaEA\"," +
             "\"image\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"ImageObject\"," +
                 "\"contentUrl\": \"https://s1.ticketm.net/dam/v/e6b/380fa861-3f46-44a9-a514-21553f7fbe6b_379601_SOURCE.jpg\"" +
             "}," +
@@ -56,7 +56,7 @@ namespace Schema.NET.Test
             "]," +
             "\"url\": \"https://foursquare.com/dolbytheatre\"," +
             "\"address\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"PostalAddress\"," +
                 "\"addressCountry\": \"US\"," +
                 "\"addressLocality\": \"Los Angeles\"," +
@@ -65,7 +65,7 @@ namespace Schema.NET.Test
                 "\"streetAddress\": \"6801 Hollywood Blvd\"" +
             "}," +
             "\"geo\": {" +
-                "\"@context\": \"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\": \"GeoCoordinates\"," +
                 "\"latitude\": \"34.1018929033898\"," +
                 "\"longitude\": \"-118.340147939959\"" +

--- a/Tests/Schema.NET.Test/core/NewsArticleTest.cs
+++ b/Tests/Schema.NET.Test/core/NewsArticleTest.cs
@@ -37,7 +37,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"NewsArticle\"," +
             "\"description\":\"A most wonderful article\"," +
             "\"image\":{" +

--- a/Tests/Schema.NET.Test/core/OrganizationTest.cs
+++ b/Tests/Schema.NET.Test/core/OrganizationTest.cs
@@ -24,6 +24,22 @@ namespace Schema.NET.Test
 
         private readonly string json =
         @"{" +
+            "\"@context\":\"https://schema.org\"," +
+            "\"@type\":\"Organization\"," +
+            "\"url\":\"https://example.com\"," +
+            "\"areaServed\":\"GB\"," +
+            "\"contactPoint\":{" +
+                "\"@type\":\"ContactPoint\"," +
+                "\"availableLanguage\":\"English\"," +
+                "\"contactOption\":\"https://schema.org/TollFree\"," +
+                "\"contactType\":\"customer service\"," +
+                "\"telephone\":\"+1-401-555-1212\"" +
+            "}," +
+            "\"logo\":\"https://example.com/logo.png\"" +
+        "}";
+
+        private readonly string jsonHttp =
+        @"{" +
             "\"@context\":\"http://schema.org\"," +
             "\"@type\":\"Organization\"," +
             "\"url\":\"https://example.com\"," +
@@ -48,5 +64,8 @@ namespace Schema.NET.Test
             Assert.Equal(this.organization.ToString(), JsonConvert.DeserializeObject<Organization>(this.json, TestDefaults.DefaultJsonSerializerSettings).ToString());
             Assert.Equal(JsonConvert.SerializeObject(this.organization, TestDefaults.DefaultJsonSerializerSettings), JsonConvert.SerializeObject(JsonConvert.DeserializeObject<Organization>(this.json, TestDefaults.DefaultJsonSerializerSettings), TestDefaults.DefaultJsonSerializerSettings));
         }
+
+        [Fact]
+        public void Deserializing_OrganizationJsonLd_WithHttpSchemaOrg_ReturnsOrganization() => Assert.Equal(this.organization.ToString().Replace("\"@context\":\"https://schema.org\"", "\"@context\":\"http://schema.org\""), JsonConvert.DeserializeObject<Organization>(this.jsonHttp, TestDefaults.DefaultJsonSerializerSettings).ToString());
     }
 }

--- a/Tests/Schema.NET.Test/core/PersonTest.cs
+++ b/Tests/Schema.NET.Test/core/PersonTest.cs
@@ -23,7 +23,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"Person\"," +
             "\"name\":\"Name\"," +
             "\"sameAs\":[" +

--- a/Tests/Schema.NET.Test/core/ProductTest.cs
+++ b/Tests/Schema.NET.Test/core/ProductTest.cs
@@ -41,7 +41,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"Product\"," +
             "\"name\":\"Executive Anvil\"," +
             "\"description\":\"Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveller looking for something to drop from a height.\"," +
@@ -58,8 +58,8 @@ namespace Schema.NET.Test
             "\"mpn\":\"925872\"," +
             "\"offers\":{" +
                 "\"@type\":\"Offer\"," +
-                "\"availability\":\"http://schema.org/InStock\"," +
-                "\"itemCondition\":\"http://schema.org/UsedCondition\"," +
+                "\"availability\":\"https://schema.org/InStock\"," +
+                "\"itemCondition\":\"https://schema.org/UsedCondition\"," +
                 "\"price\":119.99," +
                 "\"priceCurrency\":\"USD\"," +
                 "\"priceValidUntil\":\"2020-11-05\"," +

--- a/Tests/Schema.NET.Test/core/RecipeTest.cs
+++ b/Tests/Schema.NET.Test/core/RecipeTest.cs
@@ -47,7 +47,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
             "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"Recipe\"," +
             "\"name\":\"Grandma's Holiday Apple Pie\"," +
             "\"description\":\"This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.\"," +

--- a/Tests/Schema.NET.Test/core/RestaurantTest.cs
+++ b/Tests/Schema.NET.Test/core/RestaurantTest.cs
@@ -63,7 +63,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
         "{" +
-            "\"@context\":\"http://schema.org\"," +
+            "\"@context\":\"https://schema.org\"," +
             "\"@type\":\"Restaurant\"," +
             "\"@id\":\"http://davessteakhouse.example.com\"," +
             "\"name\":\"Dave's Steak House\"," +

--- a/Tests/Schema.NET.Test/core/VideoObjectTest.cs
+++ b/Tests/Schema.NET.Test/core/VideoObjectTest.cs
@@ -35,7 +35,7 @@ namespace Schema.NET.Test
 
         private readonly string json =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"VideoObject\"," +
                 "\"name\":\"Title\"," +
                 "\"description\":\"Video description\"," +

--- a/Tests/Schema.NET.Test/core/WebsiteTest.cs
+++ b/Tests/Schema.NET.Test/core/WebsiteTest.cs
@@ -21,7 +21,7 @@ namespace Schema.NET.Test
             };
             var expectedJson =
                 "{" +
-                    "\"@context\":\"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\":\"WebSite\"," +
                     "\"potentialAction\":{" +
                         "\"@type\":\"SearchAction\"," +
@@ -48,7 +48,7 @@ namespace Schema.NET.Test
             };
             var expectedJson =
                 "{" +
-                    "\"@context\":\"http://schema.org\"," +
+                    "\"@context\":\"https://schema.org\"," +
                     "\"@type\":\"WebSite\"," +
                     "\"name\":\"Your Site Name\"," +
                     "\"alternateName\":\"An Alternative Name\"," +
@@ -75,7 +75,7 @@ namespace Schema.NET.Test
 
             var json =
             "{" +
-                "\"@context\":\"http://schema.org\"," +
+                "\"@context\":\"https://schema.org\"," +
                 "\"@type\":\"WebSite\"," +
                 "\"potentialAction\":{" +
                     "\"@type\":\"SearchAction\"," +


### PR DESCRIPTION
This switches the enumeration values and @context to "https" to ensure that this library meets stricter standards requirements where "https" is already being enforced today, while retaining backwards compatibility in deserialization.

"Over time we will migrate the schema.org site itself towards using https:  as the default version of the site and our preferred form in examples." - https://schema.org/docs/faq.html#19

Note that [this commit](https://github.com/RehanSaeed/Schema.NET/pull/89/commits/e07688964a486db726389d5e24a9a01879c48c22) contains the changes excluding the regenerated classes, to simplify review.