### PR TITLE
Values Struct Equality Fix

### DIFF
--- a/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
@@ -473,40 +473,15 @@ namespace Schema.NET
         /// </returns>
         public bool Equals(Values<T1, T2, T3, T4> other)
         {
-            if (other.HasValue1)
-            {
-                if (this.HasValue1)
-                {
-                    return this.Value1.Equals(other.Value1);
-                }
-            }
-            else if (other.HasValue2)
-            {
-                if (this.HasValue2)
-                {
-                    return this.Value2.Equals(other.Value2);
-                }
-            }
-            else if (other.HasValue3)
-            {
-                if (this.HasValue3)
-                {
-                    return this.Value3.Equals(other.Value3);
-                }
-            }
-            else if (other.HasValue4)
-            {
-                if (this.HasValue4)
-                {
-                    return this.Value4.Equals(other.Value4);
-                }
-            }
-            else if (!other.HasValue && !this.HasValue)
+            if (!other.HasValue && !this.HasValue)
             {
                 return true;
             }
 
-            return false;
+            return this.Value1.Equals(other.Value1) &&
+                this.Value2.Equals(other.Value2) &&
+                this.Value3.Equals(other.Value3) &&
+                this.Value4.Equals(other.Value4);
         }
 
         /// <summary>

--- a/Source/Schema.NET/Values{T1,T2,T3}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3}.cs
@@ -404,33 +404,14 @@ namespace Schema.NET
         /// </returns>
         public bool Equals(Values<T1, T2, T3> other)
         {
-            if (other.HasValue1)
-            {
-                if (this.HasValue1)
-                {
-                    return this.Value1.Equals(other.Value1);
-                }
-            }
-            else if (other.HasValue2)
-            {
-                if (this.HasValue2)
-                {
-                    return this.Value2.Equals(other.Value2);
-                }
-            }
-            else if (other.HasValue3)
-            {
-                if (this.HasValue3)
-                {
-                    return this.Value3.Equals(other.Value3);
-                }
-            }
-            else if (!other.HasValue && !this.HasValue)
+            if (!other.HasValue && !this.HasValue)
             {
                 return true;
             }
 
-            return false;
+            return this.Value1.Equals(other.Value1) &&
+                this.Value2.Equals(other.Value2) &&
+                this.Value3.Equals(other.Value3);
         }
 
         /// <summary>

--- a/Source/Schema.NET/Values{T1,T2}.cs
+++ b/Source/Schema.NET/Values{T1,T2}.cs
@@ -302,34 +302,13 @@ namespace Schema.NET
         /// </returns>
         public bool Equals(Values<T1, T2> other)
         {
-            if (other.HasValue1 && other.HasValue2)
-            {
-                if (this.HasValue1 && this.HasValue2)
-                {
-                    return this.Value1.Equals(other.Value1) &&
-                        this.Value2.Equals(other.Value2);
-                }
-            }
-            else if (other.HasValue1)
-            {
-                if (this.HasValue1)
-                {
-                    return this.Value1.Equals(other.Value1);
-                }
-            }
-            else if (other.HasValue2)
-            {
-                if (this.HasValue2)
-                {
-                    return this.Value2.Equals(other.Value2);
-                }
-            }
-            else if (!other.HasValue && !this.HasValue)
+            if (!other.HasValue && !this.HasValue)
             {
                 return true;
             }
 
-            return false;
+            return this.Value1.Equals(other.Value1) &&
+                this.Value2.Equals(other.Value2);
         }
 
         /// <summary>

--- a/Tests/Schema.NET.Test/MixedTypesTest.cs
+++ b/Tests/Schema.NET.Test/MixedTypesTest.cs
@@ -66,26 +66,6 @@ namespace Schema.NET.Test
         }
 
         [Fact]
-        public void DeserializeObject_DeserializesBankAccountTypeToStringAndUri_BankAccountTypeHasStringAndUriValues()
-        {
-            var json =
-                @"{" +
-                    "\"@context\":\"https://schema.org\"," +
-                    "\"@type\":\"BankAccount\"," +
-                    "\"bankAccountType\":[" +
-                        "\"http://example.com/1\"," +
-                    "]" +
-                "}";
-
-            var bankAccount = JsonConvert.DeserializeObject<BankAccount>(json, TestDefaults.DefaultJsonSerializerSettings);
-
-            Assert.True(bankAccount.BankAccountType.HasValue);
-            Assert.Equal(
-                new List<object>() { "http://example.com/1", new Uri("http://example.com/1") },
-                bankAccount.BankAccountType);
-        }
-
-        [Fact]
         public void ToString_Book_MatchesExpectedJson() =>
             Assert.Equal(this.json, this.book.ToString());
 

--- a/Tests/Schema.NET.Test/Values2Test.cs
+++ b/Tests/Schema.NET.Test/Values2Test.cs
@@ -213,6 +213,22 @@ namespace Schema.NET.Test
             Assert.False(new Values<int, string>(new object[] { 0, "Foo" }).Equals(new Values<int, string>(new object[] { 1, "Foo" })));
 
         [Fact]
