### PR TITLE
set privateassets for Microsoft.VisualStudio.Threading.Analyzers

### DIFF
--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -42,7 +42,7 @@
     <!-- See https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.4.43" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>


### PR DESCRIPTION
Addresses issue https://github.com/RehanSaeed/Schema.NET/issues/123

Setting PrivateAssets="All" should do the trick 
(Src: https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019#dependent-projects)