### PR TITLE
Fix link to Contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,5 @@
 Thank you good citizen for your hard work!
 
 Please read the contributing guide before raising a pull request.
-https://github.com/RehanSaeed/Schema.NET/blob/master/CONTRIBUTING.md
+https://github.com/RehanSaeed/Schema.NET/blob/master/.github/CONTRIBUTING.md
 -->


### PR DESCRIPTION
Ironically I only noticed this from opening the other PR but basically, the link was broken for the contributing guide. The old link pointed to the repository root for the file but it actually exists in the `.github` folder.
