### PR TITLE
Refactoring OneOrMany

### DIFF
--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -256,7 +256,11 @@ namespace Schema.NET
             }
             else
             {
+#if NETSTANDARD1_1
                 return new T[0];
+#else
+                return Array.Empty<T>();
+#endif
             }
         }
 

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -265,12 +265,6 @@ namespace Schema.NET
         }
 
         /// <summary>
-        /// Returns the first item from <see cref="OneOrMany{T}"/> or default <typeparamref name="T"/>.
-        /// </summary>
-        /// <returns>The first element in the <see cref="OneOrMany{T}"/></returns>
-        public T FirstOrDefault() => this.Count > 0 ? this.collection[0] : default;
-
-        /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -39,24 +39,19 @@ namespace Schema.NET
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOrMany{T}"/> struct.
         /// </summary>
-        /// <param name="array">The array of values.</param>
-        public OneOrMany(params T[] array)
+        /// <param name="span">The span of values.</param>
+        public OneOrMany(ReadOnlySpan<T> span)
         {
-            if (array is null)
+            if (!span.IsEmpty)
             {
-                throw new ArgumentNullException(nameof(array));
-            }
-
-            if (array.Length > 0)
-            {
-                var items = new T[array.Length];
+                var items = new T[span.Length];
                 var index = 0;
 
                 if (typeof(T) == typeof(string))
                 {
-                    for (var i = 0; i < array.Length; i++)
+                    for (var i = 0; i < span.Length; i++)
                     {
-                        var item = array[i];
+                        var item = span[i];
                         if (!string.IsNullOrWhiteSpace(item as string))
                         {
                             items[index] = item;
@@ -66,9 +61,9 @@ namespace Schema.NET
                 }
                 else
                 {
-                    for (var i = 0; i < array.Length; i++)
+                    for (var i = 0; i < span.Length; i++)
                     {
-                        var item = array[i];
+                        var item = span[i];
                         if (item != null)
                         {
                             items[index] = item;
@@ -79,7 +74,7 @@ namespace Schema.NET
 
                 if (index > 0)
                 {
-                    if (index == array.Length)
+                    if (index == span.Length)
                     {
                         this.collection = items;
                     }
@@ -101,9 +96,18 @@ namespace Schema.NET
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOrMany{T}"/> struct.
         /// </summary>
+        /// <param name="array">The array of values.</param>
+        public OneOrMany(params T[] array)
+            : this(array.AsSpan())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OneOrMany{T}"/> struct.
+        /// </summary>
         /// <param name="collection">The collection of values.</param>
         public OneOrMany(IEnumerable<T> collection)
-            : this(collection.ToArray())
+            : this(collection.ToArray().AsSpan())
         {
         }
 
@@ -112,7 +116,7 @@ namespace Schema.NET
         /// </summary>
         /// <param name="collection">The list of values.</param>
         public OneOrMany(IEnumerable<object> collection)
-            : this(collection?.Cast<T>())
+            : this(collection.Cast<T>().ToArray().AsSpan())
         {
         }
 

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -239,6 +239,34 @@ namespace Schema.NET
         IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
         /// <summary>
+        /// Creates an array from <see cref="OneOrMany{T}" />.
+        /// </summary>
+        /// <returns>An array containing all the elements.</returns>
+        public T[] ToArray()
+        {
+            if (this.HasOne)
+            {
+                return new[] { this.collection[0] };
+            }
+            else if (this.HasMany)
+            {
+                var result = new T[this.collection.Length];
+                Array.Copy(this.collection, 0, result, 0, this.collection.Length);
+                return result;
+            }
+            else
+            {
+                return new T[0];
+            }
+        }
+
+        /// <summary>
+        /// Returns the first item from <see cref="OneOrMany{T}"/> or default <typeparamref name="T"/>.
+        /// </summary>
+        /// <returns>The first element in the <see cref="OneOrMany{T}"/></returns>
+        public T FirstOrDefault() => this.Count > 0 ? this.collection[0] : default;
+
+        /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -287,6 +287,6 @@ namespace Schema.NET
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        public override int GetHashCode() => this.collection is null ? 0 : HashCode.OfEach(this.collection);
+        public override int GetHashCode() => HashCode.OfEach(this.collection);
     }
 }

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzer Package References">

--- a/Tests/Schema.NET.Test/OneOrManyTest.cs
+++ b/Tests/Schema.NET.Test/OneOrManyTest.cs
@@ -57,7 +57,7 @@ namespace Schema.NET.Test
             Assert.Throws<ArgumentNullException>(() => new OneOrMany<int>((List<int>)null));
 
         [Fact]
-        public void Count_DefaultStructConstructor_ReturnsOne() => Assert.Single(default(OneOrMany<int>));
+        public void Count_DefaultStructConstructor_ReturnsZero() => Assert.Empty(default(OneOrMany<int>));
 
         [Fact]
         public void Count_DefaultClassConstructor_ReturnsZero() => Assert.Empty(default(OneOrMany<string>));
@@ -76,7 +76,7 @@ namespace Schema.NET.Test
             Assert.Equal(2, new OneOrMany<int>(new List<int>() { 1, 2 }).Count);
 
         [Fact]
-        public void HasOne_DefaultStructConstructor_ReturnsTrue() => Assert.True(default(OneOrMany<int>).HasOne);
+        public void HasOne_DefaultStructConstructor_ReturnsFalse() => Assert.False(default(OneOrMany<int>).HasOne);
 
         [Fact]
         public void HasOne_DefaultClassConstructor_ReturnsFalse() => Assert.False(default(OneOrMany<string>).HasOne);
@@ -169,11 +169,8 @@ namespace Schema.NET.Test
             Assert.True(new OneOrMany<int>(1) != new OneOrMany<int>(2));
 
         [Fact]
-        public void GetEnumerator_DefaultStructConstructor_ReturnsZero()
-        {
-            var item = Assert.Single(((IEnumerable)default(OneOrMany<int>)).Cast<object>());
-            Assert.Equal(0, item);
-        }
+        public void GetEnumerator_DefaultStructConstructor_ReturnsNull() =>
+            Assert.Empty(((IEnumerable)default(OneOrMany<int>)).Cast<object>());
 
         [Fact]
         public void GetEnumerator_DefaultClassConstructor_ReturnsNull() =>

--- a/Tests/Schema.NET.Test/Values2Test.cs
+++ b/Tests/Schema.NET.Test/Values2Test.cs
@@ -25,7 +25,7 @@ namespace Schema.NET.Test
             var values = new Values<int, string>("Foo");
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Single(values.Value2);
             Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
@@ -98,7 +98,7 @@ namespace Schema.NET.Test
             Values<int, string> values = "Foo";
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Single(values.Value2);
             Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
@@ -122,7 +122,7 @@ namespace Schema.NET.Test
             Values<int, string> values = new List<string>() { "Foo", "Bar" };
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Equal(2, values.Value2.Count);
             Assert.Equal(new List<object>() { "Foo", "Bar" }, ((IValues)values).Cast<object>().ToList());

--- a/Tests/Schema.NET.Test/Values3Test.cs
+++ b/Tests/Schema.NET.Test/Values3Test.cs
@@ -25,7 +25,7 @@ namespace Schema.NET.Test
             var values = new Values<int, string, DayOfWeek>("Foo");
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Single(values.Value2);
             Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
@@ -37,7 +37,7 @@ namespace Schema.NET.Test
             var values = new Values<int, string, DayOfWeek>(DayOfWeek.Friday);
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.True(values.HasValue3);
@@ -129,7 +129,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek> values = "Foo";
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Single(values.Value2);
             Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
@@ -141,7 +141,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek> values = DayOfWeek.Friday;
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.True(values.HasValue3);
@@ -167,7 +167,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek> values = new List<string>() { "Foo", "Bar" };
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Equal(2, values.Value2.Count);
             Assert.Equal(new List<string>() { "Foo", "Bar" }, ((IValues)values).Cast<object>().ToList());
@@ -179,7 +179,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek> values = new List<DayOfWeek>() { DayOfWeek.Friday, DayOfWeek.Monday };
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.True(values.HasValue3);

--- a/Tests/Schema.NET.Test/Values4Test.cs
+++ b/Tests/Schema.NET.Test/Values4Test.cs
@@ -25,7 +25,7 @@ namespace Schema.NET.Test
             var values = new Values<int, string, DayOfWeek, Person>("Foo");
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Single(values.Value2);
             Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
@@ -37,7 +37,7 @@ namespace Schema.NET.Test
             var values = new Values<int, string, DayOfWeek, Person>(DayOfWeek.Friday);
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.True(values.HasValue3);
@@ -51,11 +51,11 @@ namespace Schema.NET.Test
             var values = new Values<int, string, DayOfWeek, Person>(new Person());
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.False(values.HasValue3);
-            Assert.Single(values.Value3);
+            Assert.Empty(values.Value3);
             Assert.True(values.HasValue4);
             Assert.Single(values.Value4);
             var item = Assert.Single(((IValues)values).Cast<object>().ToList());
@@ -157,7 +157,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek, Person> values = "Foo";
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Single(values.Value2);
             Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
@@ -169,7 +169,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek, Person> values = DayOfWeek.Friday;
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.True(values.HasValue3);
@@ -183,11 +183,11 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek, Person> values = new Person();
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.False(values.HasValue3);
-            Assert.Single(values.Value3);
+            Assert.Empty(values.Value3);
             Assert.True(values.HasValue4);
             Assert.Single(values.Value4);
             var item = Assert.Single(((IValues)values).Cast<object>().ToList());
@@ -212,7 +212,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek, Person> values = new List<string>() { "Foo", "Bar" };
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.True(values.HasValue2);
             Assert.Equal(2, values.Value2.Count);
             Assert.Equal(new List<object>() { "Foo", "Bar" }, ((IValues)values).Cast<object>().ToList());
@@ -224,7 +224,7 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek, Person> values = new List<DayOfWeek>() { DayOfWeek.Friday, DayOfWeek.Monday };
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.True(values.HasValue3);
@@ -238,11 +238,11 @@ namespace Schema.NET.Test
             Values<int, string, DayOfWeek, Person> values = new List<Person>() { new Person(), new Person() };
 
             Assert.False(values.HasValue1);
-            Assert.Single(values.Value1);
+            Assert.Empty(values.Value1);
             Assert.False(values.HasValue2);
             Assert.Empty(values.Value2);
             Assert.False(values.HasValue3);
-            Assert.Single(values.Value3);
+            Assert.Empty(values.Value3);
             Assert.True(values.HasValue4);
             Assert.Equal(2, values.Value4.Count);
             Assert.Equal(2, ((IValues)values).Cast<object>().ToList().Count);


### PR DESCRIPTION
Changes the internal logic of `OneOrMany` to be an array only (rather than an array or single item) as well as addresses a few minor bugs outlined in #116.

These changes also result in a ~3% allocation reducation in .NET Framework (though with no measurable reduction in .NET Core).