### PR TITLE
Add testing support for .NET Framework

### DIFF
--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -1,10 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <CodeAnalysisRuleSet>../../MinimumRecommendedRulesWithStyleCop.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RestoreAdditionalProjectSources>
+      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+    </RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">
@@ -12,8 +15,6 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <!-- See https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -23,6 +24,14 @@
   <ItemGroup Label="Analyzer Package References">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.4.33" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' AND '$(TargetFramework)' == 'net472' ">
+    <PackageReference
+        Include="Microsoft.TargetingPack.NETFramework.v4.7.2"
+        Version="1.0.0"
+        ExcludeAssets="All"
+        PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <CodeAnalysisRuleSet>../../MinimumRecommendedRulesWithStyleCop.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -12,6 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
+    <!-- See https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -29,6 +29,7 @@
         Version="1.0.0"
         ExcludeAssets="All"
         PrivateAssets="All" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' AND '$(TargetFramework)' == 'net472' ">
     <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.7.2/1.0.0/lib/net472/</FrameworkPathOverride>

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -15,6 +15,7 @@
     <!-- See https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -30,6 +30,7 @@
         ExcludeAssets="All"
         PrivateAssets="All" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Threading.Tasks" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' AND '$(TargetFramework)' == 'net472' ">
     <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.7.2/1.0.0/lib/net472/</FrameworkPathOverride>

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
@@ -12,6 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
+    <!-- See https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -22,20 +24,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.4.33" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' AND '$(TargetFramework)' == 'net472' ">
-    <PackageReference
-        Include="Microsoft.TargetingPack.NETFramework.v4.7.2"
-        Version="1.0.0"
-        ExcludeAssets="All"
-        PrivateAssets="All" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading.Tasks" />
-  </ItemGroup>
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' AND '$(TargetFramework)' == 'net472' ">
-    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.7.2/1.0.0/lib/net472/</FrameworkPathOverride>
-    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
-  </PropertyGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -5,9 +5,6 @@
     <CodeAnalysisRuleSet>../../MinimumRecommendedRulesWithStyleCop.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RestoreAdditionalProjectSources>
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
-    </RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">
@@ -33,6 +30,10 @@
         ExcludeAssets="All"
         PrivateAssets="All" />
   </ItemGroup>
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' AND '$(TargetFramework)' == 'net472' ">
+    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.7.2/1.0.0/lib/net472/</FrameworkPathOverride>
+    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/Schema.NET.Test/StringExtensions.cs
+++ b/Tests/Schema.NET.Test/StringExtensions.cs
@@ -1,0 +1,19 @@
+#if NET472
+namespace Schema.NET.Test
+{
+    using System;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable CA1801 // Remove unused parameter
+
+    public static class StringExtensions
+    {
+        public static string Replace(this string target, string oldValue, string newValue, StringComparison stringComparison) => target.Replace(oldValue, newValue);
+
+        public static int GetHashCode(this string target, StringComparison stringComparison) => target.GetHashCode();
+    }
+
+#pragma warning restore CA1801 // Remove unused parameter
+#pragma warning restore IDE0060 // Remove unused parameter
+}
+#endif


### PR DESCRIPTION
When looking into some issues with #100, I realised that the unit tests aren't setup to test .NET Framework. For that PR at least, it shows a large number of issues with .NET Framework - I don't know if that is from the custom `ValuesJsonConverter` or from `System.Text.Json` itself.

In either case however, I realised it would be a good thing to have even outside of that PR (for example, testing #109). There is actually one failing test when testing .NET Framework on master: https://github.com/RehanSaeed/Schema.NET/blob/c815daf10ed59e9328992e0f729b2ee23529e62b/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs#L238-L255

The test fails as the current `ValuesJsonConverter` on master returns `null` due to not finding a suitable type. This isn't a problem in .NET Core 3 with JSON.Net but is a problem in .NET Framework 4.7.2 - this issue however should already be resolved in #109 due to how it attempts to find a concrete type.

I'm not fully versed in the build process for Schema.NET so I don't know if it is going to be as easy as the two changes I've made. I guess we will see when the CI finishes...

If you are curious, the `StringExtensions` class is to work around the combination of multiple calls to these specific methods with those methods not being supported in .NET Framework and the linting requiring these calls in .NET Core. I didn't really want to wrap the individual calls in linting suppression statements.