### PR TITLE
Add basic serialize/deserialize benchmarks

### DIFF
--- a/Benchmarks/Schema.NET.Benchmarks/Core/BookBenchmark.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/Core/BookBenchmark.cs
@@ -1,0 +1,82 @@
+namespace Schema.NET.Benchmarks.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using BenchmarkDotNet.Attributes;
+
+    public class BookBenchmark : SchemaBenchmarkBase
+    {
+        [GlobalSetup]
+        public void Setup() => this.ConfigureBenchmark(new Book()
+        {
+            Id = new Uri("http://example.com/book/1"),
+            Name = "The Catcher in the Rye",
+            Author = new Person()
+            {
+                Name = "J.D. Salinger"
+            },
+            Url = new Uri("http://www.barnesandnoble.com/store/info/offer/JDSalinger"),
+            WorkExample = new List<ICreativeWork>()
+            {
+                new Book()
+                {
+                    Isbn = "031676948",
+                    BookEdition = "2nd Edition",
+                    BookFormat = BookFormatType.Hardcover,
+                    PotentialAction = new ReadAction()
+                    {
+                        Target = new EntryPoint()
+                        {
+                            UrlTemplate = "http://www.barnesandnoble.com/store/info/offer/0316769487?purchase=true",
+                            ActionPlatform = new List<Uri>()
+                            {
+                                new Uri("https://schema.org/DesktopWebPlatform"),
+                                new Uri("https://schema.org/IOSPlatform"),
+                                new Uri("https://schema.org/AndroidPlatform")
+                            }
+                        },
+                        ExpectsAcceptanceOf = new Offer()
+                        {
+                            Price = 6.99M,
+                            PriceCurrency = "USD",
+                            EligibleRegion = new Country()
+                            {
+                                Name = "US"
+                            },
+                            Availability = ItemAvailability.InStock
+                        }
+                    },
+                },
+                new Book()
+                {
+                    Isbn = "031676947",
+                    BookEdition = "1st Edition",
+                    BookFormat = BookFormatType.EBook,
+                    PotentialAction = new ReadAction()
+                    {
+                        Target = new EntryPoint()
+                        {
+                            UrlTemplate = "http://www.barnesandnoble.com/store/info/offer/031676947?purchase=true",
+                            ActionPlatform = new List<Uri>()
+                            {
+                                new Uri("https://schema.org/DesktopWebPlatform"),
+                                new Uri("https://schema.org/IOSPlatform"),
+                                new Uri("https://schema.org/AndroidPlatform")
+                            }
+                        },
+                        ExpectsAcceptanceOf = new Offer()
+                        {
+                            Price = 1.99M,
+                            PriceCurrency = "USD",
+                            EligibleRegion = new Country()
+                            {
+                                Name = "UK"
+                            },
+                            Availability = ItemAvailability.InStock
+                        }
+                    },
+                }
+            }
+        });
+    }
+}

--- a/Benchmarks/Schema.NET.Benchmarks/Core/WebsiteBenchmark.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/Core/WebsiteBenchmark.cs
@@ -1,0 +1,19 @@
+namespace Schema.NET.Benchmarks.Core
+{
+    using System;
+    using BenchmarkDotNet.Attributes;
+
+    public class WebsiteBenchmark : SchemaBenchmarkBase
+    {
+        [GlobalSetup]
+        public void Setup() => this.ConfigureBenchmark(new WebSite()
+        {
+            PotentialAction = new SearchAction()
+            {
+                Target = new Uri("http://example.com/search?&q={query}"),
+                QueryInput = "required"
+            },
+            Url = new Uri("https://example.com")
+        });
+    }
+}

