### PR TITLE
Faster instance creation for ValuesJsonConverter

### DIFF
--- a/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
@@ -13,7 +13,7 @@ namespace Schema.NET.Benchmarks
     [CsvMeasurementsExporter]
     [RPlotExporter]
     [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp30)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     public abstract class SchemaBenchmarkBase
     {
         protected Thing Thing { get; set; }

--- a/Source/Schema.NET/FastActivator.cs
+++ b/Source/Schema.NET/FastActivator.cs
@@ -1,0 +1,61 @@
+namespace Schema.NET
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using System.Text;
+
+    /// <summary>
+    /// A faster version of <see cref="Activator.CreateInstance(System.Type, object[])"/> by providing constructor delegates.
+    /// </summary>
+    internal static class FastActivator
+    {
+        private static readonly ConcurrentDictionary<(Type, Type), Delegate> ConstructorDelegateLookup = new ConcurrentDictionary<(Type, Type), Delegate>();
+
+        /// <summary>
+        /// Creates a constructor delegate for the specified type.
+        /// </summary>
+        /// <typeparam name="T1">Type of first argument for constructor.</typeparam>
+        /// <param name="objectType">The object to find the constructor.</param>
+        /// <returns>The constructor delegate.</returns>
+        public static Func<T1, object> GetDynamicConstructor<T1>(Type objectType)
+        {
+            var constructorKey = (objectType, typeof(T1));
+            if (!ConstructorDelegateLookup.TryGetValue(constructorKey, out var constructorDelegate))
+            {
+                var constructor = GetConstructorInfo(objectType, typeof(T1));
+                constructorDelegate = CreateConstructorDelegate<T1>(constructor);
+                ConstructorDelegateLookup.TryAdd(constructorKey, constructorDelegate);
+            }
+
+            return constructorDelegate as Func<T1, object>;
+        }
+
+        private static Func<T1, object> CreateConstructorDelegate<T1>(ConstructorInfo constructor) => Expression.Lambda<Func<T1, object>>(
+                Expression.Convert(
+                    Expression.New(constructor, ConstructorParameter<T1>.SingleParameter),
+                    typeof(object)),
+                ConstructorParameter<T1>.SingleParameter).Compile();
+
+        private static ConstructorInfo GetConstructorInfo(Type objectType, Type parameter1)
+        {
+            foreach (var constructor in objectType.GetTypeInfo().DeclaredConstructors)
+            {
+                var parameters = constructor.GetParameters();
+                if (constructor.IsPublic && parameters.Length == 1 && parameters[0].ParameterType == parameter1)
+                {
+                    return constructor;
+                }
+            }
+
+            return null;
+        }
+
+        private static class ConstructorParameter<T1>
+        {
+            public static readonly ParameterExpression[] SingleParameter = new[] { Expression.Parameter(typeof(T1)) };
+        }
+    }
+}

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -45,6 +45,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' Or '$(TargetFramework)' == 'net461'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
 
   <ItemGroup Label="Analyzer Package References">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="all" Version="2.9.8" />


### PR DESCRIPTION
It turns out `Activator.CreateInstance` is slow relative to the rest of the serialization process.

![image](https://user-images.githubusercontent.com/904226/71414965-60961b00-26a9-11ea-8a7a-9aa171866f8d.png)
In that image, you can see it taking a little over 30% of the deserialization time.

Using a technique from [JSON .NET](https://github.com/JamesNK/Newtonsoft.Json/blob/cdf10151d507d497a3f9a71d36d544b199f73435/Src/Newtonsoft.Json/Utilities/ExpressionReflectionDelegateFactory.cs#L44-L58) (with a similar technique in [System.Text.Json](https://github.com/dotnet/corefx/blob/e99ec129cfd594d53f4390bf97d1d736cff6f860/src/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs#L15-L56)), the idea is to create a custom constructor delegate to avoid the overhead of finding and calling the constructor through reflection.

![image](https://user-images.githubusercontent.com/904226/71415208-7a842d80-26aa-11ea-9b25-654c3e921162.png)
In this image, we can see the large drop in both the `System.Private.CoreLib` module as well as the line percentage dropping down to ~7% of the deserialization time.

With benchmarks, we can see the difference in performance and allocations as well. Specifically with the Book benchmark:

*Before*

|      Method |       Runtime |     Mean |    Error |   StdDev |   Median |      Min |      Max |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |-------------- |---------:|---------:|---------:|---------:|---------:|---------:|--------:|------:|------:|----------:|
|   Serialize |    .NET 4.7.2 | 205.1 us | 13.57 us | 28.33 us | 190.9 us | 183.1 us | 267.9 us | 15.3809 |     - |     - |  47.49 KB |
| Deserialize |    .NET 4.7.2 | 361.1 us |  6.54 us |  5.47 us | 360.4 us | 350.1 us | 371.7 us | 34.6680 |     - |     - |  107.3 KB |
|   Serialize | .NET Core 3.1 | 177.1 us |  3.10 us |  2.59 us | 177.2 us | 173.7 us | 181.0 us | 15.3809 |     - |     - |  47.27 KB |
| Deserialize | .NET Core 3.1 | 290.0 us |  4.08 us |  3.82 us | 290.0 us | 281.4 us | 295.7 us | 33.6914 |     - |     - |    104 KB |

*After*

|      Method |       Runtime |     Mean |    Error |   StdDev |   Median |      Min |      Max |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |-------------- |---------:|---------:|---------:|---------:|---------:|---------:|--------:|------:|------:|----------:|
|   Serialize |    .NET 4.7.2 | 206.4 us | 13.75 us | 27.47 us | 191.3 us | 182.7 us | 261.2 us | 15.3809 |     - |     - |  47.49 KB |
| Deserialize |    .NET 4.7.2 | 176.3 us |  1.98 us |  1.85 us | 176.9 us | 172.7 us | 178.4 us | 26.6113 |     - |     - |  81.84 KB |
|   Serialize | .NET Core 3.1 | 181.5 us |  3.14 us |  2.93 us | 181.5 us | 174.0 us | 185.6 us | 15.3809 |     - |     - |  47.27 KB |
| Deserialize | .NET Core 3.1 | 155.5 us |  1.48 us |  1.38 us | 155.4 us | 152.7 us | 158.1 us | 25.6348 |     - |     - |   79.1 KB |

As you can see, deserialization times are cut in half while also allocating ~24% less.

The constructor delegate cache is built per each object type (eg. `OneOrMany<string>` or `Values<string, Uri>`) with every type getting an entry. For a one-off serialization of a type, this would actually use more and likely take longer as each constructor gets generated for every type on every property being serialized. The benefits to this change come more with the frequency of deserializations.

-----

With the update to the benchmark runtime moniker, I found there to be a strange performance measuring issue when there is a mix of .NET 3.1 target in the project file with a runtime moniker targeting 3.0 while not having 3.0 installed (.NET Core was performing far worse than .NET Framework). I figure let's just make the project target and the benchmark runtime moniker be the same.