### PR TITLE
Switch to System.Text.Json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
           dotnet-version: "5.0.x"
       - name: "Install .NET Core SDK"
         uses: actions/setup-dotnet@v1.8.2
+        with:
+          include-prerelease: true
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,6 @@ jobs:
           dotnet-version: "5.0.x"
       - name: "Install .NET Core SDK"
         uses: actions/setup-dotnet@v1.8.2
-        with:
-          include-prerelease: true
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh

--- a/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
@@ -1,9 +1,9 @@
 namespace Schema.NET.Benchmarks
 {
     using System;
+    using System.Text.Json;
     using BenchmarkDotNet.Attributes;
     using BenchmarkDotNet.Jobs;
-    using Newtonsoft.Json;
 
     [KeepBenchmarkFiles]
     [MemoryDiagnoser]
@@ -36,6 +36,6 @@ namespace Schema.NET.Benchmarks
         public string Serialize() => this.Thing.ToString();
 
         [Benchmark]
-        public object? Deserialize() => JsonConvert.DeserializeObject(this.SerializedThing, this.ThingType);
+        public object? Deserialize() => JsonSerializer.Deserialize(this.SerializedThing, this.ThingType);
     }
 }

--- a/Schema.NET.sln
+++ b/Schema.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31515.178
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31612.314
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{719809C2-A551-4C4A-9EFD-B10FB5E35BC0}"
 	ProjectSection(SolutionItems) = preProject

--- a/Schema.NET.sln
+++ b/Schema.NET.sln
@@ -94,6 +94,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Schema.NET.Pending", "Sourc
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{AF228B8A-7290-4E26-8506-934C290C6AE3}"
 	ProjectSection(SolutionItems) = preProject
+		Source\Common\Constants.cs = Source\Common\Constants.cs
 		Source\Common\ContactType.cs = Source\Common\ContactType.cs
 		Source\Common\ContextJsonConverter.cs = Source\Common\ContextJsonConverter.cs
 		Source\Common\DateTimeHelper.cs = Source\Common\DateTimeHelper.cs

--- a/Schema.NET.sln
+++ b/Schema.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31423.177
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31515.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{719809C2-A551-4C4A-9EFD-B10FB5E35BC0}"
 	ProjectSection(SolutionItems) = preProject
@@ -106,6 +106,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{AF228B
 		Source\Common\JsonLdObject.cs = Source\Common\JsonLdObject.cs
 		Source\Common\OneOrMany{T}.cs = Source\Common\OneOrMany{T}.cs
 		Source\Common\PropertyValueSpecification.Partial.cs = Source\Common\PropertyValueSpecification.Partial.cs
+		Source\Common\SchemaEnumJsonConverter{T}.cs = Source\Common\SchemaEnumJsonConverter{T}.cs
 		Source\Common\SchemaSerializer.cs = Source\Common\SchemaSerializer.cs
 		Source\Common\Thing.Partial.cs = Source\Common\Thing.Partial.cs
 		Source\Common\TimeSpanToISO8601DurationValuesJsonConverter.cs = Source\Common\TimeSpanToISO8601DurationValuesJsonConverter.cs

--- a/Source/Common/Constants.cs
+++ b/Source/Common/Constants.cs
@@ -1,0 +1,18 @@
+namespace Schema.NET
+{
+    /// <summary>
+    /// Various constants for use within Schema.NET
+    /// </summary>
+    public static class Constants
+    {
+        /// <summary>
+        /// The HTTPS URL for Schema.org
+        /// </summary>
+        public const string HttpsSchemaOrgUrl = "https://schema.org";
+
+        /// <summary>
+        /// The HTTPS URL for Schema.org
+        /// </summary>
+        public const string HttpSchemaOrgUrl = "http://schema.org";
+    }
+}

--- a/Source/Common/Constants.cs
+++ b/Source/Common/Constants.cs
@@ -6,12 +6,12 @@ namespace Schema.NET
     public static class Constants
     {
         /// <summary>
-        /// The HTTPS URL for Schema.org
+        /// The HTTPS URL for Schema.org, excluding trailing slash.
         /// </summary>
         public const string HttpsSchemaOrgUrl = "https://schema.org";
 
         /// <summary>
-        /// The HTTPS URL for Schema.org
+        /// The HTTP URL for Schema.org, excluding trailing slash.
         /// </summary>
         public const string HttpSchemaOrgUrl = "http://schema.org";
     }

--- a/Source/Common/ContextJsonConverter.cs
+++ b/Source/Common/ContextJsonConverter.cs
@@ -41,7 +41,7 @@ namespace Schema.NET
 
                 if (document.RootElement.TryGetProperty("name", out var nameElement))
                 {
-                    name = nameElement.GetString() ?? "http://schema.org";
+                    name = nameElement.GetString() ?? Constants.HttpsSchemaOrgUrl;
                 }
 
                 if (document.RootElement.TryGetProperty("@language", out var languageElement))
@@ -74,10 +74,8 @@ namespace Schema.NET
                 }
             }
 
-#pragma warning disable CA1062 // Validate arguments of public methods
             context.Name = name;
             context.Language = language;
-#pragma warning restore CA1062 // Validate arguments of public methods
             return context;
         }
 

