### PR TITLE
On-demand List allocation in Values<> type

### DIFF
--- a/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
@@ -101,40 +101,60 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(items));
             }
 
-            var items1 = new List<T1>();
-            var items2 = new List<T2>();
-            var items3 = new List<T3>();
-            var items4 = new List<T4>();
+            List<T1> items1 = null;
+            List<T2> items2 = null;
+            List<T3> items3 = null;
+            List<T4> items4 = null;
 
             foreach (var item in items)
             {
                 if (item is T4 itemT4)
                 {
+                    if (items4 == null)
+                    {
+                        items4 = new List<T4>();
+                    }
+
                     items4.Add(itemT4);
                 }
                 else if (item is T3 itemT3)
                 {
+                    if (items3 == null)
+                    {
+                        items3 = new List<T3>();
+                    }
+
                     items3.Add(itemT3);
                 }
                 else if (item is T2 itemT2)
                 {
+                    if (items2 == null)
+                    {
+                        items2 = new List<T2>();
+                    }
+
                     items2.Add(itemT2);
                 }
                 else if (item is T1 itemT1)
                 {
+                    if (items1 == null)
+                    {
+                        items1 = new List<T1>();
+                    }
+
                     items1.Add(itemT1);
                 }
             }
 
-            this.HasValue1 = items1.Count > 0;
-            this.HasValue2 = items2.Count > 0;
-            this.HasValue3 = items3.Count > 0;
-            this.HasValue4 = items4.Count > 0;
+            this.HasValue1 = items1?.Count > 0;
+            this.HasValue2 = items2?.Count > 0;
+            this.HasValue3 = items3?.Count > 0;
+            this.HasValue4 = items4?.Count > 0;
 
-            this.Value1 = items1;
-            this.Value2 = items2;
-            this.Value3 = items3;
-            this.Value4 = items4;
+            this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
+            this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
+            this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
+            this.Value4 = items4 == null ? default : (OneOrMany<T4>)items4;
         }
 
         /// <summary>

--- a/Source/Schema.NET/Values{T1,T2,T3}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3}.cs
@@ -78,33 +78,48 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(items));
             }
 
-            var items1 = new List<T1>();
-            var items2 = new List<T2>();
-            var items3 = new List<T3>();
+            List<T1> items1 = null;
+            List<T2> items2 = null;
+            List<T3> items3 = null;
 
             foreach (var item in items)
             {
                 if (item is T3 itemT3)
                 {
+                    if (items3 == null)
+                    {
+                        items3 = new List<T3>();
+                    }
+
                     items3.Add(itemT3);
                 }
                 else if (item is T2 itemT2)
                 {
+                    if (items2 == null)
+                    {
+                        items2 = new List<T2>();
+                    }
+
                     items2.Add(itemT2);
                 }
                 else if (item is T1 itemT1)
                 {
+                    if (items1 == null)
+                    {
+                        items1 = new List<T1>();
+                    }
+
                     items1.Add(itemT1);
                 }
             }
 
-            this.HasValue1 = items1.Count > 0;
-            this.HasValue2 = items2.Count > 0;
-            this.HasValue3 = items3.Count > 0;
+            this.HasValue1 = items1?.Count > 0;
+            this.HasValue2 = items2?.Count > 0;
+            this.HasValue3 = items3?.Count > 0;
 
-            this.Value1 = items1;
-            this.Value2 = items2;
-            this.Value3 = items3;
+            this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
+            this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
+            this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
         }
 
         /// <summary>

--- a/Source/Schema.NET/Values{T1,T2}.cs
+++ b/Source/Schema.NET/Values{T1,T2}.cs
@@ -59,26 +59,36 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(items));
             }
 
-            var items1 = new List<T1>();
-            var items2 = new List<T2>();
+            List<T1> items1 = null;
+            List<T2> items2 = null;
 
             foreach (var item in items)
             {
                 if (item is T2 itemT2)
                 {
+                    if (items2 == null)
+                    {
+                        items2 = new List<T2>();
+                    }
+
                     items2.Add(itemT2);
                 }
                 else if (item is T1 itemT1)
                 {
+                    if (items1 == null)
+                    {
+                        items1 = new List<T1>();
+                    }
+
                     items1.Add(itemT1);
                 }
             }
 
-            this.HasValue1 = items1.Count > 0;
-            this.HasValue2 = items2.Count > 0;
+            this.HasValue1 = items1?.Count > 0;
+            this.HasValue2 = items2?.Count > 0;
 
-            this.Value1 = items1;
-            this.Value2 = items2;
+            this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
+            this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
         }
 
         /// <summary>


### PR DESCRIPTION
Previously we would allocate (up to) 4 lists in the `IEnumerable<object>` constructor on `Values<>`. This is fine when we have all types supported by `Values<>` present in the JSON we are reading but is overkill when we have less than that.

This change is effectively just-in-time list construction where we only instantiate that type when we actually have an item of that type.

According to my benchmarks, there is a 1.5% decrease in allocations - likely as a best case. As a worst case (a `Values4` has all 4 types present in JSON), the allocations should be the same.