--- a/Benchmarks/Schema.NET.Benchmarks/Program.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/Program.cs
@@ -1,0 +1,10 @@
+namespace Schema.NET.Benchmarks
+{
+    using System;
+    using BenchmarkDotNet.Running;
+
+    internal class Program
+    {
+        private static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
+++ b/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Build">
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <CodeAnalysisRuleSet>../../MinimumRecommendedRulesWithStyleCop.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\Source\Schema.NET\Schema.NET.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzer Package References">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.4.16" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
+  </ItemGroup>
+
+
+</Project>

--- a/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
+++ b/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <!-- See https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzer Package References">

--- a/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
+++ b/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
     <CodeAnalysisRuleSet>../../MinimumRecommendedRulesWithStyleCop.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
@@ -5,8 +5,15 @@ namespace Schema.NET.Benchmarks
     using BenchmarkDotNet.Jobs;
     using Newtonsoft.Json;
 
-    [SimpleJob(RuntimeMoniker.NetCoreApp30)]
+    [KeepBenchmarkFiles]
     [MemoryDiagnoser]
+    [MinColumn]
+    [MaxColumn]
+    [HtmlExporter]
+    [CsvMeasurementsExporter]
+    [RPlotExporter]
+    [SimpleJob(RuntimeMoniker.Net472)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp30)]
     public abstract class SchemaBenchmarkBase
     {
         protected Thing Thing { get; set; }

--- a/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
@@ -1,0 +1,31 @@
+namespace Schema.NET.Benchmarks
+{
+    using System;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Jobs;
+    using Newtonsoft.Json;
+
+    [SimpleJob(RuntimeMoniker.NetCoreApp30)]
+    [MemoryDiagnoser]
+    public abstract class SchemaBenchmarkBase
+    {
+        protected Thing Thing { get; set; }
+
+        private Type ThingType { get; set; }
+
+        private string SerializedThing { get; set; }
+
+        [Benchmark]
+        public string Serialize() => this.Thing.ToString();
+
+        [Benchmark]
+        public object Deserialize() => JsonConvert.DeserializeObject(this.SerializedThing, this.ThingType);
+
+        protected void ConfigureBenchmark(Thing thing)
+        {
+            this.Thing = thing;
+            this.ThingType = this.Thing.GetType();
+            this.SerializedThing = this.Thing.ToString();
+        }
+    }
+}

--- a/Schema.NET.sln
+++ b/Schema.NET.sln
@@ -55,6 +55,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{0555
 		.github\SECURITY.md = .github\SECURITY.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{E25F6292-80CE-45FE-97B0-0EBBF8E1FC6A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Schema.NET.Benchmarks", "Benchmarks\Schema.NET.Benchmarks\Schema.NET.Benchmarks.csproj", "{EA1CBFC3-F165-4811-AA9F-157DEB8E31CC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +77,10 @@ Global
 		{3E75002C-0EF2-4F04-8EC6-CED90BA27AD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E75002C-0EF2-4F04-8EC6-CED90BA27AD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E75002C-0EF2-4F04-8EC6-CED90BA27AD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA1CBFC3-F165-4811-AA9F-157DEB8E31CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA1CBFC3-F165-4811-AA9F-157DEB8E31CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA1CBFC3-F165-4811-AA9F-157DEB8E31CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA1CBFC3-F165-4811-AA9F-157DEB8E31CC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +91,7 @@ Global
 		{3E75002C-0EF2-4F04-8EC6-CED90BA27AD1} = {E1B24F25-B8A4-46EE-B7EB-7803DCFC543F}
 		{566DF0E2-1288-4083-9B55-4C8B69BB1432} = {0555C737-CE4B-4C78-87AB-6296E1E32D01}
 		{0555C737-CE4B-4C78-87AB-6296E1E32D01} = {7EDFA103-DB69-4C88-9DE4-97ADBF8253A1}
+		{EA1CBFC3-F165-4811-AA9F-157DEB8E31CC} = {E25F6292-80CE-45FE-97B0-0EBBF8E1FC6A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73F36209-F8D6-4066-8951-D97729F773CF}


### PR DESCRIPTION
As I mentioned in #100 , it would be a good idea to add some benchmarks to Schema.NET, specifically around the serialization/deserialization process.

While the core serialization processing might be in a third-party library (either `Newtonsoft.Json` or eventually `System.Text.Json`), there are multiple custom converters used in the library which may have their own performance bottlenecks.

The benchmarks, however, are also useful for gauging the performance improvement when going to `System.Text.Json` too.

I've specifically included 2 benchmarks, one testing `WebSite` with a fairly basic model (taken from the `WebSiteTest`) and one for `Book` (taken from `BookTest`). While there isn't anything to really base these numbers on at the moment, it can help for relative improvements.

I may add more specialised benchmarks, specifically targeting the `ValuesJsonConverter` in the future as that is where I believe the biggest gains are in the library.

```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-alpha1-015710
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT
  Job-MDWQYW : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT

Runtime=.NET Core 3.0
```
**Book Benchmark**

|      Method |     Mean |   Error |  StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|--------:|--------:|------:|------:|----------:|
|   Serialize | 175.9 us | 1.05 us | 0.88 us | 15.3809 |     - |     - |  47.27 KB |
| Deserialize | 445.8 us | 3.48 us | 3.26 us | 39.0625 |     - |     - | 120.96 KB |

**WebSite Benchmark**

|      Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|---------:|---------:|-------:|------:|------:|----------:|
|   Serialize | 26.90 us | 0.252 us | 0.236 us | 2.9297 |     - |     - |   9.16 KB |
| Deserialize | 47.89 us | 0.300 us | 0.280 us | 4.9438 |     - |     - |  15.17 KB |