--- a/Source/Common/ContextJsonConverter.cs
+++ b/Source/Common/ContextJsonConverter.cs
@@ -1,8 +1,8 @@
 namespace Schema.NET
 {
     using System;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Converts a <see cref="JsonLdContext"/> object to and from JSON.
@@ -11,78 +11,65 @@ namespace Schema.NET
     public class ContextJsonConverter : JsonConverter<JsonLdContext>
     {
         /// <inheritdoc />
-        public override JsonLdContext ReadJson(JsonReader reader, Type objectType, JsonLdContext? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override JsonLdContext Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
 #if NET6_0_OR_GREATER
-            ArgumentNullException.ThrowIfNull(reader);
-            ArgumentNullException.ThrowIfNull(objectType);
-            if (hasExistingValue)
-            {
-                ArgumentNullException.ThrowIfNull(existingValue);
-            }
-
-            ArgumentNullException.ThrowIfNull(serializer);
+            ArgumentNullException.ThrowIfNull(typeToConvert);
+            ArgumentNullException.ThrowIfNull(options);
 #else
-            if (reader is null)
+            if (typeToConvert is null)
             {
-                throw new ArgumentNullException(nameof(reader));
+                throw new ArgumentNullException(nameof(typeToConvert));
             }
 
-            if (objectType is null)
+            if (options is null)
             {
-                throw new ArgumentNullException(nameof(objectType));
-            }
-
-            if (hasExistingValue && existingValue is null)
-            {
-                throw new ArgumentNullException(nameof(existingValue));
-            }
-
-            if (serializer is null)
-            {
-                throw new ArgumentNullException(nameof(serializer));
+                throw new ArgumentNullException(nameof(options));
             }
 #endif
+            var context = new JsonLdContext();
 
-            var context = hasExistingValue ? existingValue! : new JsonLdContext();
-
-            string? name;
-            string? language;
-            if (reader.TokenType == JsonToken.String)
+            string? name = null;
+            string? language = null;
+            if (reader.TokenType == JsonTokenType.String)
             {
-                name = (string?)reader.Value;
-                language = null;
+                name = reader.GetString();
             }
-            else if (reader.TokenType == JsonToken.StartObject)
+            else if (reader.TokenType == JsonTokenType.StartObject)
             {
-                var o = JObject.Load(reader);
+                var document = JsonDocument.ParseValue(ref reader);
 
-                var nameProperty = o.Property("name", StringComparison.OrdinalIgnoreCase);
-                name = nameProperty?.Value?.ToString() ?? "https://schema.org";
+                if (document.RootElement.TryGetProperty("name", out var nameElement))
+                {
+                    name = nameElement.GetString() ?? "http://schema.org";
+                }
 
-                var languageProperty = o.Property("@language", StringComparison.OrdinalIgnoreCase);
-                language = languageProperty?.Value?.ToString();
+                if (document.RootElement.TryGetProperty("@language", out var languageElement))
+                {
+                    language = languageElement.GetString();
+                }
             }
             else
             {
-                var a = JArray.Load(reader);
+                var array = JsonDocument.ParseValue(ref reader).RootElement.EnumerateArray();
 
-                name = language = null;
-                foreach (var entry in a)
+                foreach (var entry in array)
                 {
-                    if (entry.Type == JTokenType.String)
+                    if (entry.ValueKind == JsonValueKind.String)
                     {
-                        name ??= (string?)entry;
+                        name ??= entry.GetString();
                     }
-                    else
+                    else if (entry.ValueKind == JsonValueKind.Object)
                     {
-                        var o = (JObject)entry;
+                        if (entry.TryGetProperty("name", out var nameElement))
+                        {
+                            name ??= nameElement.GetString() ?? "http://schema.org";
+                        }
 
-                        var nameProperty = o.Property("name", StringComparison.OrdinalIgnoreCase);
-                        name ??= nameProperty?.Value?.ToString() ?? "https://schema.org";
-
-                        var languageProperty = o.Property("@language", StringComparison.OrdinalIgnoreCase);
-                        language ??= languageProperty?.Value?.ToString();
+                        if (entry.TryGetProperty("@language", out var languageElement))
+                        {
+                            language ??= languageElement.GetString();
+                        }
                     }
                 }
             }
@@ -95,12 +82,12 @@ namespace Schema.NET
         }
 
         /// <inheritdoc />
-        public override void WriteJson(JsonWriter writer, JsonLdContext? value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, JsonLdContext value, JsonSerializerOptions options)
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(writer);
             ArgumentNullException.ThrowIfNull(value);
-            ArgumentNullException.ThrowIfNull(serializer);
+            ArgumentNullException.ThrowIfNull(options);
 #else
             if (writer is null)
             {
@@ -112,23 +99,23 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(value));
             }
 
-            if (serializer is null)
+            if (options is null)
             {
-                throw new ArgumentNullException(nameof(serializer));
+                throw new ArgumentNullException(nameof(options));
             }
 #endif
 
             if (string.IsNullOrWhiteSpace(value.Language))
             {
-                writer.WriteValue(value.Name);
+                writer.WriteStringValue(value.Name);
             }
             else
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("name");
-                writer.WriteValue(value.Name);
+                writer.WriteStringValue(value.Name);
                 writer.WritePropertyName("@language");
-                writer.WriteValue(value.Language);
+                writer.WriteStringValue(value.Language);
                 writer.WriteEndObject();
             }
         }

