### PR TITLE
Updated artifact path to match other build scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,10 @@ test: off
 
 artifacts:
 - name: NuGet Packages
-  path: ./Artifacts/**/*.nupkg
+  path: ./Artefacts/**/*.nupkg
 - name: NuGet Symbol Packages
-  path: ./Artifacts/**/*.snupkg
+  path: ./Artefacts/**/*.snupkg
 - name: xUnit XML Test Results
-  path: ./Artifacts/**/*.xml
+  path: ./Artefacts/**/*.xml
 - name: xUnit HTML Test Results
-  path: ./Artifacts/**/*.html
+  path: ./Artefacts/**/*.html


### PR DESCRIPTION
Don't you just love that English has the same word with two different spellings?

Changing AppVeyor's use to match the Azure Pipelines use seems to be the path of least hassle.

Anyway, this should allow artifacts/artefacts to be picked up correctly as they currently aren't: https://ci.appveyor.com/project/RehanSaeed/schema-net/builds/29536122/job/3cckikl9vbq8vuk9#L196