+        public void Equals_MixedTypes_ThisMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string>(new object[] { 0 }).Equals(new Values<int, string>(new object[] { 0, "Foo" })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string>(new object[] { "Foo" }).Equals(new Values<int, string>(new object[] { 0, "Foo" })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string>(new object[] { 0, "Foo" }).Equals(new Values<int, string>(new object[] { 0 })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string>(new object[] { 0, "Foo" }).Equals(new Values<int, string>(new object[] { "Foo" })));
+
+        [Fact]
         public void GetHashCode_Value1Passed_ReturnsMatchingHashCode() =>
             Assert.Equal(CombineHashCodes(1.GetHashCode(), 0), new Values<int, string>(1).GetHashCode());
 

--- a/Tests/Schema.NET.Test/Values2Test.cs
+++ b/Tests/Schema.NET.Test/Values2Test.cs
@@ -201,6 +201,18 @@ namespace Schema.NET.Test
             Assert.False(new Values<int, string>("Foo").Equals(new Values<int, string>("Bar")));
 
         [Fact]
+        public void Equals_EqualValuesPassed_ReturnsTrue() =>
+            Assert.True(new Values<int, string>(new object[] { 0, "Foo" }).Equals(new object[] { 0, "Foo" }));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2NotEqual_ReturnsFalse() =>
+            Assert.False(new Values<int, string>(new object[] { 0, "Foo" }).Equals(new Values<int, string>(new object[] { 0, "Bar" })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1NotEqualValue2Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string>(new object[] { 0, "Foo" }).Equals(new Values<int, string>(new object[] { 1, "Foo" })));
+
+        [Fact]
         public void GetHashCode_Value1Passed_ReturnsMatchingHashCode() =>
             Assert.Equal(CombineHashCodes(1.GetHashCode(), 0), new Values<int, string>(1).GetHashCode());
 

--- a/Tests/Schema.NET.Test/Values3Test.cs
+++ b/Tests/Schema.NET.Test/Values3Test.cs
@@ -305,6 +305,30 @@ namespace Schema.NET.Test
             Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 1, "Foo", DayOfWeek.Tuesday })));
 
         [Fact]
+        public void Equals_MixedTypes_ThisMissingValue3_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo" }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue3_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo" })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, DayOfWeek.Tuesday })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { "Foo", DayOfWeek.Tuesday })));
+
+        [Fact]
         public void GetHashCode_Value1Passed_ReturnsMatchingHashCode() =>
             Assert.Equal(
                 CombineHashCodes(CombineHashCodes(1.GetHashCode(), 0), 0),

--- a/Tests/Schema.NET.Test/Values3Test.cs
+++ b/Tests/Schema.NET.Test/Values3Test.cs
@@ -293,6 +293,18 @@ namespace Schema.NET.Test
             Assert.False(new Values<int, string, DayOfWeek>(DayOfWeek.Friday).Equals(new Values<int, string, DayOfWeek>(DayOfWeek.Monday)));
 
         [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3NotEqual_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Wednesday })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2NotEqualValue3Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Bar", DayOfWeek.Tuesday })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1NotEqualValue2EqualValue3Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek>(new object[] { 1, "Foo", DayOfWeek.Tuesday })));
+
+        [Fact]
         public void GetHashCode_Value1Passed_ReturnsMatchingHashCode() =>
             Assert.Equal(
                 CombineHashCodes(CombineHashCodes(1.GetHashCode(), 0), 0),

--- a/Tests/Schema.NET.Test/Values4Test.cs
+++ b/Tests/Schema.NET.Test/Values4Test.cs
@@ -399,19 +399,51 @@ namespace Schema.NET.Test
 
         [Fact]
         public void Equals_MixedTypes_Value1EqualValue2EqualValue3EqualValue4NotEqual_ReturnsFalse() =>
-            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person { Name = "Schema" } })));
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person { Name = "Schema" } })));
 
         [Fact]
         public void Equals_MixedTypes_Value1EqualValue2EqualValue3NotEqualValue4Equal_ReturnsFalse() =>
-            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Wednesday, new Person() })));
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Wednesday, new Person() })));
 
         [Fact]
         public void Equals_MixedTypes_Value1EqualValue2NotEqualValue3EqualValue4Equal_ReturnsFalse() =>
-            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Bar", DayOfWeek.Tuesday, new Person() })));
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Bar", DayOfWeek.Tuesday, new Person() })));
 
         [Fact]
         public void Equals_MixedTypes_Value1NotEqualValue2EqualValue3EqualValue4Equal_ReturnsFalse() =>
-            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 1, "Foo", DayOfWeek.Tuesday, new Person() })));
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 1, "Foo", DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue4_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue3_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue4_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue3_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { 0, DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek, Person>(new object[] { "Foo", DayOfWeek.Tuesday, new Person() })));
 
         [Fact]
         public void GetHashCode_Value1Passed_ReturnsMatchingHashCode() =>

--- a/Tests/Schema.NET.Test/Values4Test.cs
+++ b/Tests/Schema.NET.Test/Values4Test.cs
@@ -398,6 +398,22 @@ namespace Schema.NET.Test
             Assert.False(new Values<int, string, DayOfWeek, Person>(new Person()).Equals(new Values<int, string, DayOfWeek, Person>(new Person())));
 
         [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3EqualValue4NotEqual_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person { Name = "Schema" } })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3NotEqualValue4Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Wednesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2NotEqualValue3EqualValue4Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 0, "Bar", DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1NotEqualValue2EqualValue3EqualValue4Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person() }).Equals(new Values<int, string, DayOfWeek>(new object[] { 1, "Foo", DayOfWeek.Tuesday, new Person() })));
+
+        [Fact]
         public void GetHashCode_Value1Passed_ReturnsMatchingHashCode() =>
             Assert.Equal(
                 CombineHashCodes(CombineHashCodes(CombineHashCodes(1.GetHashCode(), 0), 0), 0),


### PR DESCRIPTION
There was a subtle bug in the equality checking of the `Values` structs that didn't properly handle mixed types. While `Values2` did properly handle mixed types, it didn't properly handle only one of the types having data.

After a bit of studying the code, it really can be simplified down to comparing the internal `OneOrMany`. I do add one additional check prior to that as a shortcut for empty data.