--- a/Source/Common/ContextJsonConverter.cs
+++ b/Source/Common/ContextJsonConverter.cs
@@ -63,7 +63,7 @@ namespace Schema.NET
                     {
                         if (entry.TryGetProperty("name", out var nameElement))
                         {
-                            name ??= nameElement.GetString() ?? "http://schema.org";
+                            name ??= nameElement.GetString() ?? Constants.HttpsSchemaOrgUrl;
                         }
 
                         if (entry.TryGetProperty("@language", out var languageElement))

--- a/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
+++ b/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
@@ -30,11 +30,6 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
             if (options is null)
             {
                 throw new ArgumentNullException(nameof(options));

--- a/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
+++ b/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
@@ -2,7 +2,8 @@ namespace Schema.NET
 {
     using System;
     using System.Globalization;
-    using Newtonsoft.Json;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Converts an <see cref="IValues"/> object to JSON. If the <see cref="IValues"/> contains a
@@ -17,8 +18,8 @@ namespace Schema.NET
         /// </summary>
         /// <param name="writer">The JSON writer.</param>
         /// <param name="value">The value to write.</param>
-        /// <param name="serializer">The JSON serializer.</param>
-        public override void WriteObject(JsonWriter writer, object? value, JsonSerializer serializer)
+        /// <param name="options">The JSON serializer options.</param>
+        public override void WriteObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(writer);
@@ -29,19 +30,24 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (serializer is null)
+            if (value is null)
             {
-                throw new ArgumentNullException(nameof(serializer));
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
             }
 #endif
 
             if (value is DateTime dateTimeType)
             {
-                writer.WriteValue(dateTimeType.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                writer.WriteStringValue(dateTimeType.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
             }
             else
             {
-                base.WriteObject(writer, value, serializer);
+                base.WriteObject(writer, value, options);
             }
         }
     }

--- a/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
+++ b/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
@@ -23,7 +23,7 @@ namespace Schema.NET
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(writer);
-            ArgumentNullException.ThrowIfNull(serializer);
+            ArgumentNullException.ThrowIfNull(options);
 #else
             if (writer is null)
             {

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -9,9 +9,6 @@ namespace Schema.NET
     /// </summary>
     internal static class EnumHelper
     {
-        private const int HttpSchemaOrgLength = 18; // equivalent to "http://schema.org/".Length
-        private const int HttpsSchemaOrgLength = 19; // equivalent to "https://schema.org/".Length
-
         /// <summary>
         /// Converts the string representation of the name or numeric value of one or more
         /// enumerated constants to an equivalent enumerated object.
@@ -67,13 +64,13 @@ namespace Schema.NET
             if (value is not null && value.StartsWith(Constants.HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
             {
 #pragma warning disable IDE0057 // Use range operator. Need to multi-target.
-                enumString = value.Substring(HttpSchemaOrgLength);
+                enumString = value.Substring(Constants.HttpSchemaOrgUrl.Length);
 #pragma warning restore IDE0057 // Use range operator. Need to multi-target.
             }
             else if (value is not null && value.StartsWith(Constants.HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
             {
 #pragma warning disable IDE0057 // Use range operator. Need to multi-target.
-                enumString = value.Substring(HttpsSchemaOrgLength);
+                enumString = value.Substring(Constants.HttpsSchemaOrgUrl.Length);
 #pragma warning restore IDE0057 // Use range operator. Need to multi-target.
             }
             else

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -1,6 +1,7 @@
 namespace Schema.NET
 {
     using System;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -8,6 +9,11 @@ namespace Schema.NET
     /// </summary>
     internal static class EnumHelper
     {
+        private const string HttpSchemaOrgUrl = "http://schema.org/";
+        private const int HttpSchemaOrgLength = 18; // equivalent to "http://schema.org/".Length
+        private const string HttpsSchemaOrgUrl = "https://schema.org/";
+        private const int HttpsSchemaOrgLength = 19; // equivalent to "https://schema.org/".Length
+
         /// <summary>
         /// Converts the string representation of the name or numeric value of one or more
         /// enumerated constants to an equivalent enumerated object.
@@ -42,6 +48,50 @@ namespace Schema.NET
             return Enum.TryParse(enumType, value, out result);
 #pragma warning restore IDE0022 // Use expression body for methods
 #endif
+        }
+
+        /// <summary>
+        /// Converts the Schema URI representation of the enum type to an equivalent enumerated object.
+        /// </summary>
+        /// <param name="enumType">The enum type to use for parsing.</param>
+        /// <param name="value">The string representation of the name or numeric value of one or more enumerated constants.</param>
+        /// <param name="result">When this method returns true, an object containing an enumeration constant representing the parsed value.</param>
+        /// <returns><see langword="true"/> if the conversion succeeded; <see langword="false"/> otherwise.</returns>
+        public static bool TryParseEnumFromSchemaUri(
+            Type enumType,
+#if NETCOREAPP3_1_OR_GREATER
+            [NotNullWhen(true)]
+#endif
+            string? value,
+            out object? result)
+        {
+            string? enumString;
+            if (value is not null && value.StartsWith(HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
+            {
+#pragma warning disable IDE0057 // Use range operator. Need to multi-target.
+                enumString = value.Substring(HttpSchemaOrgLength);
+#pragma warning restore IDE0057 // Use range operator. Need to multi-target.
+            }
+            else if (value is not null && value.StartsWith(HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
+            {
+#pragma warning disable IDE0057 // Use range operator. Need to multi-target.
+                enumString = value.Substring(HttpsSchemaOrgLength);
+#pragma warning restore IDE0057 // Use range operator. Need to multi-target.
+            }
+            else
+            {
+                enumString = value;
+            }
+
+            if (TryParse(enumType, enumString, out result))
+            {
+                return true;
+            }
+            else
+            {
+                Debug.WriteLine($"Unable to parse enumeration of type {enumType.FullName} with value {enumString}.");
+                return false;
+            }
         }
     }
 }

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -9,9 +9,7 @@ namespace Schema.NET
     /// </summary>
     internal static class EnumHelper
     {
-        private const string HttpSchemaOrgUrl = "http://schema.org/";
         private const int HttpSchemaOrgLength = 18; // equivalent to "http://schema.org/".Length
-        private const string HttpsSchemaOrgUrl = "https://schema.org/";
         private const int HttpsSchemaOrgLength = 19; // equivalent to "https://schema.org/".Length
 
         /// <summary>
@@ -66,13 +64,13 @@ namespace Schema.NET
             out object? result)
         {
             string? enumString;
-            if (value is not null && value.StartsWith(HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
+            if (value is not null && value.StartsWith(Constants.HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
             {
 #pragma warning disable IDE0057 // Use range operator. Need to multi-target.
                 enumString = value.Substring(HttpSchemaOrgLength);
 #pragma warning restore IDE0057 // Use range operator. Need to multi-target.
             }
-            else if (value is not null && value.StartsWith(HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
+            else if (value is not null && value.StartsWith(Constants.HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
             {
 #pragma warning disable IDE0057 // Use range operator. Need to multi-target.
                 enumString = value.Substring(HttpsSchemaOrgLength);

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -64,13 +64,13 @@ namespace Schema.NET
             if (value is not null && value.StartsWith(Constants.HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
             {
 #pragma warning disable IDE0057 // Use range operator. Need to multi-target.
-                enumString = value.Substring(Constants.HttpSchemaOrgUrl.Length);
+                enumString = value.Substring(Constants.HttpSchemaOrgUrl.Length + 1);
 #pragma warning restore IDE0057 // Use range operator. Need to multi-target.
             }
             else if (value is not null && value.StartsWith(Constants.HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
             {
 #pragma warning disable IDE0057 // Use range operator. Need to multi-target.
-                enumString = value.Substring(Constants.HttpsSchemaOrgUrl.Length);
+                enumString = value.Substring(Constants.HttpsSchemaOrgUrl.Length + 1);
 #pragma warning restore IDE0057 // Use range operator. Need to multi-target.
             }
             else

--- a/Source/Common/JsonLdContext.cs
+++ b/Source/Common/JsonLdContext.cs
@@ -13,12 +13,14 @@ namespace Schema.NET
         /// Gets or sets the name.
         /// </summary>
         [JsonPropertyName("name")]
+        [JsonPropertyOrder(0)]
         public string? Name { get; set; } = "https://schema.org";
 
         /// <summary>
         /// Gets or sets the language.
         /// </summary>
         [JsonPropertyName("@language")]
+        [JsonPropertyOrder(1)]
         public string? Language { get; set; }
 
         /// <summary>

--- a/Source/Common/JsonLdContext.cs
+++ b/Source/Common/JsonLdContext.cs
@@ -14,7 +14,7 @@ namespace Schema.NET
         /// </summary>
         [JsonPropertyName("name")]
         [JsonPropertyOrder(0)]
-        public string? Name { get; set; } = "https://schema.org";
+        public string? Name { get; set; } = Constants.HttpsSchemaOrgUrl;
 
         /// <summary>
         /// Gets or sets the language.

--- a/Source/Common/JsonLdContext.cs
+++ b/Source/Common/JsonLdContext.cs
@@ -1,7 +1,7 @@
 namespace Schema.NET
 {
     using System;
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// The @context for a JSON-LD document.
@@ -12,13 +12,13 @@ namespace Schema.NET
         /// <summary>
         /// Gets or sets the name.
         /// </summary>
-        [DataMember(Name = "name", Order = 0)]
+        [JsonPropertyName("name")]
         public string? Name { get; set; } = "https://schema.org";
 
         /// <summary>
         /// Gets or sets the language.
         /// </summary>
-        [DataMember(Name = "@language", Order = 1)]
+        [JsonPropertyName("@language")]
         public string? Language { get; set; }
 
         /// <summary>

--- a/Source/Common/JsonLdObject.cs
+++ b/Source/Common/JsonLdObject.cs
@@ -25,6 +25,7 @@ namespace Schema.NET
         [JsonPropertyName("@context")]
         [JsonPropertyOrder(0)]
         [JsonConverter(typeof(ContextJsonConverter))]
+        [JsonInclude]
         public virtual JsonLdContext Context { get; internal set; } = new JsonLdContext();
 
         /// <summary>

--- a/Source/Common/JsonLdObject.cs
+++ b/Source/Common/JsonLdObject.cs
@@ -2,14 +2,12 @@ namespace Schema.NET
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.Serialization;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// The base JSON-LD object.
     /// See https://json-ld.org/spec/latest/json-ld
     /// </summary>
-    [DataContract]
     public class JsonLdObject : IEquatable<JsonLdObject>
     {
         /// <summary>
@@ -24,7 +22,7 @@ namespace Schema.NET
         /// Simply speaking, a context is used to map terms to IRIs. Terms are case sensitive and any valid string that
         /// is not a reserved JSON-LD keyword can be used as a term.
         /// </summary>
-        [DataMember(Name = "@context", Order = 0)]
+        [JsonPropertyName("@context")]
         [JsonConverter(typeof(ContextJsonConverter))]
         public virtual JsonLdContext Context { get; internal set; } = new JsonLdContext();
 
@@ -32,7 +30,7 @@ namespace Schema.NET
         /// Gets the type, used to uniquely identify things that are being described in the document with IRIs or
         /// blank node identifiers.
         /// </summary>
-        [DataMember(Name = "@type", Order = 1)]
+        [JsonPropertyName("@type")]
         public virtual string? Type { get; }
 
         /// <summary>
@@ -43,7 +41,7 @@ namespace Schema.NET
         /// result in a representation of that node.This may allow an application to retrieve further information about
         /// a node. In JSON-LD, a node is identified using the @id keyword:
         /// </summary>
-        [DataMember(Name = "@id", Order = 2)]
+        [JsonPropertyName("@id")]
         public virtual Uri? Id { get; set; }
 
         /// <summary>

--- a/Source/Common/JsonLdObject.cs
+++ b/Source/Common/JsonLdObject.cs
@@ -23,6 +23,7 @@ namespace Schema.NET
         /// is not a reserved JSON-LD keyword can be used as a term.
         /// </summary>
         [JsonPropertyName("@context")]
+        [JsonPropertyOrder(0)]
         [JsonConverter(typeof(ContextJsonConverter))]
         public virtual JsonLdContext Context { get; internal set; } = new JsonLdContext();
 
@@ -31,6 +32,7 @@ namespace Schema.NET
         /// blank node identifiers.
         /// </summary>
         [JsonPropertyName("@type")]
+        [JsonPropertyOrder(1)]
         public virtual string? Type { get; }
 
         /// <summary>
@@ -42,6 +44,7 @@ namespace Schema.NET
         /// a node. In JSON-LD, a node is identified using the @id keyword:
         /// </summary>
         [JsonPropertyName("@id")]
+        [JsonPropertyOrder(2)]
         public virtual Uri? Id { get; set; }
 
         /// <summary>

--- a/Source/Common/SchemaEnumJsonConverter{T}.cs
+++ b/Source/Common/SchemaEnumJsonConverter{T}.cs
@@ -41,6 +41,11 @@ namespace Schema.NET
         /// <returns>The enumeration value.</returns>
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (typeToConvert is null)
+            {
+                throw new ArgumentNullException(nameof(typeToConvert));
+            }
+
             var valueString = reader.GetString();
             if (EnumHelper.TryParseEnumFromSchemaUri(typeToConvert, valueString, out var result))
             {
@@ -56,6 +61,14 @@ namespace Schema.NET
         /// <param name="writer">The JSON writer.</param>
         /// <param name="value">The enumeration value.</param>
         /// <param name="options">The JSON serializer options.</param>
-        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) => writer.WriteStringValue(this.valueNameMap[value]);
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (writer is null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            writer.WriteStringValue(this.valueNameMap[value]);
+        }
     }
 }

--- a/Source/Common/SchemaEnumJsonConverter{T}.cs
+++ b/Source/Common/SchemaEnumJsonConverter{T}.cs
@@ -1,0 +1,61 @@
+namespace Schema.NET
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Converts a Schema enumeration to and from JSON.
+    /// </summary>
+    /// <typeparam name="T">The enum type to convert</typeparam>
+    public class SchemaEnumJsonConverter<T> : JsonConverter<T>
+        where T : struct, Enum
+    {
+        private readonly Dictionary<T, string> valueNameMap = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaEnumJsonConverter{T}"/> class.
+        /// </summary>
+        public SchemaEnumJsonConverter()
+        {
+            var enumType = typeof(T);
+            var values = Enum.GetValues(enumType);
+
+            foreach (var value in values)
+            {
+                var enumMember = enumType.GetMember(value!.ToString()!)[0];
+                var enumMemberAttribute = enumMember.GetCustomAttribute<EnumMemberAttribute>(false);
+                this.valueNameMap[(T)value] = enumMemberAttribute!.Value!;
+            }
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the enumeration.
+        /// </summary>
+        /// <param name="reader">The <see cref="Utf8JsonReader"/> to read from.</param>
+        /// <param name="typeToConvert">Type of the enumeration.</param>
+        /// <param name="options">The serializer options.</param>
+        /// <returns>The enumeration value.</returns>
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var valueString = reader.GetString();
+            if (EnumHelper.TryParseEnumFromSchemaUri(typeToConvert, valueString, out var result))
+            {
+                return (T)(result!);
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Writes the specified enumeration using the JSON writer.
+        /// </summary>
+        /// <param name="writer">The JSON writer.</param>
+        /// <param name="value">The enumeration value.</param>
+        /// <param name="options">The JSON serializer options.</param>
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) => writer.WriteStringValue(this.valueNameMap[value]);
+    }
+}

--- a/Source/Common/SchemaSerializer.cs
+++ b/Source/Common/SchemaSerializer.cs
@@ -32,6 +32,7 @@ namespace Schema.NET
 
             DefaultSerializationSettings = new JsonSerializerOptions
             {
+                AllowTrailingCommas = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
                 Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             };
@@ -39,6 +40,7 @@ namespace Schema.NET
 
             HtmlEscapedSerializationSettings = new JsonSerializerOptions
             {
+                AllowTrailingCommas = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
             };
             HtmlEscapedSerializationSettings.Converters.Add(stringEnumConverter);

--- a/Source/Common/SchemaSerializer.cs
+++ b/Source/Common/SchemaSerializer.cs
@@ -3,8 +3,8 @@ namespace Schema.NET
     using System;
     using System.Collections.Generic;
     using System.Text;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Schema JSON Serializer
@@ -14,40 +14,35 @@ namespace Schema.NET
         private const string ContextPropertyJson = "\"@context\":\"https://schema.org\",";
 
         /// <summary>
-        /// Default serializer settings used when deserializing
-        /// </summary>
-        private static readonly JsonSerializerSettings DeserializeSettings = new()
-        {
-            DateParseHandling = DateParseHandling.None,
-        };
-
-        /// <summary>
         /// Default serializer settings used when HTML escaping is not required.
         /// </summary>
-        private static readonly JsonSerializerSettings DefaultSerializationSettings = new()
-        {
-            Converters = new List<JsonConverter>()
-            {
-                new StringEnumConverter(),
-            },
-            DefaultValueHandling = DefaultValueHandling.Ignore,
-            NullValueHandling = NullValueHandling.Ignore,
-        };
+        private static readonly JsonSerializerOptions DefaultSerializationSettings;
 
         /// <summary>
         /// Serializer settings used when trying to avoid XSS vulnerabilities where user-supplied data is used
         /// and the output of the serialization is embedded into a web page raw.
         /// </summary>
-        private static readonly JsonSerializerSettings HtmlEscapedSerializationSettings = new()
+        private static readonly JsonSerializerOptions HtmlEscapedSerializationSettings;
+
+#pragma warning disable CA1810 // Initialize reference type static fields inline
+        static SchemaSerializer()
+#pragma warning restore CA1810 // Initialize reference type static fields inline
         {
-            Converters = new List<JsonConverter>()
+            var stringEnumConverter = new JsonStringEnumConverter();
+
+            DefaultSerializationSettings = new JsonSerializerOptions
             {
-                new StringEnumConverter(),
-            },
-            DefaultValueHandling = DefaultValueHandling.Ignore,
-            NullValueHandling = NullValueHandling.Ignore,
-            StringEscapeHandling = StringEscapeHandling.EscapeHtml,
-        };
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            };
+            DefaultSerializationSettings.Converters.Add(stringEnumConverter);
+
+            HtmlEscapedSerializationSettings = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+            };
+            HtmlEscapedSerializationSettings.Converters.Add(stringEnumConverter);
+        }
 
         /// <summary>
         /// Deserializes the JSON to the specified type.
@@ -55,8 +50,8 @@ namespace Schema.NET
         /// <typeparam name="T">Deserialization target type</typeparam>
         /// <param name="value">JSON to deserialize</param>
         /// <returns>An instance of <typeparamref name="T"/> deserialized from JSON</returns>
-        public static T? DeserializeObject<T>(string value) =>
-            JsonConvert.DeserializeObject<T>(value, DeserializeSettings);
+        public static T? DeserializeObject<T>(string value)
+            => JsonSerializer.Deserialize<T>(value);
 
         /// <summary>
         /// Serializes the value to JSON with default serialization settings.
@@ -78,10 +73,10 @@ namespace Schema.NET
         /// Serializes the value to JSON with custom serialization settings.
         /// </summary>
         /// <param name="value">Serialization target value</param>
-        /// <param name="jsonSerializerSettings">JSON serialization settings</param>
+        /// <param name="options">JSON serialization settings</param>
         /// <returns>The serialized JSON string</returns>
-        public static string SerializeObject(object value, JsonSerializerSettings jsonSerializerSettings) =>
-            RemoveAllButFirstContext(JsonConvert.SerializeObject(value, jsonSerializerSettings));
+        public static string SerializeObject(object value, JsonSerializerOptions options)
+            => RemoveAllButFirstContext(JsonSerializer.Serialize(value, options));
 
         private static string RemoveAllButFirstContext(string json)
         {

--- a/Source/Common/SchemaSerializer.cs
+++ b/Source/Common/SchemaSerializer.cs
@@ -48,8 +48,8 @@ namespace Schema.NET
         /// <typeparam name="T">Deserialization target type</typeparam>
         /// <param name="value">JSON to deserialize</param>
         /// <returns>An instance of <typeparamref name="T"/> deserialized from JSON</returns>
-        public static T? DeserializeObject<T>(string value)
-            => JsonSerializer.Deserialize<T>(value, DefaultSerializationSettings);
+        public static T? DeserializeObject<T>(string value) =>
+            JsonSerializer.Deserialize<T>(value, DefaultSerializationSettings);
 
         /// <summary>
         /// Serializes the value to JSON with default serialization settings.
@@ -73,8 +73,8 @@ namespace Schema.NET
         /// <param name="value">Serialization target value</param>
         /// <param name="options">JSON serialization settings</param>
         /// <returns>The serialized JSON string</returns>
-        public static string SerializeObject(object value, JsonSerializerOptions options)
-            => RemoveAllButFirstContext(JsonSerializer.Serialize(value, options));
+        public static string SerializeObject(object value, JsonSerializerOptions options) =>
+            RemoveAllButFirstContext(JsonSerializer.Serialize(value, options));
 
         private static string RemoveAllButFirstContext(string json)
         {

--- a/Source/Common/SchemaSerializer.cs
+++ b/Source/Common/SchemaSerializer.cs
@@ -53,7 +53,7 @@ namespace Schema.NET
         /// <param name="value">JSON to deserialize</param>
         /// <returns>An instance of <typeparamref name="T"/> deserialized from JSON</returns>
         public static T? DeserializeObject<T>(string value)
-            => JsonSerializer.Deserialize<T>(value);
+            => JsonSerializer.Deserialize<T>(value, DefaultSerializationSettings);
 
         /// <summary>
         /// Serializes the value to JSON with default serialization settings.

--- a/Source/Common/SchemaSerializer.cs
+++ b/Source/Common/SchemaSerializer.cs
@@ -28,22 +28,18 @@ namespace Schema.NET
         static SchemaSerializer()
 #pragma warning restore CA1810 // Initialize reference type static fields inline
         {
-            var stringEnumConverter = new JsonStringEnumConverter();
-
             DefaultSerializationSettings = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
                 Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             };
-            DefaultSerializationSettings.Converters.Add(stringEnumConverter);
 
             HtmlEscapedSerializationSettings = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
             };
-            HtmlEscapedSerializationSettings.Converters.Add(stringEnumConverter);
         }
 
         /// <summary>

--- a/Source/Common/Thing.Partial.cs
+++ b/Source/Common/Thing.Partial.cs
@@ -1,6 +1,6 @@
 namespace Schema.NET
 {
-    using Newtonsoft.Json;
+    using System.Text.Json;
 
     /// <summary>
     /// The most generic type of item.
@@ -37,18 +37,13 @@ namespace Schema.NET
         public string ToHtmlEscapedString() => SchemaSerializer.HtmlEscapedSerializeObject(this);
 
         /// <summary>
-        /// Returns the JSON-LD representation of this instance using the <see cref="JsonSerializerSettings"/> provided.
-        ///
-        /// Caution: You should ensure your <paramref name="serializerSettings"/> has
-        /// <see cref="JsonSerializerSettings.StringEscapeHandling"/> set to <see cref="StringEscapeHandling.EscapeHtml"/>
-        /// if you plan to embed the output using @Html.Raw anywhere in a web page, else you open yourself up a possible
-        /// Cross-Site Scripting (XSS) attack if untrusted data is set on any of this object's properties.
+        /// Returns the JSON-LD representation of this instance using the <see cref="JsonSerializerOptions"/> provided.
         /// </summary>
-        /// <param name="serializerSettings">Serialization settings.</param>
+        /// <param name="options">Serialization settings.</param>
         /// <returns>
         /// A <see cref="string" /> that represents the JSON-LD representation of this instance.
         /// </returns>
-        public string ToString(JsonSerializerSettings serializerSettings) =>
-            SchemaSerializer.SerializeObject(this, serializerSettings);
+        public string ToString(JsonSerializerOptions options) =>
+            SchemaSerializer.SerializeObject(this, options);
     }
 }

--- a/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
+++ b/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
@@ -31,11 +31,6 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
             if (options is null)
             {
                 throw new ArgumentNullException(nameof(options));

--- a/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
+++ b/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
@@ -23,8 +23,7 @@ namespace Schema.NET
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(writer);
-            ArgumentNullException.ThrowIfNull(value);
-            ArgumentNullException.ThrowIfNull(serializer);
+            ArgumentNullException.ThrowIfNull(options);
 #else
             if (writer is null)
             {

--- a/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
+++ b/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
@@ -1,8 +1,9 @@
 namespace Schema.NET
 {
     using System;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
     using System.Xml;
-    using Newtonsoft.Json;
 
     /// <summary>
     /// Converts an <see cref="IValues"/> object to JSON. If the <see cref="IValues"/> contains a
@@ -17,8 +18,8 @@ namespace Schema.NET
         /// </summary>
         /// <param name="writer">The JSON writer.</param>
         /// <param name="value">The value to write.</param>
-        /// <param name="serializer">The JSON serializer.</param>
-        public override void WriteObject(JsonWriter writer, object? value, JsonSerializer serializer)
+        /// <param name="options">The JSON serializer options.</param>
+        public override void WriteObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(writer);
@@ -35,19 +36,19 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(value));
             }
 
-            if (serializer is null)
+            if (options is null)
             {
-                throw new ArgumentNullException(nameof(serializer));
+                throw new ArgumentNullException(nameof(options));
             }
 #endif
 
             if (value is TimeSpan duration)
             {
-                writer.WriteValue(XmlConvert.ToString(duration));
+                writer.WriteStringValue(XmlConvert.ToString(duration));
             }
             else
             {
-                base.WriteObject(writer, value, serializer);
+                base.WriteObject(writer, value, options);
             }
         }
     }

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -175,6 +175,15 @@ namespace Schema.NET
                 // System.Text.Json won't support timespans as time of day. See https://github.com/dotnet/runtime/issues/29932
                 writer.WriteStringValue(timeSpan.ToString("c", CultureInfo.InvariantCulture));
             }
+            else if (value is decimal decimalNumber)
+            {
+                //TODO: Potential unnecessary allocation - may be able to write to a stackalloc span.
+                writer.WriteRawValue(decimalNumber.ToString("G0", CultureInfo.InvariantCulture));
+            }
+            else if (value is double doubleNumber)
+            {
+                writer.WriteRawValue(doubleNumber.ToString("G0", CultureInfo.InvariantCulture));
+            }
             else
             {
                 JsonSerializer.Serialize(writer, value, value.GetType(), options);

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -16,11 +16,6 @@ namespace Schema.NET
     /// <seealso cref="JsonConverter" />
     public class ValuesJsonConverter : JsonConverter<IValues>
     {
-        private const string HttpSchemaOrgUrl = "http://schema.org/";
-        private const int HttpSchemaOrgLength = 18; // equivalent to "http://schema.org/".Length
-        private const string HttpsSchemaOrgUrl = "https://schema.org/";
-        private const int HttpsSchemaOrgLength = 19; // equivalent to "https://schema.org/".Length
-
         private static readonly Dictionary<string, Type> BuiltInThingTypeLookup = new(StringComparer.Ordinal);
 
         static ValuesJsonConverter()
@@ -299,35 +294,9 @@ namespace Schema.NET
                     success = decimal.TryParse(valueString, NumberStyles.Float, CultureInfo.InvariantCulture, out var localResult);
                     result = localResult;
                 }
-                else if (targetType.GetTypeInfo().IsEnum)
+                else if (targetType.IsEnum)
                 {
-                    string? enumString;
-                    if (valueString is not null && valueString.StartsWith(HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
-                    {
-#pragma warning disable IDE0057 // Use range operator. Need to multi-target.
-                        enumString = valueString.Substring(HttpSchemaOrgLength);
-#pragma warning restore IDE0057 // Use range operator. Need to multi-target.
-                    }
-                    else if (valueString is not null && valueString.StartsWith(HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
-                    {
-#pragma warning disable IDE0057 // Use range operator. Need to multi-target.
-                        enumString = valueString.Substring(HttpsSchemaOrgLength);
-#pragma warning restore IDE0057 // Use range operator. Need to multi-target.
-                    }
-                    else
-                    {
-                        enumString = valueString;
-                    }
-
-                    if (EnumHelper.TryParse(targetType, enumString, out result))
-                    {
-                        success = true;
-                    }
-                    else
-                    {
-                        Debug.WriteLine($"Unable to parse enumeration of type {targetType.FullName} with value {enumString}.");
-                        success = false;
-                    }
+                    success = EnumHelper.TryParseEnumFromSchemaUri(targetType, valueString, out result);
                 }
                 else if (targetType == typeof(DateTime))
                 {

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -110,18 +110,13 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
             if (options is null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
 #endif
 
-            if (value.Count == 0)
+            if (value is null || value.Count == 0)
             {
                 writer.WriteNullValue();
             }
@@ -272,19 +267,10 @@ namespace Schema.NET
                 }
                 else if (targetType.GetTypeInfo().IsPrimitive)
                 {
+                    // Common primitives first
                     if (targetType == typeof(int))
                     {
                         success = int.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var localResult);
-                        result = localResult;
-                    }
-                    else if (targetType == typeof(long))
-                    {
-                        success = long.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var localResult);
-                        result = localResult;
-                    }
-                    else if (targetType == typeof(float))
-                    {
-                        success = float.TryParse(valueString, NumberStyles.Float, CultureInfo.InvariantCulture, out var localResult);
                         result = localResult;
                     }
                     else if (targetType == typeof(double))
@@ -295,6 +281,38 @@ namespace Schema.NET
                     else if (targetType == typeof(bool))
                     {
                         success = bool.TryParse(valueString, out var localResult);
+                        result = localResult;
+                    }
+
+                    // All other supported primitives
+                    else if (targetType == typeof(short))
+                    {
+                        success = short.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var localResult);
+                        result = localResult;
+                    }
+                    else if (targetType == typeof(ushort))
+                    {
+                        success = ushort.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var localResult);
+                        result = localResult;
+                    }
+                    else if (targetType == typeof(uint))
+                    {
+                        success = uint.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var localResult);
+                        result = localResult;
+                    }
+                    else if (targetType == typeof(long))
+                    {
+                        success = long.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var localResult);
+                        result = localResult;
+                    }
+                    else if (targetType == typeof(ulong))
+                    {
+                        success = ulong.TryParse(valueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var localResult);
+                        result = localResult;
+                    }
+                    else if (targetType == typeof(float))
+                    {
+                        success = float.TryParse(valueString, NumberStyles.Float, CultureInfo.InvariantCulture, out var localResult);
                         result = localResult;
                     }
                 }
@@ -372,7 +390,50 @@ namespace Schema.NET
             }
             else if (tokenType == JsonTokenType.Number)
             {
-                if (targetType == typeof(short) || targetType == typeof(int) || targetType == typeof(long) || targetType == typeof(float) || targetType == typeof(double) || targetType == typeof(decimal))
+                // Common number types first
+                if (targetType == typeof(int))
+                {
+                    success = reader.TryGetInt32(out var localResult);
+                    result = localResult;
+                }
+                else if (targetType == typeof(double))
+                {
+                    success = reader.TryGetDouble(out var localResult);
+                    result = localResult;
+                }
+                else if (targetType == typeof(decimal))
+                {
+                    success = reader.TryGetDecimal(out var localResult);
+                    result = localResult;
+                }
+
+                // All other supported number types
+                else if (targetType == typeof(short))
+                {
+                    success = reader.TryGetInt16(out var localResult);
+                    result = localResult;
+                }
+                else if (targetType == typeof(ushort))
+                {
+                    success = reader.TryGetUInt16(out var localResult);
+                    result = localResult;
+                }
+                else if (targetType == typeof(uint))
+                {
+                    success = reader.TryGetUInt32(out var localResult);
+                    result = localResult;
+                }
+                else if (targetType == typeof(long))
+                {
+                    success = reader.TryGetInt64(out var localResult);
+                    result = localResult;
+                }
+                else if (targetType == typeof(ulong))
+                {
+                    success = reader.TryGetUInt64(out var localResult);
+                    result = localResult;
+                }
+                else if (targetType == typeof(float))
                 {
                     result = Convert.ChangeType(reader.GetDecimal(), targetType, CultureInfo.InvariantCulture);
                     success = true;

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -171,7 +171,19 @@ namespace Schema.NET
             }
 #endif
 
-            JsonSerializer.Serialize(writer, value, value?.GetType() ?? typeof(object), options);
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else if (value is TimeSpan timeSpan)
+            {
+                // System.Text.Json won't support timespans as time of day. See https://github.com/dotnet/runtime/issues/29932
+                writer.WriteStringValue(timeSpan.ToString("c", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                JsonSerializer.Serialize(writer, value, value.GetType(), options);
+            }
         }
 
         private static object? ProcessToken(ref Utf8JsonReader reader, Type[] targetTypes, JsonSerializerOptions options)

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -177,7 +177,7 @@ namespace Schema.NET
             }
             else if (value is decimal decimalNumber)
             {
-                //TODO: Potential unnecessary allocation - may be able to write to a stackalloc span.
+                // TODO: Potential unnecessary allocation - may be able to write to a stackalloc span.
                 writer.WriteRawValue(decimalNumber.ToString("G0", CultureInfo.InvariantCulture));
             }
             else if (value is double doubleNumber)
@@ -407,7 +407,7 @@ namespace Schema.NET
                 try
                 {
                     var localType = Type.GetType(typeName, false);
-                    if (typeof(IThing).IsAssignableFrom(localType))
+                    if (localType is not null && typeof(IThing).IsAssignableFrom(localType))
                     {
                         type = localType;
                         return true;

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -201,7 +201,7 @@ namespace Schema.NET
                         var targetType = targetTypes[i];
                         if (targetType.IsAssignableFrom(explicitType))
                         {
-                            return ProcessObject(objectRoot, explicitType!, options);
+                            return objectRoot.Deserialize(explicitType!, options);
                         }
                     }
                 }
@@ -224,7 +224,7 @@ namespace Schema.NET
                                 localTargetType = concreteType!;
                             }
 
-                            return ProcessObject(objectRoot, localTargetType, options);
+                            return objectRoot.Deserialize(localTargetType, options);
                         }
 #pragma warning disable CA1031 // Do not catch general exception types
                         catch (Exception ex)
@@ -488,14 +488,6 @@ namespace Schema.NET
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
             }
-        }
-
-        private static object? ProcessObject(JsonElement element, Type objectType, JsonSerializerOptions options)
-        {
-            // TODO: Investigate avoiding the string allocation
-            // Related issue: https://github.com/dotnet/runtime/issues/31274
-            var json = element.GetRawText();
-            return JsonSerializer.Deserialize(json, objectType ?? typeof(object), options);
         }
     }
 }

--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.6.21352.12" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21377.19" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-rc.1.21451.13" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-rc.1.21451.13" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.6.21352.12" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="5.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.2.21154.6" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.6.21352.12" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21377.19" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-rc.1.21451.13" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.6.21352.12" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.2.21154.6" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-rc.1.21451.13" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Tests/Schema.NET.Test/DateValuesJsonConverterTest.cs
+++ b/Tests/Schema.NET.Test/DateValuesJsonConverterTest.cs
@@ -1,0 +1,28 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using System.Text.Json.Serialization;
+    using Xunit;
+
+    public class DateValuesJsonConverterTest
+    {
+        [Fact]
+        public void WriteJson_DateTime_ISO8601_Date()
+        {
+            var value = new OneOrMany<DateTime>(new DateTime(2000, 1, 1, 12, 34, 56));
+            var json = SerializeObject(value);
+            Assert.Equal("{\"Property\":\"2000-01-01\"}", json);
+        }
+
+        private static string SerializeObject<T>(T value)
+            where T : struct, IValues
+            => SchemaSerializer.SerializeObject(new TestModel<T> { Property = value });
+
+        private class TestModel<T>
+            where T : struct, IValues
+        {
+            [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
+            public T Property { get; set; }
+        }
+    }
+}

--- a/Tests/Schema.NET.Test/DurationValuesJsonConverterTest.cs
+++ b/Tests/Schema.NET.Test/DurationValuesJsonConverterTest.cs
@@ -1,0 +1,28 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using System.Text.Json.Serialization;
+    using Xunit;
+
+    public class DurationValuesJsonConverterTest
+    {
+        [Fact]
+        public void WriteJson_TimeSpan_ISO8601_Duration()
+        {
+            var value = new OneOrMany<TimeSpan>(new TimeSpan(12, 34, 56));
+            var json = SerializeObject(value);
+            Assert.Equal("{\"Property\":\"PT12H34M56S\"}", json);
+        }
+
+        private static string SerializeObject<T>(T value)
+            where T : struct, IValues
+            => SchemaSerializer.SerializeObject(new TestModel<T> { Property = value });
+
+        private class TestModel<T>
+            where T : struct, IValues
+        {
+            [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
+            public T Property { get; set; }
+        }
+    }
+}

--- a/Tests/Schema.NET.Test/Examples/JobPostingTest.cs
+++ b/Tests/Schema.NET.Test/Examples/JobPostingTest.cs
@@ -62,7 +62,7 @@ namespace Schema.NET.Test.Examples
                 "\"value\":{" +
                     "\"@type\":\"QuantitativeValue\"," +
                     "\"unitText\":\"HOUR\"," +
-                    "\"value\":40.0" +
+                    "\"value\":40" +
                 "}" +
             "}," +
             "\"datePosted\":\"2017-01-18\"," +

--- a/Tests/Schema.NET.Test/Examples/RecipeTest.cs
+++ b/Tests/Schema.NET.Test/Examples/RecipeTest.cs
@@ -53,7 +53,7 @@ namespace Schema.NET.Test.Examples
             "\"image\":\"https://example.com/image.jpg\"," +
             "\"aggregateRating\":{" +
                 "\"@type\":\"AggregateRating\"," +
-                "\"ratingValue\":4.0," +
+                "\"ratingValue\":4," +
                 "\"reviewCount\":35" +
             "}," +
             "\"author\":{" +

--- a/Tests/Schema.NET.Test/Examples/RestaurantTest.cs
+++ b/Tests/Schema.NET.Test/Examples/RestaurantTest.cs
@@ -78,9 +78,9 @@ namespace Schema.NET.Test.Examples
             "}," +
             "\"aggregateRating\":{" +
                 "\"@type\":\"AggregateRating\"," +
-                "\"bestRating\":100.0," +
-                "\"ratingValue\":88.0," +
-                "\"worstRating\":1.0," +
+                "\"bestRating\":100," +
+                "\"ratingValue\":88," +
+                "\"worstRating\":1," +
                 "\"ratingCount\":20" +
             "}," +
             "\"geo\":{" +
@@ -106,9 +106,9 @@ namespace Schema.NET.Test.Examples
                 "}," +
                 "\"reviewRating\":{" +
                     "\"@type\":\"Rating\"," +
-                    "\"bestRating\":4.0," +
+                    "\"bestRating\":4," +
                     "\"ratingValue\":3.5," +
-                    "\"worstRating\":1.0" +
+                    "\"worstRating\":1" +
                 "}" +
             "}," +
             "\"telephone\":\"+12122459600\"," +

--- a/Tests/Schema.NET.Test/Models/ExternalSchemaModelCustomNamespace.cs
+++ b/Tests/Schema.NET.Test/Models/ExternalSchemaModelCustomNamespace.cs
@@ -1,7 +1,7 @@
 namespace SomeCustomNamespace
 {
     using System.Runtime.Serialization;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
     using Schema.NET;
 
     public class ExternalSchemaModelCustomNamespace : Thing

--- a/Tests/Schema.NET.Test/Models/ExternalSchemaModelCustomNamespace.cs
+++ b/Tests/Schema.NET.Test/Models/ExternalSchemaModelCustomNamespace.cs
@@ -1,15 +1,14 @@
 namespace SomeCustomNamespace
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
     using Schema.NET;
 
     public class ExternalSchemaModelCustomNamespace : Thing
     {
-        [DataMember(Name = "@type")]
+        [JsonPropertyName("@type")]
         public override string Type => "ExternalSchemaModelCustomNamespace";
 
-        [DataMember(Name = "myCustomProperty")]
+        [JsonPropertyName("myCustomProperty")]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> MyCustomProperty { get; set; }
     }

--- a/Tests/Schema.NET.Test/Models/ExternalSchemaModelSharedNamespace.cs
+++ b/Tests/Schema.NET.Test/Models/ExternalSchemaModelSharedNamespace.cs
@@ -1,6 +1,5 @@
 namespace Schema.NET
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     public class ExternalSchemaModelSharedNamespace : Thing

--- a/Tests/Schema.NET.Test/Models/ExternalSchemaModelSharedNamespace.cs
+++ b/Tests/Schema.NET.Test/Models/ExternalSchemaModelSharedNamespace.cs
@@ -5,10 +5,10 @@ namespace Schema.NET
 
     public class ExternalSchemaModelSharedNamespace : Thing
     {
-        [DataMember(Name = "@type")]
+        [JsonPropertyName("@type")]
         public override string Type => "ExternalSchemaModelSharedNamespace";
 
-        [DataMember(Name = "myCustomProperty")]
+        [JsonPropertyName("myCustomProperty")]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> MyCustomProperty { get; set; }
     }

--- a/Tests/Schema.NET.Test/Models/ExternalSchemaModelSharedNamespace.cs
+++ b/Tests/Schema.NET.Test/Models/ExternalSchemaModelSharedNamespace.cs
@@ -1,7 +1,7 @@
 namespace Schema.NET
 {
     using System.Runtime.Serialization;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     public class ExternalSchemaModelSharedNamespace : Thing
     {

--- a/Tests/Schema.NET.Test/ThingTest.cs
+++ b/Tests/Schema.NET.Test/ThingTest.cs
@@ -179,7 +179,7 @@ namespace Schema.NET.Test
                 Name = "Test</script><script>alert('gotcha');</script>",
             };
 
-            Assert.Equal(expectedJson, thing.ToHtmlEscapedString());
+            Assert.Equal(expectedJson, thing.ToHtmlEscapedString(), ignoreCase: true);
         }
 
         [Fact]

--- a/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
+++ b/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
@@ -2,7 +2,7 @@ namespace Schema.NET.Test
 {
     using System;
     using System.Linq;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
     using Xunit;
 
     public class ValuesJsonConverterTest
@@ -276,7 +276,7 @@ namespace Schema.NET.Test
                     "\"author\":{" +
                         "\"@type\":\"Person\"," +
                         "\"name\":\"J.D. Salinger\"" +
-                    "}," +
+                    "}" +
                 "}" +
             "}";
             var result = DeserializeObject<Values<string, IBook>>(json);
@@ -302,7 +302,7 @@ namespace Schema.NET.Test
                     "\"author\":{" +
                         "\"@type\":\"Person\"," +
                         "\"name\":\"J.D. Salinger\"" +
-                    "}," +
+                    "}" +
                 "}" +
             "}";
             var result = DeserializeObject<Values<string, Book>>(json);
@@ -327,7 +327,7 @@ namespace Schema.NET.Test
                     "\"author\":{" +
                         "\"@type\":\"Person\"," +
                         "\"name\":\"J.D. Salinger\"" +
-                    "}," +
+                    "}" +
                 "}" +
             "}";
             var result = DeserializeObject<Values<string, IBook>>(json);
@@ -352,7 +352,7 @@ namespace Schema.NET.Test
                     "\"author\":{" +
                         "\"@type\":\"Person\"," +
                         "\"name\":\"J.D. Salinger\"" +
-                    "}," +
+                    "}" +
                 "}" +
             "}";
             var result = DeserializeObject<Values<string, Book>>(json);
@@ -435,7 +435,7 @@ namespace Schema.NET.Test
                     "\"author\":{" +
                         "\"@type\":\"Person\"," +
                         "\"name\":\"J.D. Salinger\"" +
-                    "}," +
+                    "}" +
                 "}," +
                 "{" +
                     "\"@context\":\"https://schema.org\"," +
@@ -446,7 +446,7 @@ namespace Schema.NET.Test
                     "\"author\":{" +
                         "\"@type\":\"Person\"," +
                         "\"name\":\"J.R.R. Tolkien\"" +
-                    "}," +
+                    "}" +
                 "}" +
             "]}";
             var result = DeserializeObject<Values<string, IBook>>(json);
@@ -564,18 +564,18 @@ namespace Schema.NET.Test
         }
 
         private static string SerializeObject<T>(T value)
-            where T : IValues =>
-            SchemaSerializer.SerializeObject(new TestModel<T> { Property = value });
+            where T : struct, IValues
+            => SchemaSerializer.SerializeObject(new TestModel<T> { Property = value });
 
         private static T DeserializeObject<T>(string json)
-            where T : IValues =>
-            SchemaSerializer.DeserializeObject<TestModel<T>>(json)!.Property!;
+            where T : struct, IValues
+            => SchemaSerializer.DeserializeObject<TestModel<T>>(json)!.Property;
 
         private class TestModel<T>
-            where T : IValues
+            where T : struct, IValues
         {
             [JsonConverter(typeof(ValuesJsonConverter))]
-            public T? Property { get; set; }
+            public T Property { get; set; }
         }
     }
 }

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -100,8 +100,8 @@ $@"namespace Schema.NET
 {{
     using System;
     using System.Collections.Generic;
-    using System.Runtime.Serialization;
-    using Newtonsoft.Json;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// {SourceUtility.RenderDoc(4, schemaClass.Description)}
@@ -117,19 +117,18 @@ $@"namespace Schema.NET
     /// <summary>
     /// {SourceUtility.RenderDoc(4, schemaClass.Description)}
     /// </summary>
-    [DataContract]
     public{classModifiers} partial class {schemaClass.Name} :{classImplements} I{schemaClass.Name}, IEquatable<{schemaClass.Name}>
     {{
         /// <summary>
         /// Gets the name of the type as specified by schema.org.
         /// </summary>
-        [DataMember(Name = ""@type"", Order = 1)]
+        [JsonPropertyName(""@type"")]
         public override string Type => ""{schemaClass.Name}"";{SourceUtility.RenderItems(allProperties, property => $@"
 
         /// <summary>
         /// {SourceUtility.RenderDoc(8, property.Description)}
         /// </summary>
-        [DataMember(Name = ""{property.JsonName}"", Order = {property.Order})]
+        [JsonPropertyName(""{property.JsonName}"")]
         [JsonConverter(typeof({property.JsonConverterType}))]
         public{GetAccessModifier(property)} {property.PropertyTypeString} {property.Name} {{ get; set; }}")}
 
@@ -242,13 +241,12 @@ $@"namespace Schema.NET
 $@"namespace Schema.NET
 {{
     using System.Runtime.Serialization;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// {SourceUtility.RenderDoc(4, schemaEnumeration.Description)}
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum {schemaEnumeration.Name}
     {{{SourceUtility.RenderItems(schemaEnumeration.Values, value => $@"
         /// <summary>

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -248,7 +248,7 @@ $@"namespace Schema.NET
     /// <summary>
     /// {SourceUtility.RenderDoc(4, schemaEnumeration.Description)}
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(SchemaEnumJsonConverter<{schemaEnumeration.Name}>))]
     public enum {schemaEnumeration.Name}
     {{{SourceUtility.RenderItems(schemaEnumeration.Values, value => $@"
         /// <summary>

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -123,12 +123,14 @@ $@"namespace Schema.NET
         /// Gets the name of the type as specified by schema.org.
         /// </summary>
         [JsonPropertyName(""@type"")]
+        [JsonPropertyOrder(1)]
         public override string Type => ""{schemaClass.Name}"";{SourceUtility.RenderItems(allProperties, property => $@"
 
         /// <summary>
         /// {SourceUtility.RenderDoc(8, property.Description)}
         /// </summary>
         [JsonPropertyName(""{property.JsonName}"")]
+        [JsonPropertyOrder({property.Order})]
         [JsonConverter(typeof({property.JsonConverterType}))]
         public{GetAccessModifier(property)} {property.PropertyTypeString} {property.Name} {{ get; set; }}")}
 


### PR DESCRIPTION
Attempts to resolve #96 , switching from JSON.Net to System.Text.Json.

One problem with the migration is it requires dropping .NET Standard 1.1 support. I've done that in this PR already however if you're wanting to maintain that, it might be possible with falling back to JSON.Net but likely will require a ton of `#if` declarations in every class.

Current status: Down from 27000 errors to 0 - just testing is left.