### PR TITLE
Schema.org Release v7

### DIFF
--- a/Source/Schema.NET/DateTimeHelper.cs
+++ b/Source/Schema.NET/DateTimeHelper.cs
@@ -1,0 +1,116 @@
+namespace Schema.NET
+{
+    using System;
+
+    /// <summary>
+    /// Helper for parsing strings into <see cref="DateTime"/> or <see cref="DateTimeOffset"/>
+    /// </summary>
+    internal static class DateTimeHelper
+    {
+        private const string MSDateStringStart = "/Date(";
+        private const string MSDateStringEnd = ")/";
+        private const string NegativeOffset = "-";
+        private static readonly DateTime EpochDate = new DateTime(1970, 1, 1);
+        private static readonly char[] OffsetChars = new[] { '+', '-' };
+
+        /// <summary>
+        /// Whether a given ISO 8601 date string has an offset defined (eg. "+", "-", "Z")
+        /// </summary>
+        /// <param name="input">The input string</param>
+        /// <returns>True if the input string has an offset defined</returns>
+        public static bool ContainsTimeOffset(string input)
+        {
+            if (input.IndexOf("+", StringComparison.Ordinal) != -1 || input.IndexOf("Z", StringComparison.Ordinal) != -1)
+            {
+                return true;
+            }
+
+            var timeSeparatorIndex = input.IndexOf("T", StringComparison.Ordinal);
+            if (timeSeparatorIndex != -1)
+            {
+                return input.IndexOf(NegativeOffset, timeSeparatorIndex, StringComparison.Ordinal) != -1;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Parse MS DateTime as Date eg. "/Date(946730040000)/"
+        /// </summary>
+        /// <param name="input">The input string</param>
+        /// <param name="result">The result date and time</param>
+        /// <returns>True if the input string was able to be parsed into a <see cref="DateTime"/></returns>
+        public static bool TryParseMSDateTime(string input, out DateTime result)
+        {
+            if (input.StartsWith(MSDateStringStart, StringComparison.Ordinal) && input.EndsWith(MSDateStringEnd, StringComparison.Ordinal))
+            {
+                var dateTimeStartIndex = MSDateStringStart.Length;
+                var dateTimeLength = input.IndexOf(MSDateStringEnd, StringComparison.Ordinal) - dateTimeStartIndex;
+
+#if NETCOREAPP3_1
+                var timeValue = input.AsSpan().Slice(dateTimeStartIndex, dateTimeLength);
+#else
+                var timeValue = input.Substring(dateTimeStartIndex, dateTimeLength);
+#endif
+
+                if (double.TryParse(timeValue, out var milliseconds))
+                {
+                    result = EpochDate.AddMilliseconds(milliseconds);
+                    return true;
+                }
+            }
+
+            result = DateTime.MinValue;
+            return false;
+        }
+
+        /// <summary>
+        /// Parse MS DateTime as <see cref="DateTimeOffset"/> eg. "/Date(946730040000-0100)/"
+        /// </summary>
+        /// <param name="input">The input string</param>
+        /// <param name="result">The result date and time with offset</param>
+        /// <returns>True if the input string was able to be parsed into a <see cref="DateTimeOffset"/></returns>
+        public static bool TryParseMSDateTimeOffset(string input, out DateTimeOffset result)
+        {
+            if (input.StartsWith(MSDateStringStart, StringComparison.Ordinal) && input.EndsWith(MSDateStringEnd, StringComparison.Ordinal))
+            {
+                var dateTimeStartIndex = MSDateStringStart.Length;
+                var offsetIndex = input.IndexOfAny(OffsetChars);
+                var dateTimeLength = offsetIndex - dateTimeStartIndex;
+                var offsetLength = input.IndexOf(MSDateStringEnd, offsetIndex, StringComparison.Ordinal) - offsetIndex;
+
+#if NETCOREAPP3_1
+                var timeValue = input.AsSpan().Slice(dateTimeStartIndex, dateTimeLength);
+                var offsetType = input.AsSpan().Slice(offsetIndex, 1);
+                var offsetValue = input.AsSpan().Slice(offsetIndex + 1, offsetLength - 1);
+#else
+                var timeValue = input.Substring(dateTimeStartIndex, dateTimeLength);
+                var offsetType = input.Substring(offsetIndex, 1);
+                var offsetValue = input.Substring(offsetIndex + 1, offsetLength);
+#endif
+
+                if (double.TryParse(timeValue, out var milliseconds))
+                {
+                    if (int.TryParse(offsetValue, out var offset))
+                    {
+                        var dateTime = EpochDate.AddMilliseconds(milliseconds);
+                        var hours = offset / 100;
+                        var minutes = offset - (hours * 100);
+                        var offsetTimeSpan = new TimeSpan(hours, minutes, 0);
+
+                        if (offsetType[0] == NegativeOffset[0])
+                        {
+                            offsetTimeSpan = -offsetTimeSpan;
+                        }
+
+                        result = new DateTimeOffset(dateTime, offsetTimeSpan);
+                        return true;
+                    }
+                }
+            }
+
+            result = DateTimeOffset.MinValue;
+            return false;
+        }
+    }
+}

--- a/Source/Schema.NET/DateTimeHelper.cs
+++ b/Source/Schema.NET/DateTimeHelper.cs
@@ -86,7 +86,7 @@ namespace Schema.NET
 #else
                 var timeValue = input.Substring(dateTimeStartIndex, dateTimeLength);
                 var offsetType = input.Substring(offsetIndex, 1);
-                var offsetValue = input.Substring(offsetIndex + 1, offsetLength);
+                var offsetValue = input.Substring(offsetIndex + 1, offsetLength - 1);
 #endif
 
                 if (double.TryParse(timeValue, out var milliseconds))

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net472;netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Source/Schema.NET/SchemaSerializer.cs
+++ b/Source/Schema.NET/SchemaSerializer.cs
@@ -1,0 +1,99 @@
+namespace Schema.NET
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// Schema JSON Serializer
+    /// </summary>
+    public static class SchemaSerializer
+    {
+        private const string ContextPropertyJson = "\"@context\":\"https://schema.org\",";
+
+        /// <summary>
+        /// Default serializer settings used when deserializing
+        /// </summary>
+        private static readonly JsonSerializerSettings DeserializeSettings = new JsonSerializerSettings
+        {
+            DateParseHandling = DateParseHandling.None,
+        };
+
+        /// <summary>
+        /// Default serializer settings used when HTML escaping is not required.
+        /// </summary>
+        private static readonly JsonSerializerSettings DefaultSerializationSettings = new JsonSerializerSettings()
+        {
+            Converters = new List<JsonConverter>()
+            {
+                new StringEnumConverter(),
+            },
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+            NullValueHandling = NullValueHandling.Ignore,
+        };
+
+        /// <summary>
+        /// Serializer settings used when trying to avoid XSS vulnerabilities where user-supplied data is used
+        /// and the output of the serialization is embedded into a web page raw.
+        /// </summary>
+        private static readonly JsonSerializerSettings HtmlEscapedSerializationSettings = new JsonSerializerSettings()
+        {
+            Converters = new List<JsonConverter>()
+            {
+                new StringEnumConverter(),
+            },
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+            NullValueHandling = NullValueHandling.Ignore,
+            StringEscapeHandling = StringEscapeHandling.EscapeHtml,
+        };
+
+        /// <summary>
+        /// Deserializes the JSON to the specified type.
+        /// </summary>
+        /// <typeparam name="T">Deserialization target type</typeparam>
+        /// <param name="value">JSON to deserialize</param>
+        /// <returns>An instance of <typeparamref name="T"/> deserialized from JSON</returns>
+        public static T DeserializeObject<T>(string value)
+            => JsonConvert.DeserializeObject<T>(value, DeserializeSettings);
+
+        /// <summary>
+        /// Serializes the value to JSON with default serialization settings.
+        /// </summary>
+        /// <param name="value">Serialization target value</param>
+        /// <returns>The serialized JSON string</returns>
+        public static string SerializeObject(object value)
+            => SerializeObject(value, DefaultSerializationSettings);
+
+        /// <summary>
+        /// Serializes the value to JSON with HTML escaping serialization settings.
+        /// </summary>
+        /// <param name="value">Serialization target value</param>
+        /// <returns>The serialized JSON string</returns>
+        public static string HtmlEscapedSerializeObject(object value)
+            => SerializeObject(value, HtmlEscapedSerializationSettings);
+
+        /// <summary>
+        /// Serializes the value to JSON with custom serialization settings.
+        /// </summary>
+        /// <param name="value">Serialization target value</param>
+        /// <param name="jsonSerializerSettings">JSON serialization settings</param>
+        /// <returns>The serialized JSON string</returns>
+        public static string SerializeObject(object value, JsonSerializerSettings jsonSerializerSettings)
+            => RemoveAllButFirstContext(JsonConvert.SerializeObject(value, jsonSerializerSettings));
+
+        private static string RemoveAllButFirstContext(string json)
+        {
+            if (json.IndexOf(ContextPropertyJson, StringComparison.Ordinal) != -1)
+            {
+                var stringBuilder = new StringBuilder(json);
+                var startIndex = ContextPropertyJson.Length + 1; // We add the one to represent the opening curly brace.
+                stringBuilder.Replace(ContextPropertyJson, string.Empty, startIndex, stringBuilder.Length - startIndex);
+                return stringBuilder.ToString();
+            }
+
+            return json;
+        }
+    }
+}

--- a/Source/Schema.NET/Thing.Partial.cs
+++ b/Source/Schema.NET/Thing.Partial.cs
@@ -1,52 +1,19 @@
 namespace Schema.NET
 {
-    using System.Collections.Generic;
-    using System.Text;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
 
     /// <summary>
     /// The most generic type of item.
     /// </summary>
     public partial class Thing : JsonLdObject
     {
-        private const string ContextPropertyJson = "\"@context\":\"https://schema.org\",";
-
-        /// <summary>
-        /// Default serializer settings used.
-        /// </summary>
-        private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings()
-        {
-            Converters = new List<JsonConverter>()
-            {
-                new StringEnumConverter(),
-            },
-            DefaultValueHandling = DefaultValueHandling.Ignore,
-            NullValueHandling = NullValueHandling.Ignore,
-        };
-
-        /// <summary>
-        /// Serializer settings used when trying to avoid XSS vulnerabilities where user-supplied data is used
-        /// and the output of the serialization is embedded into a web page raw.
-        /// </summary>
-        private static readonly JsonSerializerSettings HtmlEscapedSerializerSettings = new JsonSerializerSettings()
-        {
-            Converters = new List<JsonConverter>()
-            {
-                new StringEnumConverter(),
-            },
-            DefaultValueHandling = DefaultValueHandling.Ignore,
-            NullValueHandling = NullValueHandling.Ignore,
-            StringEscapeHandling = StringEscapeHandling.EscapeHtml,
-        };
-
         /// <summary>
         /// Returns the JSON-LD representation of this instance.
         /// </summary>
         /// <returns>
         /// A <see cref="string" /> that represents the JSON-LD representation of this instance.
         /// </returns>
-        public override string ToString() => this.ToString(SerializerSettings);
+        public override string ToString() => SchemaSerializer.SerializeObject(this);
 
         /// <summary>
         /// Returns the JSON-LD representation of this instance.
@@ -58,7 +25,7 @@ namespace Schema.NET
         /// <returns>
         /// A <see cref="string" /> that represents the JSON-LD representation of this instance.
         /// </returns>
-        public string ToHtmlEscapedString() => this.ToString(HtmlEscapedSerializerSettings);
+        public string ToHtmlEscapedString() => SchemaSerializer.HtmlEscapedSerializeObject(this);
 
         /// <summary>
         /// Returns the JSON-LD representation of this instance using the <see cref="JsonSerializerSettings"/> provided.
@@ -73,14 +40,6 @@ namespace Schema.NET
         /// A <see cref="string" /> that represents the JSON-LD representation of this instance.
         /// </returns>
         public string ToString(JsonSerializerSettings serializerSettings) =>
-            RemoveAllButFirstContext(JsonConvert.SerializeObject(this, serializerSettings));
-
-        private static string RemoveAllButFirstContext(string json)
-        {
-            var stringBuilder = new StringBuilder(json);
-            var startIndex = ContextPropertyJson.Length + 1; // We add the one to represent the opening curly brace.
-            stringBuilder.Replace(ContextPropertyJson, string.Empty, startIndex, stringBuilder.Length - startIndex);
-            return stringBuilder.ToString();
-        }
+            SchemaSerializer.SerializeObject(this, serializerSettings);
     }
 }

--- a/Source/Schema.NET/ValuesJsonConverter.cs
+++ b/Source/Schema.NET/ValuesJsonConverter.cs
@@ -323,8 +323,11 @@ namespace Schema.NET
                 }
                 else if (targetType == typeof(DateTimeOffset))
                 {
-                    success = DateTimeOffset.TryParse(valueString, CultureInfo.InvariantCulture, DateTimeStyles.None, out var localResult);
-                    result = localResult;
+                    if (valueString.Contains("+") || valueString.Contains("Z"))
+                    {
+                        success = DateTimeOffset.TryParse(valueString, CultureInfo.InvariantCulture, DateTimeStyles.None, out var localResult);
+                        result = localResult;
+                    }
                 }
                 else if (targetType == typeof(TimeSpan))
                 {

--- a/Source/Schema.NET/ValuesJsonConverter.cs
+++ b/Source/Schema.NET/ValuesJsonConverter.cs
@@ -318,14 +318,27 @@ namespace Schema.NET
                 }
                 else if (targetType == typeof(DateTime))
                 {
-                    success = DateTime.TryParse(valueString, CultureInfo.InvariantCulture, DateTimeStyles.None, out var localResult);
-                    result = localResult;
+                    if (DateTimeHelper.TryParseMSDateTime(valueString, out var localResult))
+                    {
+                        success = true;
+                        result = localResult;
+                    }
+                    else
+                    {
+                        success = DateTime.TryParse(valueString, CultureInfo.InvariantCulture, DateTimeStyles.None, out localResult);
+                        result = localResult;
+                    }
                 }
                 else if (targetType == typeof(DateTimeOffset))
                 {
-                    if (valueString.Contains("+") || valueString.Contains("Z"))
+                    if (DateTimeHelper.TryParseMSDateTimeOffset(valueString, out var localResult))
                     {
-                        success = DateTimeOffset.TryParse(valueString, CultureInfo.InvariantCulture, DateTimeStyles.None, out var localResult);
+                        success = true;
+                        result = localResult;
+                    }
+                    else if (DateTimeHelper.ContainsTimeOffset(valueString))
+                    {
+                        success = DateTimeOffset.TryParse(valueString, CultureInfo.InvariantCulture, DateTimeStyles.None, out localResult);
                         result = localResult;
                     }
                 }
@@ -367,19 +380,6 @@ namespace Schema.NET
                 if (targetType.GetTypeInfo().IsPrimitive || targetType == typeof(decimal))
                 {
                     result = Convert.ChangeType(reader.Value, targetType, CultureInfo.InvariantCulture);
-                    success = true;
-                }
-            }
-            else if (tokenType == JsonToken.Date)
-            {
-                if (targetType == typeof(DateTime) && reader.Value is DateTimeOffset dateTimeOffset)
-                {
-                    result = dateTimeOffset.UtcDateTime;
-                    success = true;
-                }
-                else if (targetType == typeof(DateTimeOffset) && reader.Value is DateTime dateTime)
-                {
-                    result = new DateTimeOffset(dateTime);
                     success = true;
                 }
             }

--- a/Source/Schema.NET/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -1,0 +1,950 @@
+namespace Schema.NET
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// A single or list of values which can be any of the specified types.
+    /// </summary>
+    /// <typeparam name="T1">The first type the values can take.</typeparam>
+    /// <typeparam name="T2">The second type the values can take.</typeparam>
+    /// <typeparam name="T3">The third type the values can take.</typeparam>
+    /// <typeparam name="T4">The fourth type the values can take.</typeparam>
+    /// <typeparam name="T5">The fifth type the values can take.</typeparam>
+    /// <typeparam name="T6">The sixth type the values can take.</typeparam>
+    /// <typeparam name="T7">The seventh type the values can take.</typeparam>
+#pragma warning disable CA1710 // Identifiers should have correct suffix
+    public readonly struct Values<T1, T2, T3, T4, T5, T6, T7>
+        : IReadOnlyCollection<object>, IEnumerable<object>, IValues, IEquatable<Values<T1, T2, T3, T4, T5, T6, T7>>
+#pragma warning restore CA1710 // Identifiers should have correct suffix
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="value">The value of type <typeparamref name="T1"/>.</param>
+        public Values(OneOrMany<T1> value)
+        {
+            this.Value1 = value;
+            this.Value2 = default;
+            this.Value3 = default;
+            this.Value4 = default;
+            this.Value5 = default;
+            this.Value6 = default;
+            this.Value7 = default;
+            this.HasValue1 = value.Count > 0;
+            this.HasValue2 = false;
+            this.HasValue3 = false;
+            this.HasValue4 = false;
+            this.HasValue5 = false;
+            this.HasValue6 = false;
+            this.HasValue7 = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="value">The value of type <typeparamref name="T2"/>.</param>
+        public Values(OneOrMany<T2> value)
+        {
+            this.Value1 = default;
+            this.Value2 = value;
+            this.Value3 = default;
+            this.Value4 = default;
+            this.Value5 = default;
+            this.Value6 = default;
+            this.Value7 = default;
+            this.HasValue1 = false;
+            this.HasValue2 = value.Count > 0;
+            this.HasValue3 = false;
+            this.HasValue4 = false;
+            this.HasValue5 = false;
+            this.HasValue6 = false;
+            this.HasValue7 = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="value">The value of type <typeparamref name="T3"/>.</param>
+        public Values(OneOrMany<T3> value)
+        {
+            this.Value1 = default;
+            this.Value2 = default;
+            this.Value3 = value;
+            this.Value4 = default;
+            this.Value5 = default;
+            this.Value6 = default;
+            this.Value7 = default;
+            this.HasValue1 = false;
+            this.HasValue2 = false;
+            this.HasValue3 = value.Count > 0;
+            this.HasValue4 = false;
+            this.HasValue5 = false;
+            this.HasValue6 = false;
+            this.HasValue7 = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="value">The value of type <typeparamref name="T4"/>.</param>
+        public Values(OneOrMany<T4> value)
+        {
+            this.Value1 = default;
+            this.Value2 = default;
+            this.Value3 = default;
+            this.Value4 = value;
+            this.Value5 = default;
+            this.Value6 = default;
+            this.Value7 = default;
+            this.HasValue1 = false;
+            this.HasValue2 = false;
+            this.HasValue3 = false;
+            this.HasValue4 = value.Count > 0;
+            this.HasValue5 = false;
+            this.HasValue6 = false;
+            this.HasValue7 = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="value">The value of type <typeparamref name="T4"/>.</param>
+        public Values(OneOrMany<T5> value)
+        {
+            this.Value1 = default;
+            this.Value2 = default;
+            this.Value3 = default;
+            this.Value4 = default;
+            this.Value5 = value;
+            this.Value6 = default;
+            this.Value7 = default;
+            this.HasValue1 = false;
+            this.HasValue2 = false;
+            this.HasValue3 = false;
+            this.HasValue4 = false;
+            this.HasValue5 = value.Count > 0;
+            this.HasValue6 = false;
+            this.HasValue7 = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="value">The value of type <typeparamref name="T4"/>.</param>
+        public Values(OneOrMany<T6> value)
+        {
+            this.Value1 = default;
+            this.Value2 = default;
+            this.Value3 = default;
+            this.Value4 = default;
+            this.Value5 = default;
+            this.Value6 = value;
+            this.Value7 = default;
+            this.HasValue1 = false;
+            this.HasValue2 = false;
+            this.HasValue3 = false;
+            this.HasValue4 = false;
+            this.HasValue5 = false;
+            this.HasValue6 = value.Count > 0;
+            this.HasValue7 = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="value">The value of type <typeparamref name="T4"/>.</param>
+        public Values(OneOrMany<T7> value)
+        {
+            this.Value1 = default;
+            this.Value2 = default;
+            this.Value3 = default;
+            this.Value4 = default;
+            this.Value5 = default;
+            this.Value6 = default;
+            this.Value7 = value;
+            this.HasValue1 = false;
+            this.HasValue2 = false;
+            this.HasValue3 = false;
+            this.HasValue4 = false;
+            this.HasValue5 = false;
+            this.HasValue6 = false;
+            this.HasValue7 = value.Count > 0;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="items">The items.</param>
+        public Values(params object[] items)
+            : this(items.AsEnumerable())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
+        /// </summary>
+        /// <param name="items">The items.</param>
+        public Values(IEnumerable<object> items)
+        {
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            List<T1> items1 = null;
+            List<T2> items2 = null;
+            List<T3> items3 = null;
+            List<T4> items4 = null;
+            List<T5> items5 = null;
+            List<T6> items6 = null;
+            List<T7> items7 = null;
+
+            foreach (var item in items)
+            {
+                if (item is T7 itemT7)
+                {
+                    if (items7 == null)
+                    {
+                        items7 = new List<T7>();
+                    }
+
+                    items7.Add(itemT7);
+                }
+                else if (item is T6 itemT6)
+                {
+                    if (items6 == null)
+                    {
+                        items6 = new List<T6>();
+                    }
+
+                    items6.Add(itemT6);
+                }
+                else if (item is T5 itemT5)
+                {
+                    if (items5 == null)
+                    {
+                        items5 = new List<T5>();
+                    }
+
+                    items5.Add(itemT5);
+                }
+                else if (item is T4 itemT4)
+                {
+                    if (items4 == null)
+                    {
+                        items4 = new List<T4>();
+                    }
+
+                    items4.Add(itemT4);
+                }
+                else if (item is T3 itemT3)
+                {
+                    if (items3 == null)
+                    {
+                        items3 = new List<T3>();
+                    }
+
+                    items3.Add(itemT3);
+                }
+                else if (item is T2 itemT2)
+                {
+                    if (items2 == null)
+                    {
+                        items2 = new List<T2>();
+                    }
+
+                    items2.Add(itemT2);
+                }
+                else if (item is T1 itemT1)
+                {
+                    if (items1 == null)
+                    {
+                        items1 = new List<T1>();
+                    }
+
+                    items1.Add(itemT1);
+                }
+            }
+
+            this.HasValue1 = items1?.Count > 0;
+            this.HasValue2 = items2?.Count > 0;
+            this.HasValue3 = items3?.Count > 0;
+            this.HasValue4 = items4?.Count > 0;
+            this.HasValue5 = items5?.Count > 0;
+            this.HasValue6 = items6?.Count > 0;
+            this.HasValue7 = items7?.Count > 0;
+
+            this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
+            this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
+            this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
+            this.Value4 = items4 == null ? default : (OneOrMany<T4>)items4;
+            this.Value5 = items5 == null ? default : (OneOrMany<T5>)items5;
+            this.Value6 = items6 == null ? default : (OneOrMany<T6>)items6;
+            this.Value7 = items7 == null ? default : (OneOrMany<T7>)items7;
+        }
+
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        public int Count => this.Value1.Count + this.Value2.Count + this.Value3.Count + this.Value4.Count + this.Value5.Count + this.Value6.Count + this.Value7.Count;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has a value.
+        /// </summary>
+        public bool HasValue => this.HasValue1 || this.HasValue2 || this.HasValue3 || this.HasValue4 || this.HasValue5 || this.HasValue6 || this.HasValue7;
+
+        /// <summary>
+        /// Gets a value indicating whether the value of type <typeparamref name="T1" /> has a value.
+        /// </summary>
+        public bool HasValue1 { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the value of type <typeparamref name="T2" /> has a value.
+        /// </summary>
+        public bool HasValue2 { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the value of type <typeparamref name="T3" /> has a value.
+        /// </summary>
+        public bool HasValue3 { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the value of type <typeparamref name="T4" /> has a value.
+        /// </summary>
+        public bool HasValue4 { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the value of type <typeparamref name="T5" /> has a value.
+        /// </summary>
+        public bool HasValue5 { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the value of type <typeparamref name="T6" /> has a value.
+        /// </summary>
+        public bool HasValue6 { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the value of type <typeparamref name="T7" /> has a value.
+        /// </summary>
+        public bool HasValue7 { get; }
+
+        /// <summary>
+        /// Gets the value of type <typeparamref name="T1" />.
+        /// </summary>
+        public OneOrMany<T1> Value1 { get; }
+
+        /// <summary>
+        /// Gets the value of type <typeparamref name="T2" />.
+        /// </summary>
+        public OneOrMany<T2> Value2 { get; }
+
+        /// <summary>
+        /// Gets the value of type <typeparamref name="T3" />.
+        /// </summary>
+        public OneOrMany<T3> Value3 { get; }
+
+        /// <summary>
+        /// Gets the value of type <typeparamref name="T4" />.
+        /// </summary>
+        public OneOrMany<T4> Value4 { get; }
+
+        /// <summary>
+        /// Gets the value of type <typeparamref name="T5" />.
+        /// </summary>
+        public OneOrMany<T5> Value5 { get; }
+
+        /// <summary>
+        /// Gets the value of type <typeparamref name="T6" />.
+        /// </summary>
+        public OneOrMany<T6> Value6 { get; }
+
+        /// <summary>
+        /// Gets the value of type <typeparamref name="T7" />.
+        /// </summary>
+        public OneOrMany<T7> Value7 { get; }
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T1"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T3"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T4"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T5"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T6"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T7"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="item">The single item value.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T1[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T2[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T3[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T4[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T5[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T6[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <typeparamref name="T7[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T1> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T2> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{T3}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T3> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{T4}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T4> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{T5}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T5> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{T6}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T6> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{T7}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T7> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="object"/> array to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="array">The array of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(object[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="List{Object}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
+        /// </summary>
+        /// <param name="list">The list of values.</param>
+        /// <returns>The result of the conversion.</returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<object> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T1"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T1(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value1.FirstOrDefault();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T2"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T2(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value2.FirstOrDefault();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T3"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T3(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value3.FirstOrDefault();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T4"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T4(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value4.FirstOrDefault();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T5"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T5(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value5.FirstOrDefault();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T6"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T6(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value6.FirstOrDefault();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T7"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T7(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value7.FirstOrDefault();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T1"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T1[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value1.ToArray();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T1}"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator List<T1>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value1.ToList();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T2"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T2[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value2.ToArray();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T2}"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator List<T2>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value2.ToList();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T3"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T3[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value3.ToArray();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T3}"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator List<T3>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value3.ToList();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T4"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T4[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value4.ToArray();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T4}"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator List<T4>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value4.ToList();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T5"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T5[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value5.ToArray();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T5}"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator List<T5>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value5.ToList();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T6"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T6[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value6.ToArray();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T6}"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator List<T6>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value6.ToList();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T7"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator T7[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value7.ToArray();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T7}"/>.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        public static implicit operator List<T7>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value7.ToList();
+#pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(Values<T1, T2, T3, T4, T5, T6, T7> left, Values<T1, T2, T3, T4, T5, T6, T7> right) => left.Equals(right);
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(Values<T1, T2, T3, T4, T5, T6, T7> left, Values<T1, T2, T3, T4, T5, T6, T7> right) => !(left == right);
+
+        /// <summary>Deconstructs the specified items.</summary>
+        /// <param name="items1">The items from value 1.</param>
+        /// <param name="items2">The items from value 2.</param>
+        /// <param name="items3">The items from value 3.</param>
+        /// <param name="items4">The items from value 4.</param>
+        /// <param name="items5">The items from value 5.</param>
+        /// <param name="items6">The items from value 6.</param>
+        /// <param name="items7">The items from value 7.</param>
+        public void Deconstruct(out IEnumerable<T1> items1, out IEnumerable<T2> items2, out IEnumerable<T3> items3, out IEnumerable<T4> items4, out IEnumerable<T5> items5, out IEnumerable<T6> items6, out IEnumerable<T7> items7)
+        {
+            items1 = this.Value1;
+            items2 = this.Value2;
+            items3 = this.Value3;
+            items4 = this.Value4;
+            items5 = this.Value5;
+            items6 = this.Value6;
+            items7 = this.Value7;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object> GetEnumerator()
+        {
+            if (this.HasValue1)
+            {
+                foreach (var item1 in this.Value1)
+                {
+                    yield return item1;
+                }
+            }
+
+            if (this.HasValue2)
+            {
+                foreach (var item2 in this.Value2)
+                {
+                    yield return item2;
+                }
+            }
+
+            if (this.HasValue3)
+            {
+                foreach (var item3 in this.Value3)
+                {
+                    yield return item3;
+                }
+            }
+
+            if (this.HasValue4)
+            {
+                foreach (var item4 in this.Value4)
+                {
+                    yield return item4;
+                }
+            }
+
+            if (this.HasValue5)
+            {
+                foreach (var item5 in this.Value5)
+                {
+                    yield return item5;
+                }
+            }
+
+            if (this.HasValue6)
+            {
+                foreach (var item6 in this.Value6)
+                {
+                    yield return item6;
+                }
+            }
+
+            if (this.HasValue7)
+            {
+                foreach (var item7 in this.Value7)
+                {
+                    yield return item7;
+                }
+            }
+        }
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <returns>An <see cref="IEnumerator"/> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(Values<T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            if (!other.HasValue && !this.HasValue)
+            {
+                return true;
+            }
+
+            return this.Value1.Equals(other.Value1) &&
+                this.Value2.Equals(other.Value2) &&
+                this.Value3.Equals(other.Value3) &&
+                this.Value4.Equals(other.Value4) &&
+                this.Value5.Equals(other.Value5) &&
+                this.Value6.Equals(other.Value6) &&
+                this.Value7.Equals(other.Value7);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="object" />, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="object" /> to compare with this instance.</param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj) => obj is Values<T1, T2, T3, T4, T5, T6, T7> ? this.Equals((Values<T1, T2, T3, T4, T5, T6, T7>)obj) : false;
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
+        public override int GetHashCode() =>
+            HashCode.Of(this.Value1).And(this.Value2).And(this.Value3).And(this.Value4).And(this.Value5).And(this.Value6).And(this.Value7);
+    }
+}

--- a/Source/Schema.NET/core/Accommodation.cs
+++ b/Source/Schema.NET/core/Accommodation.cs
@@ -45,6 +45,11 @@
         OneOrMany<int?> NumberOfFullBathrooms { get; set; }
 
         /// <summary>
+        /// Number of partial bathrooms - The total number of half and ¼ bathrooms in an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/BathroomsPartial+Field"&gt;BathroomsPartial field in RESO&lt;/a&gt;.
+        /// </summary>
+        OneOrMany<int?> NumberOfPartialBathrooms { get; set; }
+
+        /// <summary>
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
         /// Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.
         /// </summary>
@@ -59,6 +64,11 @@
         /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
         /// </summary>
         Values<bool?, string> PetsAllowed { get; set; }
+
+        /// <summary>
+        /// The year an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; was constructed. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/YearBuilt+Field"&gt;YearBuilt field in RESO&lt;/a&gt;.
+        /// </summary>
+        OneOrMany<int?> YearBuilt { get; set; }
     }
 
     /// <summary>
@@ -128,26 +138,40 @@
         public OneOrMany<int?> NumberOfFullBathrooms { get; set; }
 
         /// <summary>
+        /// Number of partial bathrooms - The total number of half and ¼ bathrooms in an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/BathroomsPartial+Field"&gt;BathroomsPartial field in RESO&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "numberOfPartialBathrooms", Order = 213)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<int?> NumberOfPartialBathrooms { get; set; }
+
+        /// <summary>
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
         /// Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.
         /// </summary>
-        [DataMember(Name = "numberOfRooms", Order = 213)]
+        [DataMember(Name = "numberOfRooms", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// Indications regarding the permitted usage of the accommodation.
         /// </summary>
-        [DataMember(Name = "permittedUsage", Order = 214)]
+        [DataMember(Name = "permittedUsage", Order = 215)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PermittedUsage { get; set; }
 
         /// <summary>
         /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
         /// </summary>
-        [DataMember(Name = "petsAllowed", Order = 215)]
+        [DataMember(Name = "petsAllowed", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<bool?, string> PetsAllowed { get; set; }
+
+        /// <summary>
+        /// The year an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; was constructed. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/YearBuilt+Field"&gt;YearBuilt field in RESO&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "yearBuilt", Order = 217)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<int?> YearBuilt { get; set; }
 
         /// <inheritdoc/>
         public bool Equals(Accommodation other)
@@ -170,9 +194,11 @@
                 this.LeaseLength == other.LeaseLength &&
                 this.NumberOfBathroomsTotal == other.NumberOfBathroomsTotal &&
                 this.NumberOfFullBathrooms == other.NumberOfFullBathrooms &&
+                this.NumberOfPartialBathrooms == other.NumberOfPartialBathrooms &&
                 this.NumberOfRooms == other.NumberOfRooms &&
                 this.PermittedUsage == other.PermittedUsage &&
                 this.PetsAllowed == other.PetsAllowed &&
+                this.YearBuilt == other.YearBuilt &&
                 base.Equals(other);
         }
 
@@ -188,9 +214,11 @@
             .And(this.LeaseLength)
             .And(this.NumberOfBathroomsTotal)
             .And(this.NumberOfFullBathrooms)
+            .And(this.NumberOfPartialBathrooms)
             .And(this.NumberOfRooms)
             .And(this.PermittedUsage)
             .And(this.PetsAllowed)
+            .And(this.YearBuilt)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/Accommodation.cs
+++ b/Source/Schema.NET/core/Accommodation.cs
@@ -40,6 +40,11 @@
         OneOrMany<int?> NumberOfBathroomsTotal { get; set; }
 
         /// <summary>
+        /// The total integer number of bedrooms in a some &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt;.
+        /// </summary>
+        Values<int?, IQuantitativeValue> NumberOfBedrooms { get; set; }
+
+        /// <summary>
         /// Number of full bathrooms - The total number of full and ¾ bathrooms in an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/BathroomsFull+Field"&gt;BathroomsFull field in RESO&lt;/a&gt;.
         /// </summary>
         OneOrMany<int?> NumberOfFullBathrooms { get; set; }
@@ -131,16 +136,23 @@
         public OneOrMany<int?> NumberOfBathroomsTotal { get; set; }
 
         /// <summary>
+        /// The total integer number of bedrooms in a some &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "numberOfBedrooms", Order = 212)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<int?, IQuantitativeValue> NumberOfBedrooms { get; set; }
+
+        /// <summary>
         /// Number of full bathrooms - The total number of full and ¾ bathrooms in an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/BathroomsFull+Field"&gt;BathroomsFull field in RESO&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "numberOfFullBathrooms", Order = 212)]
+        [DataMember(Name = "numberOfFullBathrooms", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> NumberOfFullBathrooms { get; set; }
 
         /// <summary>
         /// Number of partial bathrooms - The total number of half and ¼ bathrooms in an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/BathroomsPartial+Field"&gt;BathroomsPartial field in RESO&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "numberOfPartialBathrooms", Order = 213)]
+        [DataMember(Name = "numberOfPartialBathrooms", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> NumberOfPartialBathrooms { get; set; }
 
@@ -148,28 +160,35 @@
         /// The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
         /// Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.
         /// </summary>
-        [DataMember(Name = "numberOfRooms", Order = 214)]
+        [DataMember(Name = "numberOfRooms", Order = 215)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<int?, IQuantitativeValue> NumberOfRooms { get; set; }
 
         /// <summary>
         /// Indications regarding the permitted usage of the accommodation.
         /// </summary>
-        [DataMember(Name = "permittedUsage", Order = 215)]
+        [DataMember(Name = "permittedUsage", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PermittedUsage { get; set; }
 
         /// <summary>
         /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
         /// </summary>
-        [DataMember(Name = "petsAllowed", Order = 216)]
+        [DataMember(Name = "petsAllowed", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<bool?, string> PetsAllowed { get; set; }
 
         /// <summary>
+        /// A page providing information on how to book a tour of some &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt;, such as an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; in a real estate setting, as well as other kinds of tours as appropriate.
+        /// </summary>
+        [DataMember(Name = "tourBookingPage", Order = 218)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<Uri> TourBookingPage { get; set; }
+
+        /// <summary>
         /// The year an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; was constructed. This corresponds to the &lt;a href="https://ddwiki.reso.org/display/DDW17/YearBuilt+Field"&gt;YearBuilt field in RESO&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "yearBuilt", Order = 217)]
+        [DataMember(Name = "yearBuilt", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> YearBuilt { get; set; }
 
@@ -193,11 +212,13 @@
                 this.FloorSize == other.FloorSize &&
                 this.LeaseLength == other.LeaseLength &&
                 this.NumberOfBathroomsTotal == other.NumberOfBathroomsTotal &&
+                this.NumberOfBedrooms == other.NumberOfBedrooms &&
                 this.NumberOfFullBathrooms == other.NumberOfFullBathrooms &&
                 this.NumberOfPartialBathrooms == other.NumberOfPartialBathrooms &&
                 this.NumberOfRooms == other.NumberOfRooms &&
                 this.PermittedUsage == other.PermittedUsage &&
                 this.PetsAllowed == other.PetsAllowed &&
+                this.TourBookingPage == other.TourBookingPage &&
                 this.YearBuilt == other.YearBuilt &&
                 base.Equals(other);
         }
@@ -213,11 +234,13 @@
             .And(this.FloorSize)
             .And(this.LeaseLength)
             .And(this.NumberOfBathroomsTotal)
+            .And(this.NumberOfBedrooms)
             .And(this.NumberOfFullBathrooms)
             .And(this.NumberOfPartialBathrooms)
             .And(this.NumberOfRooms)
             .And(this.PermittedUsage)
             .And(this.PetsAllowed)
+            .And(this.TourBookingPage)
             .And(this.YearBuilt)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/AggregateOffer.cs
+++ b/Source/Schema.NET/core/AggregateOffer.cs
@@ -5,7 +5,8 @@
     using Newtonsoft.Json;
 
     /// <summary>
-    /// When a single product is associated with multiple offers (for example, the same pair of shoes is offered by different merchants), then AggregateOffer can be used.
+    /// When a single product is associated with multiple offers (for example, the same pair of shoes is offered by different merchants), then AggregateOffer can be used.&lt;br/&gt;&lt;br/&gt;
+    /// Note: AggregateOffers are normally expected to associate multiple offers that all share the same defined &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; value, or default to http://purl.org/goodrelations/v1#Sell if businessFunction is not explicitly defined.
     /// </summary>
     public partial interface IAggregateOffer : IOffer
     {
@@ -35,13 +36,14 @@
         OneOrMany<int?> OfferCount { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        OneOrMany<IOffer> Offers { get; set; }
+        Values<IDemand, IOffer> Offers { get; set; }
     }
 
     /// <summary>
-    /// When a single product is associated with multiple offers (for example, the same pair of shoes is offered by different merchants), then AggregateOffer can be used.
+    /// When a single product is associated with multiple offers (for example, the same pair of shoes is offered by different merchants), then AggregateOffer can be used.&lt;br/&gt;&lt;br/&gt;
+    /// Note: AggregateOffers are normally expected to associate multiple offers that all share the same defined &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; value, or default to http://purl.org/goodrelations/v1#Sell if businessFunction is not explicitly defined.
     /// </summary>
     [DataContract]
     public partial class AggregateOffer : Offer, IAggregateOffer, IEquatable<AggregateOffer>
@@ -84,11 +86,11 @@
         public OneOrMany<int?> OfferCount { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "offers", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <inheritdoc/>
         public bool Equals(AggregateOffer other)

--- a/Source/Schema.NET/core/AllocateAction.cs
+++ b/Source/Schema.NET/core/AllocateAction.cs
@@ -9,10 +9,6 @@
     /// </summary>
     public partial interface IAllocateAction : IOrganizeAction
     {
-        /// <summary>
-        /// A goal towards an action is taken. Can be concrete or abstract.
-        /// </summary>
-        Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
     }
 
     /// <summary>
@@ -26,13 +22,6 @@
         /// </summary>
         [DataMember(Name = "@type", Order = 1)]
         public override string Type => "AllocateAction";
-
-        /// <summary>
-        /// A goal towards an action is taken. Can be concrete or abstract.
-        /// </summary>
-        [DataMember(Name = "purpose", Order = 306)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
 
         /// <inheritdoc/>
         public bool Equals(AllocateAction other)
@@ -48,7 +37,6 @@
             }
 
             return this.Type == other.Type &&
-                this.Purpose == other.Purpose &&
                 base.Equals(other);
         }
 
@@ -57,7 +45,6 @@
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
-            .And(this.Purpose)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/AnatomicalStructure.cs
+++ b/Source/Schema.NET/core/AnatomicalStructure.cs
@@ -30,11 +30,6 @@
         OneOrMany<IImageObject> Diagram { get; set; }
 
         /// <summary>
-        /// Function of the anatomical structure.
-        /// </summary>
-        OneOrMany<string> Function { get; set; }
-
-        /// <summary>
         /// The anatomical or organ system that this structure is part of.
         /// </summary>
         OneOrMany<IAnatomicalSystem> PartOfSystem { get; set; }
@@ -96,37 +91,30 @@
         public OneOrMany<IImageObject> Diagram { get; set; }
 
         /// <summary>
-        /// Function of the anatomical structure.
-        /// </summary>
-        [DataMember(Name = "function", Order = 210)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> Function { get; set; }
-
-        /// <summary>
         /// The anatomical or organ system that this structure is part of.
         /// </summary>
-        [DataMember(Name = "partOfSystem", Order = 211)]
+        [DataMember(Name = "partOfSystem", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAnatomicalSystem> PartOfSystem { get; set; }
 
         /// <summary>
         /// A medical condition associated with this anatomy.
         /// </summary>
-        [DataMember(Name = "relatedCondition", Order = 212)]
+        [DataMember(Name = "relatedCondition", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalCondition> RelatedCondition { get; set; }
 
         /// <summary>
         /// A medical therapy related to this anatomy.
         /// </summary>
-        [DataMember(Name = "relatedTherapy", Order = 213)]
+        [DataMember(Name = "relatedTherapy", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalTherapy> RelatedTherapy { get; set; }
 
         /// <summary>
         /// Component (sub-)structure(s) that comprise this anatomical structure.
         /// </summary>
-        [DataMember(Name = "subStructure", Order = 214)]
+        [DataMember(Name = "subStructure", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAnatomicalStructure> SubStructure { get; set; }
 
@@ -148,7 +136,6 @@
                 this.BodyLocation == other.BodyLocation &&
                 this.ConnectedTo == other.ConnectedTo &&
                 this.Diagram == other.Diagram &&
-                this.Function == other.Function &&
                 this.PartOfSystem == other.PartOfSystem &&
                 this.RelatedCondition == other.RelatedCondition &&
                 this.RelatedTherapy == other.RelatedTherapy &&
@@ -165,7 +152,6 @@
             .And(this.BodyLocation)
             .And(this.ConnectedTo)
             .And(this.Diagram)
-            .And(this.Function)
             .And(this.PartOfSystem)
             .And(this.RelatedCondition)
             .And(this.RelatedTherapy)

--- a/Source/Schema.NET/core/ApartmentComplex.cs
+++ b/Source/Schema.NET/core/ApartmentComplex.cs
@@ -9,6 +9,15 @@
     /// </summary>
     public partial interface IApartmentComplex : IResidence
     {
+        /// <summary>
+        /// Indicates the total (available plus unavailable) number of accommodation units in an &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;, or the number of accommodation units for a specific &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt; (within its specific &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;). See also &lt;a class="localLink" href="http://schema.org/numberOfAvailableAccommodationUnits"&gt;numberOfAvailableAccommodationUnits&lt;/a&gt;.
+        /// </summary>
+        OneOrMany<IQuantitativeValue> NumberOfAccommodationUnits { get; set; }
+
+        /// <summary>
+        /// Indicates the number of available accommodation units in an &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;, or the number of accommodation units for a specific &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt; (within its specific &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;). See also &lt;a class="localLink" href="http://schema.org/numberOfAccommodationUnits"&gt;numberOfAccommodationUnits&lt;/a&gt;.
+        /// </summary>
+        OneOrMany<IQuantitativeValue> NumberOfAvailableAccommodationUnits { get; set; }
     }
 
     /// <summary>
@@ -22,6 +31,20 @@
         /// </summary>
         [DataMember(Name = "@type", Order = 1)]
         public override string Type => "ApartmentComplex";
+
+        /// <summary>
+        /// Indicates the total (available plus unavailable) number of accommodation units in an &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;, or the number of accommodation units for a specific &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt; (within its specific &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;). See also &lt;a class="localLink" href="http://schema.org/numberOfAvailableAccommodationUnits"&gt;numberOfAvailableAccommodationUnits&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "numberOfAccommodationUnits", Order = 306)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<IQuantitativeValue> NumberOfAccommodationUnits { get; set; }
+
+        /// <summary>
+        /// Indicates the number of available accommodation units in an &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;, or the number of accommodation units for a specific &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt; (within its specific &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;). See also &lt;a class="localLink" href="http://schema.org/numberOfAccommodationUnits"&gt;numberOfAccommodationUnits&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "numberOfAvailableAccommodationUnits", Order = 307)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<IQuantitativeValue> NumberOfAvailableAccommodationUnits { get; set; }
 
         /// <inheritdoc/>
         public bool Equals(ApartmentComplex other)
@@ -37,6 +60,8 @@
             }
 
             return this.Type == other.Type &&
+                this.NumberOfAccommodationUnits == other.NumberOfAccommodationUnits &&
+                this.NumberOfAvailableAccommodationUnits == other.NumberOfAvailableAccommodationUnits &&
                 base.Equals(other);
         }
 
@@ -45,6 +70,8 @@
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
+            .And(this.NumberOfAccommodationUnits)
+            .And(this.NumberOfAvailableAccommodationUnits)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/ApartmentComplex.cs
+++ b/Source/Schema.NET/core/ApartmentComplex.cs
@@ -18,6 +18,16 @@
         /// Indicates the number of available accommodation units in an &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;, or the number of accommodation units for a specific &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt; (within its specific &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt;). See also &lt;a class="localLink" href="http://schema.org/numberOfAccommodationUnits"&gt;numberOfAccommodationUnits&lt;/a&gt;.
         /// </summary>
         OneOrMany<IQuantitativeValue> NumberOfAvailableAccommodationUnits { get; set; }
+
+        /// <summary>
+        /// The total integer number of bedrooms in a some &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt;.
+        /// </summary>
+        Values<int?, IQuantitativeValue> NumberOfBedrooms { get; set; }
+
+        /// <summary>
+        /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
+        /// </summary>
+        Values<bool?, string> PetsAllowed { get; set; }
     }
 
     /// <summary>
@@ -46,6 +56,27 @@
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IQuantitativeValue> NumberOfAvailableAccommodationUnits { get; set; }
 
+        /// <summary>
+        /// The total integer number of bedrooms in a some &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/FloorPlan"&gt;FloorPlan&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "numberOfBedrooms", Order = 308)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<int?, IQuantitativeValue> NumberOfBedrooms { get; set; }
+
+        /// <summary>
+        /// Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value.
+        /// </summary>
+        [DataMember(Name = "petsAllowed", Order = 309)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<bool?, string> PetsAllowed { get; set; }
+
+        /// <summary>
+        /// A page providing information on how to book a tour of some &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt;, such as an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; in a real estate setting, as well as other kinds of tours as appropriate.
+        /// </summary>
+        [DataMember(Name = "tourBookingPage", Order = 310)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<Uri> TourBookingPage { get; set; }
+
         /// <inheritdoc/>
         public bool Equals(ApartmentComplex other)
         {
@@ -62,6 +93,9 @@
             return this.Type == other.Type &&
                 this.NumberOfAccommodationUnits == other.NumberOfAccommodationUnits &&
                 this.NumberOfAvailableAccommodationUnits == other.NumberOfAvailableAccommodationUnits &&
+                this.NumberOfBedrooms == other.NumberOfBedrooms &&
+                this.PetsAllowed == other.PetsAllowed &&
+                this.TourBookingPage == other.TourBookingPage &&
                 base.Equals(other);
         }
 
@@ -72,6 +106,9 @@
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.NumberOfAccommodationUnits)
             .And(this.NumberOfAvailableAccommodationUnits)
+            .And(this.NumberOfBedrooms)
+            .And(this.PetsAllowed)
+            .And(this.TourBookingPage)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/Artery.cs
+++ b/Source/Schema.NET/core/Artery.cs
@@ -15,11 +15,6 @@
         OneOrMany<IAnatomicalStructure> ArterialBranch { get; set; }
 
         /// <summary>
-        /// The anatomical or organ system that the artery originates from.
-        /// </summary>
-        OneOrMany<IAnatomicalStructure> Source { get; set; }
-
-        /// <summary>
         /// The area to which the artery supplies blood.
         /// </summary>
         OneOrMany<IAnatomicalStructure> SupplyTo { get; set; }
@@ -45,16 +40,9 @@
         public OneOrMany<IAnatomicalStructure> ArterialBranch { get; set; }
 
         /// <summary>
-        /// The anatomical or organ system that the artery originates from.
-        /// </summary>
-        [DataMember(Name = "source", Order = 407)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IAnatomicalStructure> Source { get; set; }
-
-        /// <summary>
         /// The area to which the artery supplies blood.
         /// </summary>
-        [DataMember(Name = "supplyTo", Order = 408)]
+        [DataMember(Name = "supplyTo", Order = 407)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAnatomicalStructure> SupplyTo { get; set; }
 
@@ -73,7 +61,6 @@
 
             return this.Type == other.Type &&
                 this.ArterialBranch == other.ArterialBranch &&
-                this.Source == other.Source &&
                 this.SupplyTo == other.SupplyTo &&
                 base.Equals(other);
         }
@@ -84,7 +71,6 @@
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.ArterialBranch)
-            .And(this.Source)
             .And(this.SupplyTo)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/BroadcastService.cs
+++ b/Source/Schema.NET/core/BroadcastService.cs
@@ -45,6 +45,11 @@
         OneOrMany<IBroadcastChannel> HasBroadcastChannel { get; set; }
 
         /// <summary>
+        /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
+        /// </summary>
+        Values<ILanguage, string> InLanguage { get; set; }
+
+        /// <summary>
         /// A broadcast service to which the broadcast service may belong to such as regional variations of a national channel.
         /// </summary>
         OneOrMany<IBroadcastService> ParentService { get; set; }
@@ -117,16 +122,23 @@
         public OneOrMany<IBroadcastChannel> HasBroadcastChannel { get; set; }
 
         /// <summary>
+        /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
+        /// </summary>
+        [DataMember(Name = "inLanguage", Order = 313)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ILanguage, string> InLanguage { get; set; }
+
+        /// <summary>
         /// A broadcast service to which the broadcast service may belong to such as regional variations of a national channel.
         /// </summary>
-        [DataMember(Name = "parentService", Order = 313)]
+        [DataMember(Name = "parentService", Order = 314)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IBroadcastService> ParentService { get; set; }
 
         /// <summary>
         /// The type of screening or video broadcast used (e.g. IMAX, 3D, SD, HD, etc.).
         /// </summary>
-        [DataMember(Name = "videoFormat", Order = 314)]
+        [DataMember(Name = "videoFormat", Order = 315)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> VideoFormat { get; set; }
 
@@ -151,6 +163,7 @@
                 this.BroadcastTimezone == other.BroadcastTimezone &&
                 this.CallSign == other.CallSign &&
                 this.HasBroadcastChannel == other.HasBroadcastChannel &&
+                this.InLanguage == other.InLanguage &&
                 this.ParentService == other.ParentService &&
                 this.VideoFormat == other.VideoFormat &&
                 base.Equals(other);
@@ -168,6 +181,7 @@
             .And(this.BroadcastTimezone)
             .And(this.CallSign)
             .And(this.HasBroadcastChannel)
+            .And(this.InLanguage)
             .And(this.ParentService)
             .And(this.VideoFormat)
             .And(base.GetHashCode());

--- a/Source/Schema.NET/core/Course.cs
+++ b/Source/Schema.NET/core/Course.cs
@@ -30,6 +30,11 @@
         OneOrMany<ICourseInstance> HasCourseInstance { get; set; }
 
         /// <summary>
+        /// The number of credits or units awarded by a Course or required to complete an EducationalOccupationalProgram.
+        /// </summary>
+        Values<int?, IStructuredValue> NumberOfCredits { get; set; }
+
+        /// <summary>
         /// A description of the qualification, award, certificate, diploma or other occupational credential awarded as a consequence of successful completion of this course or program.
         /// </summary>
         Values<string, Uri> OccupationalCredentialAwarded { get; set; }
@@ -76,9 +81,16 @@
         public OneOrMany<ICourseInstance> HasCourseInstance { get; set; }
 
         /// <summary>
+        /// The number of credits or units awarded by a Course or required to complete an EducationalOccupationalProgram.
+        /// </summary>
+        [DataMember(Name = "numberOfCredits", Order = 210)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<int?, IStructuredValue> NumberOfCredits { get; set; }
+
+        /// <summary>
         /// A description of the qualification, award, certificate, diploma or other occupational credential awarded as a consequence of successful completion of this course or program.
         /// </summary>
-        [DataMember(Name = "occupationalCredentialAwarded", Order = 210)]
+        [DataMember(Name = "occupationalCredentialAwarded", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> OccupationalCredentialAwarded { get; set; }
 
@@ -100,6 +112,7 @@
                 this.CoursePrerequisites == other.CoursePrerequisites &&
                 this.EducationalCredentialAwarded == other.EducationalCredentialAwarded &&
                 this.HasCourseInstance == other.HasCourseInstance &&
+                this.NumberOfCredits == other.NumberOfCredits &&
                 this.OccupationalCredentialAwarded == other.OccupationalCredentialAwarded &&
                 base.Equals(other);
         }
@@ -113,6 +126,7 @@
             .And(this.CoursePrerequisites)
             .And(this.EducationalCredentialAwarded)
             .And(this.HasCourseInstance)
+            .And(this.NumberOfCredits)
             .And(this.OccupationalCredentialAwarded)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/CreativeWork.cs
+++ b/Source/Schema.NET/core/CreativeWork.cs
@@ -82,7 +82,7 @@
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        Values<IAudioObject, IClip> Audio { get; set; }
+        Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
@@ -178,7 +178,7 @@
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        Values<int?, DateTime?> DatePublished { get; set; }
+        Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -275,7 +275,7 @@
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        OneOrMany<ICreativeWork> IsPartOf { get; set; }
+        Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
@@ -303,6 +303,11 @@
         OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
+        /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+        /// </summary>
+        Values<IOrganization, IPerson> Maintainer { get; set; }
+
+        /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
         Values<IProduct, string, Uri> Material { get; set; }
@@ -318,9 +323,9 @@
         OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        OneOrMany<IOffer> Offers { get; set; }
+        Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
@@ -597,7 +602,7 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 120)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip> Audio { get; set; }
+        public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
@@ -731,7 +736,7 @@
         /// </summary>
         [DataMember(Name = "datePublished", Order = 139)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?> DatePublished { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -866,7 +871,7 @@
         /// </summary>
         [DataMember(Name = "isPartOf", Order = 158)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<ICreativeWork> IsPartOf { get; set; }
+        public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
@@ -904,72 +909,79 @@
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
+        /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+        /// </summary>
+        [DataMember(Name = "maintainer", Order = 164)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<IOrganization, IPerson> Maintainer { get; set; }
+
+        /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 164)]
+        [DataMember(Name = "material", Order = 165)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 165)]
+        [DataMember(Name = "materialExtent", Order = 166)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 166)]
+        [DataMember(Name = "mentions", Order = 167)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 167)]
+        [DataMember(Name = "offers", Order = 168)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 168)]
+        [DataMember(Name = "position", Order = 169)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 169)]
+        [DataMember(Name = "producer", Order = 170)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 170)]
+        [DataMember(Name = "provider", Order = 171)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 171)]
+        [DataMember(Name = "publication", Order = 172)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 172)]
+        [DataMember(Name = "publisher", Order = 173)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 173)]
+        [DataMember(Name = "publisherImprint", Order = 174)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -977,49 +989,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 174)]
+        [DataMember(Name = "publishingPrinciples", Order = 175)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 175)]
+        [DataMember(Name = "recordedAt", Order = 176)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 176)]
+        [DataMember(Name = "releasedEvent", Order = 177)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 177)]
+        [DataMember(Name = "review", Order = 178)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 178)]
+        [DataMember(Name = "schemaVersion", Order = 179)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 179)]
+        [DataMember(Name = "sdDatePublished", Order = 180)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 180)]
+        [DataMember(Name = "sdLicense", Order = 181)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -1027,14 +1039,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 181)]
+        [DataMember(Name = "sdPublisher", Order = 182)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 182)]
+        [DataMember(Name = "sourceOrganization", Order = 183)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -1042,7 +1054,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 183)]
+        [DataMember(Name = "spatial", Order = 184)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -1051,14 +1063,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 184)]
+        [DataMember(Name = "spatialCoverage", Order = 185)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 185)]
+        [DataMember(Name = "sponsor", Order = 186)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -1066,7 +1078,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 186)]
+        [DataMember(Name = "temporal", Order = 187)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -1076,77 +1088,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 187)]
+        [DataMember(Name = "temporalCoverage", Order = 188)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 188)]
+        [DataMember(Name = "text", Order = 189)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 189)]
+        [DataMember(Name = "thumbnailUrl", Order = 190)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 190)]
+        [DataMember(Name = "timeRequired", Order = 191)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 191)]
+        [DataMember(Name = "translationOfWork", Order = 192)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 192)]
+        [DataMember(Name = "translator", Order = 193)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 193)]
+        [DataMember(Name = "typicalAgeRange", Order = 194)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 194)]
+        [DataMember(Name = "version", Order = 195)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 195)]
+        [DataMember(Name = "video", Order = 196)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 196)]
+        [DataMember(Name = "workExample", Order = 197)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 197)]
+        [DataMember(Name = "workTranslation", Order = 198)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -1222,6 +1234,7 @@
                 this.License == other.License &&
                 this.LocationCreated == other.LocationCreated &&
                 this.MainEntity == other.MainEntity &&
+                this.Maintainer == other.Maintainer &&
                 this.Material == other.Material &&
                 this.MaterialExtent == other.MaterialExtent &&
                 this.Mentions == other.Mentions &&
@@ -1322,6 +1335,7 @@
             .And(this.License)
             .And(this.LocationCreated)
             .And(this.MainEntity)
+            .And(this.Maintainer)
             .And(this.Material)
             .And(this.MaterialExtent)
             .And(this.Mentions)

--- a/Source/Schema.NET/core/CreativeWork.cs
+++ b/Source/Schema.NET/core/CreativeWork.cs
@@ -60,6 +60,11 @@
         OneOrMany<IPerson> AccountablePerson { get; set; }
 
         /// <summary>
+        /// Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item.
+        /// </summary>
+        Values<ICreativeWork, Uri> AcquireLicensePage { get; set; }
+
+        /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
         /// </summary>
         OneOrMany<IAggregateRating> AggregateRating { get; set; }
@@ -184,6 +189,13 @@
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
         OneOrMany<Uri> DiscussionUrl { get; set; }
+
+        /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing a specific edit / edition for a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" whose &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        Values<string, Uri> EditEIDR { get; set; }
 
         /// <summary>
         /// Specifies the Person who edited the CreativeWork.
@@ -467,6 +479,12 @@
         OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
+        /// The schema.org &lt;a class="localLink" href="http://schema.org/usageInfo"&gt;usageInfo&lt;/a&gt; property indicates further information about a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.&lt;br/&gt;&lt;br/&gt;
+        /// This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+        /// </summary>
+        Values<ICreativeWork, Uri> UsageInfo { get; set; }
+
+        /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
         Values<double?, string> Version { get; set; }
@@ -570,79 +588,86 @@
         public OneOrMany<IPerson> AccountablePerson { get; set; }
 
         /// <summary>
+        /// Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item.
+        /// </summary>
+        [DataMember(Name = "acquireLicensePage", Order = 116)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> AcquireLicensePage { get; set; }
+
+        /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
         /// </summary>
-        [DataMember(Name = "aggregateRating", Order = 116)]
+        [DataMember(Name = "aggregateRating", Order = 117)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAggregateRating> AggregateRating { get; set; }
 
         /// <summary>
         /// A secondary title of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "alternativeHeadline", Order = 117)]
+        [DataMember(Name = "alternativeHeadline", Order = 118)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> AlternativeHeadline { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for encoding.
         /// </summary>
-        [DataMember(Name = "associatedMedia", Order = 118)]
+        [DataMember(Name = "associatedMedia", Order = 119)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> AssociatedMedia { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
         /// </summary>
-        [DataMember(Name = "audience", Order = 119)]
+        [DataMember(Name = "audience", Order = 120)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAudience> Audience { get; set; }
 
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        [DataMember(Name = "audio", Order = 120)]
+        [DataMember(Name = "audio", Order = 121)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        [DataMember(Name = "author", Order = 121)]
+        [DataMember(Name = "author", Order = 122)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
         /// </summary>
-        [DataMember(Name = "award", Order = 122)]
+        [DataMember(Name = "award", Order = 123)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Award { get; set; }
 
         /// <summary>
         /// Fictional person connected with a creative work.
         /// </summary>
-        [DataMember(Name = "character", Order = 123)]
+        [DataMember(Name = "character", Order = 124)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Character { get; set; }
 
         /// <summary>
         /// A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
         /// </summary>
-        [DataMember(Name = "citation", Order = 124)]
+        [DataMember(Name = "citation", Order = 125)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
         /// </summary>
-        [DataMember(Name = "comment", Order = 125)]
+        [DataMember(Name = "comment", Order = 126)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IComment> Comment { get; set; }
 
         /// <summary>
         /// The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
         /// </summary>
-        [DataMember(Name = "commentCount", Order = 126)]
+        [DataMember(Name = "commentCount", Order = 127)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CommentCount { get; set; }
 
@@ -650,126 +675,135 @@
         /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
         /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
         /// </summary>
-        [DataMember(Name = "conditionsOfAccess", Order = 127)]
+        [DataMember(Name = "conditionsOfAccess", Order = 128)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ConditionsOfAccess { get; set; }
 
         /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 128)]
+        [DataMember(Name = "contentLocation", Order = 129)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 129)]
+        [DataMember(Name = "contentRating", Order = 130)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 130)]
+        [DataMember(Name = "contentReferenceTime", Order = 131)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 131)]
+        [DataMember(Name = "contributor", Order = 132)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 132)]
+        [DataMember(Name = "copyrightHolder", Order = 133)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 133)]
+        [DataMember(Name = "copyrightYear", Order = 134)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 134)]
+        [DataMember(Name = "correction", Order = 135)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Correction { get; set; }
 
         /// <summary>
         /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
         /// </summary>
-        [DataMember(Name = "creativeWorkStatus", Order = 135)]
+        [DataMember(Name = "creativeWorkStatus", Order = 136)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 136)]
+        [DataMember(Name = "creator", Order = 137)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 137)]
+        [DataMember(Name = "dateCreated", Order = 138)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 138)]
+        [DataMember(Name = "dateModified", Order = 139)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 139)]
+        [DataMember(Name = "datePublished", Order = 140)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 140)]
+        [DataMember(Name = "discussionUrl", Order = 141)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing a specific edit / edition for a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" whose &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "editEIDR", Order = 142)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> EditEIDR { get; set; }
+
+        /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 141)]
+        [DataMember(Name = "editor", Order = 143)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 142)]
+        [DataMember(Name = "educationalAlignment", Order = 144)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 143)]
+        [DataMember(Name = "educationalUse", Order = 145)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 144)]
+        [DataMember(Name = "encoding", Order = 146)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -778,210 +812,210 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 145)]
+        [DataMember(Name = "encodingFormat", Order = 147)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 146)]
+        [DataMember(Name = "exampleOfWork", Order = 148)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 147)]
+        [DataMember(Name = "expires", Order = 149)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 148)]
+        [DataMember(Name = "funder", Order = 150)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 149)]
+        [DataMember(Name = "genre", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 150)]
+        [DataMember(Name = "hasPart", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 151)]
+        [DataMember(Name = "headline", Order = 153)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 152)]
+        [DataMember(Name = "inLanguage", Order = 154)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 153)]
+        [DataMember(Name = "interactionStatistic", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 154)]
+        [DataMember(Name = "interactivityType", Order = 156)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 155)]
+        [DataMember(Name = "isAccessibleForFree", Order = 157)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 156)]
+        [DataMember(Name = "isBasedOn", Order = 158)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 157)]
+        [DataMember(Name = "isFamilyFriendly", Order = 159)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 158)]
+        [DataMember(Name = "isPartOf", Order = 160)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 159)]
+        [DataMember(Name = "keywords", Order = 161)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 160)]
+        [DataMember(Name = "learningResourceType", Order = 162)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 161)]
+        [DataMember(Name = "license", Order = 163)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 162)]
+        [DataMember(Name = "locationCreated", Order = 164)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 163)]
+        [DataMember(Name = "mainEntity", Order = 165)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
         /// </summary>
-        [DataMember(Name = "maintainer", Order = 164)]
+        [DataMember(Name = "maintainer", Order = 166)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Maintainer { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 165)]
+        [DataMember(Name = "material", Order = 167)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 166)]
+        [DataMember(Name = "materialExtent", Order = 168)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 167)]
+        [DataMember(Name = "mentions", Order = 169)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 168)]
+        [DataMember(Name = "offers", Order = 170)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 169)]
+        [DataMember(Name = "position", Order = 171)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 170)]
+        [DataMember(Name = "producer", Order = 172)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 171)]
+        [DataMember(Name = "provider", Order = 173)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 172)]
+        [DataMember(Name = "publication", Order = 174)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 173)]
+        [DataMember(Name = "publisher", Order = 175)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 174)]
+        [DataMember(Name = "publisherImprint", Order = 176)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -989,49 +1023,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 175)]
+        [DataMember(Name = "publishingPrinciples", Order = 177)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 176)]
+        [DataMember(Name = "recordedAt", Order = 178)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 177)]
+        [DataMember(Name = "releasedEvent", Order = 179)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 178)]
+        [DataMember(Name = "review", Order = 180)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 179)]
+        [DataMember(Name = "schemaVersion", Order = 181)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 180)]
+        [DataMember(Name = "sdDatePublished", Order = 182)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 181)]
+        [DataMember(Name = "sdLicense", Order = 183)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -1039,14 +1073,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 182)]
+        [DataMember(Name = "sdPublisher", Order = 184)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 183)]
+        [DataMember(Name = "sourceOrganization", Order = 185)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -1054,7 +1088,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 184)]
+        [DataMember(Name = "spatial", Order = 186)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -1063,14 +1097,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 185)]
+        [DataMember(Name = "spatialCoverage", Order = 187)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 186)]
+        [DataMember(Name = "sponsor", Order = 188)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -1078,7 +1112,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 187)]
+        [DataMember(Name = "temporal", Order = 189)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -1088,77 +1122,85 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 188)]
+        [DataMember(Name = "temporalCoverage", Order = 190)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 189)]
+        [DataMember(Name = "text", Order = 191)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 190)]
+        [DataMember(Name = "thumbnailUrl", Order = 192)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 191)]
+        [DataMember(Name = "timeRequired", Order = 193)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 192)]
+        [DataMember(Name = "translationOfWork", Order = 194)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 193)]
+        [DataMember(Name = "translator", Order = 195)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 194)]
+        [DataMember(Name = "typicalAgeRange", Order = 196)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
+        /// The schema.org &lt;a class="localLink" href="http://schema.org/usageInfo"&gt;usageInfo&lt;/a&gt; property indicates further information about a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.&lt;br/&gt;&lt;br/&gt;
+        /// This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+        /// </summary>
+        [DataMember(Name = "usageInfo", Order = 197)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> UsageInfo { get; set; }
+
+        /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 195)]
+        [DataMember(Name = "version", Order = 198)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 196)]
+        [DataMember(Name = "video", Order = 199)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 197)]
+        [DataMember(Name = "workExample", Order = 200)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 198)]
+        [DataMember(Name = "workTranslation", Order = 201)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -1186,6 +1228,7 @@
                 this.AccessMode == other.AccessMode &&
                 this.AccessModeSufficient == other.AccessModeSufficient &&
                 this.AccountablePerson == other.AccountablePerson &&
+                this.AcquireLicensePage == other.AcquireLicensePage &&
                 this.AggregateRating == other.AggregateRating &&
                 this.AlternativeHeadline == other.AlternativeHeadline &&
                 this.AssociatedMedia == other.AssociatedMedia &&
@@ -1211,6 +1254,7 @@
                 this.DateModified == other.DateModified &&
                 this.DatePublished == other.DatePublished &&
                 this.DiscussionUrl == other.DiscussionUrl &&
+                this.EditEIDR == other.EditEIDR &&
                 this.Editor == other.Editor &&
                 this.EducationalAlignment == other.EducationalAlignment &&
                 this.EducationalUse == other.EducationalUse &&
@@ -1265,6 +1309,7 @@
                 this.TranslationOfWork == other.TranslationOfWork &&
                 this.Translator == other.Translator &&
                 this.TypicalAgeRange == other.TypicalAgeRange &&
+                this.UsageInfo == other.UsageInfo &&
                 this.Version == other.Version &&
                 this.Video == other.Video &&
                 this.WorkExample == other.WorkExample &&
@@ -1287,6 +1332,7 @@
             .And(this.AccessMode)
             .And(this.AccessModeSufficient)
             .And(this.AccountablePerson)
+            .And(this.AcquireLicensePage)
             .And(this.AggregateRating)
             .And(this.AlternativeHeadline)
             .And(this.AssociatedMedia)
@@ -1312,6 +1358,7 @@
             .And(this.DateModified)
             .And(this.DatePublished)
             .And(this.DiscussionUrl)
+            .And(this.EditEIDR)
             .And(this.Editor)
             .And(this.EducationalAlignment)
             .And(this.EducationalUse)
@@ -1366,6 +1413,7 @@
             .And(this.TranslationOfWork)
             .And(this.Translator)
             .And(this.TypicalAgeRange)
+            .And(this.UsageInfo)
             .And(this.Version)
             .And(this.Video)
             .And(this.WorkExample)

--- a/Source/Schema.NET/core/Demand.cs
+++ b/Source/Schema.NET/core/Demand.cs
@@ -132,9 +132,9 @@
         OneOrMany<OfferItemCondition?> ItemCondition { get; set; }
 
         /// <summary>
-        /// The item being offered.
+        /// An item being offered (or demanded). The transactional nature of the offer or demand is documented using &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt;, e.g. sell, lease etc. While several common expected types are listed explicitly in this definition, others can be used. Using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        Values<IProduct, IService> ItemOffered { get; set; }
+        Values<IAggregateOffer, ICreativeWork, IEvent, IMenuItem, IProduct, IService, ITrip> ItemOffered { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
@@ -360,11 +360,11 @@
         public OneOrMany<OfferItemCondition?> ItemCondition { get; set; }
 
         /// <summary>
-        /// The item being offered.
+        /// An item being offered (or demanded). The transactional nature of the offer or demand is documented using &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt;, e.g. sell, lease etc. While several common expected types are listed explicitly in this definition, others can be used. Using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "itemOffered", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService> ItemOffered { get; set; }
+        public Values<IAggregateOffer, ICreativeWork, IEvent, IMenuItem, IProduct, IService, ITrip> ItemOffered { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.

--- a/Source/Schema.NET/core/Diet.cs
+++ b/Source/Schema.NET/core/Diet.cs
@@ -25,11 +25,6 @@
         OneOrMany<string> ExpertConsiderations { get; set; }
 
         /// <summary>
-        /// Descriptive information establishing the overarching theory/philosophy of the plan. May include the rationale for the name, the population where the plan first came to prominence, etc.
-        /// </summary>
-        OneOrMany<string> Overview { get; set; }
-
-        /// <summary>
         /// Specific physiologic benefits associated to the plan.
         /// </summary>
         OneOrMany<string> PhysiologicalBenefits { get; set; }
@@ -74,23 +69,16 @@
         public OneOrMany<string> ExpertConsiderations { get; set; }
 
         /// <summary>
-        /// Descriptive information establishing the overarching theory/philosophy of the plan. May include the rationale for the name, the population where the plan first came to prominence, etc.
-        /// </summary>
-        [DataMember(Name = "overview", Order = 309)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> Overview { get; set; }
-
-        /// <summary>
         /// Specific physiologic benefits associated to the plan.
         /// </summary>
-        [DataMember(Name = "physiologicalBenefits", Order = 310)]
+        [DataMember(Name = "physiologicalBenefits", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PhysiologicalBenefits { get; set; }
 
         /// <summary>
         /// Specific physiologic risks associated to the diet plan.
         /// </summary>
-        [DataMember(Name = "risks", Order = 311)]
+        [DataMember(Name = "risks", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Risks { get; set; }
 
@@ -111,7 +99,6 @@
                 this.DietFeatures == other.DietFeatures &&
                 this.Endorsers == other.Endorsers &&
                 this.ExpertConsiderations == other.ExpertConsiderations &&
-                this.Overview == other.Overview &&
                 this.PhysiologicalBenefits == other.PhysiologicalBenefits &&
                 this.Risks == other.Risks &&
                 base.Equals(other);
@@ -125,7 +112,6 @@
             .And(this.DietFeatures)
             .And(this.Endorsers)
             .And(this.ExpertConsiderations)
-            .And(this.Overview)
             .And(this.PhysiologicalBenefits)
             .And(this.Risks)
             .And(base.GetHashCode());

--- a/Source/Schema.NET/core/DietarySupplement.cs
+++ b/Source/Schema.NET/core/DietarySupplement.cs
@@ -10,11 +10,6 @@
     public partial interface IDietarySupplement : ISubstance
     {
         /// <summary>
-        /// Descriptive information establishing a historical perspective on the supplement. May include the rationale for the name, the population where the supplement first came to prominence, etc.
-        /// </summary>
-        OneOrMany<string> Background { get; set; }
-
-        /// <summary>
         /// True if this item's name is a proprietary/brand name (vs. generic name).
         /// </summary>
         OneOrMany<bool?> IsProprietary { get; set; }
@@ -75,79 +70,72 @@
         public override OneOrMany<string> ActiveIngredient { get; set; }
 
         /// <summary>
-        /// Descriptive information establishing a historical perspective on the supplement. May include the rationale for the name, the population where the supplement first came to prominence, etc.
-        /// </summary>
-        [DataMember(Name = "background", Order = 307)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> Background { get; set; }
-
-        /// <summary>
         /// True if this item's name is a proprietary/brand name (vs. generic name).
         /// </summary>
-        [DataMember(Name = "isProprietary", Order = 308)]
+        [DataMember(Name = "isProprietary", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsProprietary { get; set; }
 
         /// <summary>
         /// The drug or supplement's legal status, including any controlled substance schedules that apply.
         /// </summary>
-        [DataMember(Name = "legalStatus", Order = 309)]
+        [DataMember(Name = "legalStatus", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IDrugLegalStatus, MedicalEnumeration?, string> LegalStatus { get; set; }
 
         /// <summary>
         /// The manufacturer of the product.
         /// </summary>
-        [DataMember(Name = "manufacturer", Order = 310)]
+        [DataMember(Name = "manufacturer", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> Manufacturer { get; set; }
 
         /// <summary>
         /// Recommended intake of this supplement for a given population as defined by a specific recommending authority.
         /// </summary>
-        [DataMember(Name = "maximumIntake", Order = 311)]
+        [DataMember(Name = "maximumIntake", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IMaximumDoseSchedule> MaximumIntake { get; set; }
 
         /// <summary>
         /// The specific biochemical interaction through which this drug or supplement produces its pharmacological effect.
         /// </summary>
-        [DataMember(Name = "mechanismOfAction", Order = 312)]
+        [DataMember(Name = "mechanismOfAction", Order = 311)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> MechanismOfAction { get; set; }
 
         /// <summary>
         /// The generic name of this drug or supplement.
         /// </summary>
-        [DataMember(Name = "nonProprietaryName", Order = 313)]
+        [DataMember(Name = "nonProprietaryName", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> NonProprietaryName { get; set; }
 
         /// <summary>
         /// Proprietary name given to the diet plan, typically by its originator or creator.
         /// </summary>
-        [DataMember(Name = "proprietaryName", Order = 314)]
+        [DataMember(Name = "proprietaryName", Order = 313)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ProprietaryName { get; set; }
 
         /// <summary>
         /// Recommended intake of this supplement for a given population as defined by a specific recommending authority.
         /// </summary>
-        [DataMember(Name = "recommendedIntake", Order = 315)]
+        [DataMember(Name = "recommendedIntake", Order = 314)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IRecommendedDoseSchedule> RecommendedIntake { get; set; }
 
         /// <summary>
         /// Any potential safety concern associated with the supplement. May include interactions with other drugs and foods, pregnancy, breastfeeding, known adverse reactions, and documented efficacy of the supplement.
         /// </summary>
-        [DataMember(Name = "safetyConsideration", Order = 316)]
+        [DataMember(Name = "safetyConsideration", Order = 315)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SafetyConsideration { get; set; }
 
         /// <summary>
         /// Characteristics of the population for which this is intended, or which typically uses it, e.g. 'adults'.
         /// </summary>
-        [DataMember(Name = "targetPopulation", Order = 317)]
+        [DataMember(Name = "targetPopulation", Order = 316)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TargetPopulation { get; set; }
 
@@ -166,7 +154,6 @@
 
             return this.Type == other.Type &&
                 this.ActiveIngredient == other.ActiveIngredient &&
-                this.Background == other.Background &&
                 this.IsProprietary == other.IsProprietary &&
                 this.LegalStatus == other.LegalStatus &&
                 this.Manufacturer == other.Manufacturer &&
@@ -186,7 +173,6 @@
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.ActiveIngredient)
-            .And(this.Background)
             .And(this.IsProprietary)
             .And(this.LegalStatus)
             .And(this.Manufacturer)

--- a/Source/Schema.NET/core/Drug.cs
+++ b/Source/Schema.NET/core/Drug.cs
@@ -35,11 +35,6 @@
         OneOrMany<string> ClinicalPharmacology { get; set; }
 
         /// <summary>
-        /// Cost per unit of the drug, as reported by the source being tagged.
-        /// </summary>
-        OneOrMany<DrugCost?> Cost { get; set; }
-
-        /// <summary>
         /// A dosage form in which this drug/supplement is available, e.g. 'tablet', 'suspension', 'injection'.
         /// </summary>
         OneOrMany<string> DosageForm { get; set; }
@@ -200,170 +195,163 @@
         public OneOrMany<string> ClinicalPharmacology { get; set; }
 
         /// <summary>
-        /// Cost per unit of the drug, as reported by the source being tagged.
-        /// </summary>
-        [DataMember(Name = "cost", Order = 312)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<DrugCost?> Cost { get; set; }
-
-        /// <summary>
         /// A dosage form in which this drug/supplement is available, e.g. 'tablet', 'suspension', 'injection'.
         /// </summary>
-        [DataMember(Name = "dosageForm", Order = 313)]
+        [DataMember(Name = "dosageForm", Order = 312)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> DosageForm { get; set; }
 
         /// <summary>
         /// A dosing schedule for the drug for a given population, either observed, recommended, or maximum dose based on the type used.
         /// </summary>
-        [DataMember(Name = "doseSchedule", Order = 314)]
+        [DataMember(Name = "doseSchedule", Order = 313)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDoseSchedule> DoseSchedule { get; set; }
 
         /// <summary>
         /// The class of drug this belongs to (e.g., statins).
         /// </summary>
-        [DataMember(Name = "drugClass", Order = 315)]
+        [DataMember(Name = "drugClass", Order = 314)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DrugClass?> DrugClass { get; set; }
 
         /// <summary>
         /// The unit in which the drug is measured, e.g. '5 mg tablet'.
         /// </summary>
-        [DataMember(Name = "drugUnit", Order = 316)]
+        [DataMember(Name = "drugUnit", Order = 315)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> DrugUnit { get; set; }
 
         /// <summary>
         /// Any precaution, guidance, contraindication, etc. related to consumption of specific foods while taking this drug.
         /// </summary>
-        [DataMember(Name = "foodWarning", Order = 317)]
+        [DataMember(Name = "foodWarning", Order = 316)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> FoodWarning { get; set; }
 
         /// <summary>
         /// Another drug that is known to interact with this drug in a way that impacts the effect of this drug or causes a risk to the patient. Note: disease interactions are typically captured as contraindications.
         /// </summary>
-        [DataMember(Name = "interactingDrug", Order = 318)]
+        [DataMember(Name = "interactingDrug", Order = 317)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDrug> InteractingDrug { get; set; }
 
         /// <summary>
         /// True if the drug is available in a generic form (regardless of name).
         /// </summary>
-        [DataMember(Name = "isAvailableGenerically", Order = 319)]
+        [DataMember(Name = "isAvailableGenerically", Order = 318)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAvailableGenerically { get; set; }
 
         /// <summary>
         /// True if this item's name is a proprietary/brand name (vs. generic name).
         /// </summary>
-        [DataMember(Name = "isProprietary", Order = 320)]
+        [DataMember(Name = "isProprietary", Order = 319)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsProprietary { get; set; }
 
         /// <summary>
         /// Link to the drug's label details.
         /// </summary>
-        [DataMember(Name = "labelDetails", Order = 321)]
+        [DataMember(Name = "labelDetails", Order = 320)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> LabelDetails { get; set; }
 
         /// <summary>
         /// The drug or supplement's legal status, including any controlled substance schedules that apply.
         /// </summary>
-        [DataMember(Name = "legalStatus", Order = 322)]
+        [DataMember(Name = "legalStatus", Order = 321)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IDrugLegalStatus, MedicalEnumeration?, string> LegalStatus { get; set; }
 
         /// <summary>
         /// The manufacturer of the product.
         /// </summary>
-        [DataMember(Name = "manufacturer", Order = 323)]
+        [DataMember(Name = "manufacturer", Order = 322)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> Manufacturer { get; set; }
 
         /// <summary>
         /// Recommended intake of this supplement for a given population as defined by a specific recommending authority.
         /// </summary>
-        [DataMember(Name = "maximumIntake", Order = 324)]
+        [DataMember(Name = "maximumIntake", Order = 323)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IMaximumDoseSchedule> MaximumIntake { get; set; }
 
         /// <summary>
         /// The specific biochemical interaction through which this drug or supplement produces its pharmacological effect.
         /// </summary>
-        [DataMember(Name = "mechanismOfAction", Order = 325)]
+        [DataMember(Name = "mechanismOfAction", Order = 324)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> MechanismOfAction { get; set; }
 
         /// <summary>
         /// The generic name of this drug or supplement.
         /// </summary>
-        [DataMember(Name = "nonProprietaryName", Order = 326)]
+        [DataMember(Name = "nonProprietaryName", Order = 325)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> NonProprietaryName { get; set; }
 
         /// <summary>
         /// Any information related to overdose on a drug, including signs or symptoms, treatments, contact information for emergency response.
         /// </summary>
-        [DataMember(Name = "overdosage", Order = 327)]
+        [DataMember(Name = "overdosage", Order = 326)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Overdosage { get; set; }
 
         /// <summary>
         /// Pregnancy category of this drug.
         /// </summary>
-        [DataMember(Name = "pregnancyCategory", Order = 328)]
+        [DataMember(Name = "pregnancyCategory", Order = 327)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DrugPregnancyCategory?> PregnancyCategory { get; set; }
 
         /// <summary>
         /// Any precaution, guidance, contraindication, etc. related to this drug's use during pregnancy.
         /// </summary>
-        [DataMember(Name = "pregnancyWarning", Order = 329)]
+        [DataMember(Name = "pregnancyWarning", Order = 328)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PregnancyWarning { get; set; }
 
         /// <summary>
         /// Link to prescribing information for the drug.
         /// </summary>
-        [DataMember(Name = "prescribingInfo", Order = 330)]
+        [DataMember(Name = "prescribingInfo", Order = 329)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> PrescribingInfo { get; set; }
 
         /// <summary>
         /// Indicates the status of drug prescription eg. local catalogs classifications or whether the drug is available by prescription or over-the-counter, etc.
         /// </summary>
-        [DataMember(Name = "prescriptionStatus", Order = 331)]
+        [DataMember(Name = "prescriptionStatus", Order = 330)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DrugPrescriptionStatus?, string> PrescriptionStatus { get; set; }
 
         /// <summary>
         /// Proprietary name given to the diet plan, typically by its originator or creator.
         /// </summary>
-        [DataMember(Name = "proprietaryName", Order = 332)]
+        [DataMember(Name = "proprietaryName", Order = 331)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ProprietaryName { get; set; }
 
         /// <summary>
         /// Any other drug related to this one, for example commonly-prescribed alternatives.
         /// </summary>
-        [DataMember(Name = "relatedDrug", Order = 333)]
+        [DataMember(Name = "relatedDrug", Order = 332)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDrug> RelatedDrug { get; set; }
 
         /// <summary>
         /// The RxCUI drug identifier from RXNORM.
         /// </summary>
-        [DataMember(Name = "rxcui", Order = 334)]
+        [DataMember(Name = "rxcui", Order = 333)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Rxcui { get; set; }
 
         /// <summary>
         /// Any FDA or other warnings about the drug (text or URL).
         /// </summary>
-        [DataMember(Name = "warning", Order = 335)]
+        [DataMember(Name = "warning", Order = 334)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Warning { get; set; }
 
@@ -387,7 +375,6 @@
                 this.AvailableStrength == other.AvailableStrength &&
                 this.BreastfeedingWarning == other.BreastfeedingWarning &&
                 this.ClinicalPharmacology == other.ClinicalPharmacology &&
-                this.Cost == other.Cost &&
                 this.DosageForm == other.DosageForm &&
                 this.DoseSchedule == other.DoseSchedule &&
                 this.DrugClass == other.DrugClass &&
@@ -425,7 +412,6 @@
             .And(this.AvailableStrength)
             .And(this.BreastfeedingWarning)
             .And(this.ClinicalPharmacology)
-            .And(this.Cost)
             .And(this.DosageForm)
             .And(this.DoseSchedule)
             .And(this.DrugClass)

--- a/Source/Schema.NET/core/Event.cs
+++ b/Source/Schema.NET/core/Event.cs
@@ -90,6 +90,16 @@
         OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
+        /// The maximum physical attendee capacity of an &lt;a class="localLink" href="http://schema.org/Event"&gt;Event&lt;/a&gt; whose &lt;a class="localLink" href="http://schema.org/eventAttendanceMode"&gt;eventAttendanceMode&lt;/a&gt; is &lt;a class="localLink" href="http://schema.org/OfflineEventAttendanceMode"&gt;OfflineEventAttendanceMode&lt;/a&gt; (or the offline aspects, in the case of a &lt;a class="localLink" href="http://schema.org/MixedEventAttendanceMode"&gt;MixedEventAttendanceMode&lt;/a&gt;).
+        /// </summary>
+        OneOrMany<int?> MaximumPhysicalAttendeeCapacity { get; set; }
+
+        /// <summary>
+        /// The maximum physical attendee capacity of an &lt;a class="localLink" href="http://schema.org/Event"&gt;Event&lt;/a&gt; whose &lt;a class="localLink" href="http://schema.org/eventAttendanceMode"&gt;eventAttendanceMode&lt;/a&gt; is &lt;a class="localLink" href="http://schema.org/OnlineEventAttendanceMode"&gt;OnlineEventAttendanceMode&lt;/a&gt; (or the online aspects, in the case of a &lt;a class="localLink" href="http://schema.org/MixedEventAttendanceMode"&gt;MixedEventAttendanceMode&lt;/a&gt;).
+        /// </summary>
+        OneOrMany<int?> MaximumVirtualAttendeeCapacity { get; set; }
+
+        /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         Values<IDemand, IOffer> Offers { get; set; }
@@ -296,100 +306,114 @@
         public OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
+        /// The maximum physical attendee capacity of an &lt;a class="localLink" href="http://schema.org/Event"&gt;Event&lt;/a&gt; whose &lt;a class="localLink" href="http://schema.org/eventAttendanceMode"&gt;eventAttendanceMode&lt;/a&gt; is &lt;a class="localLink" href="http://schema.org/OfflineEventAttendanceMode"&gt;OfflineEventAttendanceMode&lt;/a&gt; (or the offline aspects, in the case of a &lt;a class="localLink" href="http://schema.org/MixedEventAttendanceMode"&gt;MixedEventAttendanceMode&lt;/a&gt;).
+        /// </summary>
+        [DataMember(Name = "maximumPhysicalAttendeeCapacity", Order = 122)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<int?> MaximumPhysicalAttendeeCapacity { get; set; }
+
+        /// <summary>
+        /// The maximum physical attendee capacity of an &lt;a class="localLink" href="http://schema.org/Event"&gt;Event&lt;/a&gt; whose &lt;a class="localLink" href="http://schema.org/eventAttendanceMode"&gt;eventAttendanceMode&lt;/a&gt; is &lt;a class="localLink" href="http://schema.org/OnlineEventAttendanceMode"&gt;OnlineEventAttendanceMode&lt;/a&gt; (or the online aspects, in the case of a &lt;a class="localLink" href="http://schema.org/MixedEventAttendanceMode"&gt;MixedEventAttendanceMode&lt;/a&gt;).
+        /// </summary>
+        [DataMember(Name = "maximumVirtualAttendeeCapacity", Order = 123)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<int?> MaximumVirtualAttendeeCapacity { get; set; }
+
+        /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 122)]
+        [DataMember(Name = "offers", Order = 124)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// An organizer of an Event.
         /// </summary>
-        [DataMember(Name = "organizer", Order = 123)]
+        [DataMember(Name = "organizer", Order = 125)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Organizer { get; set; }
 
         /// <summary>
         /// A performer at the event&amp;#x2014;for example, a presenter, musician, musical group or actor.
         /// </summary>
-        [DataMember(Name = "performer", Order = 124)]
+        [DataMember(Name = "performer", Order = 126)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Performer { get; set; }
 
         /// <summary>
         /// Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated.
         /// </summary>
-        [DataMember(Name = "previousStartDate", Order = 125)]
+        [DataMember(Name = "previousStartDate", Order = 127)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> PreviousStartDate { get; set; }
 
         /// <summary>
         /// The CreativeWork that captured all or part of this Event.
         /// </summary>
-        [DataMember(Name = "recordedIn", Order = 126)]
+        [DataMember(Name = "recordedIn", Order = 128)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> RecordedIn { get; set; }
 
         /// <summary>
         /// The number of attendee places for an event that remain unallocated.
         /// </summary>
-        [DataMember(Name = "remainingAttendeeCapacity", Order = 127)]
+        [DataMember(Name = "remainingAttendeeCapacity", Order = 129)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> RemainingAttendeeCapacity { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 128)]
+        [DataMember(Name = "review", Order = 130)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 129)]
+        [DataMember(Name = "sponsor", Order = 131)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The start date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "startDate", Order = 130)]
+        [DataMember(Name = "startDate", Order = 132)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> StartDate { get; set; }
 
         /// <summary>
         /// The end date and time of the item (in &lt;a href="http://en.wikipedia.org/wiki/ISO_8601"&gt;ISO 8601 date format&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "endDate", Order = 131)]
+        [DataMember(Name = "endDate", Order = 133)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> EndDate { get; set; }
 
         /// <summary>
         /// An Event that is part of this event. For example, a conference event includes many presentations, each of which is a subEvent of the conference.
         /// </summary>
-        [DataMember(Name = "subEvent", Order = 132)]
+        [DataMember(Name = "subEvent", Order = 134)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> SubEvent { get; set; }
 
         /// <summary>
         /// An event that this event is a part of. For example, a collection of individual music performances might each have a music festival as their superEvent.
         /// </summary>
-        [DataMember(Name = "superEvent", Order = 133)]
+        [DataMember(Name = "superEvent", Order = 135)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> SuperEvent { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 134)]
+        [DataMember(Name = "translator", Order = 136)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 135)]
+        [DataMember(Name = "typicalAgeRange", Order = 137)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
@@ -397,14 +421,14 @@
         /// A work featured in some event, e.g. exhibited in an ExhibitionEvent.
         ///        Specific subproperties are available for workPerformed (e.g. a play), or a workPresented (a Movie at a ScreeningEvent).
         /// </summary>
-        [DataMember(Name = "workFeatured", Order = 136)]
+        [DataMember(Name = "workFeatured", Order = 138)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkFeatured { get; set; }
 
         /// <summary>
         /// A work performed in some event, for example a play performed in a TheaterEvent.
         /// </summary>
-        [DataMember(Name = "workPerformed", Order = 137)]
+        [DataMember(Name = "workPerformed", Order = 139)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkPerformed { get; set; }
 
@@ -438,6 +462,8 @@
                 this.IsAccessibleForFree == other.IsAccessibleForFree &&
                 this.Location == other.Location &&
                 this.MaximumAttendeeCapacity == other.MaximumAttendeeCapacity &&
+                this.MaximumPhysicalAttendeeCapacity == other.MaximumPhysicalAttendeeCapacity &&
+                this.MaximumVirtualAttendeeCapacity == other.MaximumVirtualAttendeeCapacity &&
                 this.Offers == other.Offers &&
                 this.Organizer == other.Organizer &&
                 this.Performer == other.Performer &&
@@ -478,6 +504,8 @@
             .And(this.IsAccessibleForFree)
             .And(this.Location)
             .And(this.MaximumAttendeeCapacity)
+            .And(this.MaximumPhysicalAttendeeCapacity)
+            .And(this.MaximumVirtualAttendeeCapacity)
             .And(this.Offers)
             .And(this.Organizer)
             .And(this.Performer)

--- a/Source/Schema.NET/core/Event.cs
+++ b/Source/Schema.NET/core/Event.cs
@@ -90,9 +90,9 @@
         OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        OneOrMany<IOffer> Offers { get; set; }
+        Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// An organizer of an Event.
@@ -296,11 +296,11 @@
         public OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "offers", Order = 122)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// An organizer of an Event.

--- a/Source/Schema.NET/core/ImageGallery.cs
+++ b/Source/Schema.NET/core/ImageGallery.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Web page type: Image gallery page.
     /// </summary>
-    public partial interface IImageGallery : ICollectionPage
+    public partial interface IImageGallery : IMediaGallery
     {
     }
 
@@ -15,7 +15,7 @@
     /// Web page type: Image gallery page.
     /// </summary>
     [DataContract]
-    public partial class ImageGallery : CollectionPage, IImageGallery, IEquatable<ImageGallery>
+    public partial class ImageGallery : MediaGallery, IImageGallery, IEquatable<ImageGallery>
     {
         /// <summary>
         /// Gets the name of the type as specified by schema.org.

--- a/Source/Schema.NET/core/JobPosting.cs
+++ b/Source/Schema.NET/core/JobPosting.cs
@@ -20,12 +20,17 @@
         OneOrMany<IAdministrativeArea> ApplicantLocationRequirements { get; set; }
 
         /// <summary>
+        /// Contact details for further information relevant to this job posting.
+        /// </summary>
+        OneOrMany<IContactPoint> ApplicationContact { get; set; }
+
+        /// <summary>
         /// The base salary of the job or of an employee in an EmployeeRole.
         /// </summary>
         Values<IMonetaryAmount, decimal?, IPriceSpecification> BaseSalary { get; set; }
 
         /// <summary>
-        /// Publication date for the job posting.
+        /// Publication date of an online listing.
         /// </summary>
         Values<int?, DateTime?> DatePosted { get; set; }
 
@@ -33,6 +38,11 @@
         /// Educational background needed for the position or Occupation.
         /// </summary>
         OneOrMany<string> EducationRequirements { get; set; }
+
+        /// <summary>
+        /// A description of the employer, career opportunities and work environment for this position.
+        /// </summary>
+        OneOrMany<string> EmployerOverview { get; set; }
 
         /// <summary>
         /// Type of employment (e.g. full-time, part-time, contract, temporary, seasonal, internship).
@@ -101,6 +111,11 @@
         OneOrMany<string> OccupationalCategory { get; set; }
 
         /// <summary>
+        /// A description of the types of physical activity associated with the job. Defined terms such as those in O*net may be used, but note that there is no way to specify the level of ability as well as its nature when using a defined term.
+        /// </summary>
+        Values<string, Uri> PhysicalRequirement { get; set; }
+
+        /// <summary>
         /// Specific qualifications required for this role or Occupation.
         /// </summary>
         OneOrMany<string> Qualifications { get; set; }
@@ -119,6 +134,16 @@
         /// The currency (coded using &lt;a href="http://en.wikipedia.org/wiki/ISO_4217"&gt;ISO 4217&lt;/a&gt; ) used for the main salary information in this job posting or for this employee.
         /// </summary>
         OneOrMany<string> SalaryCurrency { get; set; }
+
+        /// <summary>
+        /// A description of any security clearance requirements of the job.
+        /// </summary>
+        Values<string, Uri> SecurityClearanceRequirement { get; set; }
+
+        /// <summary>
+        /// A description of any sensory requirements and levels necessary to function on the job, including hearing and vision. Defined terms such as those in O*net may be used, but note that there is no way to specify the level of ability as well as its nature when using a defined term.
+        /// </summary>
+        Values<string, Uri> SensoryRequirement { get; set; }
 
         /// <summary>
         /// A statement of knowledge, skill, ability, task or any other assertion expressing a competency that is desired or required to fulfill this role or to work in this occupation.
@@ -173,107 +198,121 @@
         public OneOrMany<IAdministrativeArea> ApplicantLocationRequirements { get; set; }
 
         /// <summary>
+        /// Contact details for further information relevant to this job posting.
+        /// </summary>
+        [DataMember(Name = "applicationContact", Order = 208)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<IContactPoint> ApplicationContact { get; set; }
+
+        /// <summary>
         /// The base salary of the job or of an employee in an EmployeeRole.
         /// </summary>
-        [DataMember(Name = "baseSalary", Order = 208)]
+        [DataMember(Name = "baseSalary", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IMonetaryAmount, decimal?, IPriceSpecification> BaseSalary { get; set; }
 
         /// <summary>
-        /// Publication date for the job posting.
+        /// Publication date of an online listing.
         /// </summary>
-        [DataMember(Name = "datePosted", Order = 209)]
+        [DataMember(Name = "datePosted", Order = 210)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> DatePosted { get; set; }
 
         /// <summary>
         /// Educational background needed for the position or Occupation.
         /// </summary>
-        [DataMember(Name = "educationRequirements", Order = 210)]
+        [DataMember(Name = "educationRequirements", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationRequirements { get; set; }
 
         /// <summary>
+        /// A description of the employer, career opportunities and work environment for this position.
+        /// </summary>
+        [DataMember(Name = "employerOverview", Order = 212)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<string> EmployerOverview { get; set; }
+
+        /// <summary>
         /// Type of employment (e.g. full-time, part-time, contract, temporary, seasonal, internship).
         /// </summary>
-        [DataMember(Name = "employmentType", Order = 211)]
+        [DataMember(Name = "employmentType", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EmploymentType { get; set; }
 
         /// <summary>
         /// Indicates the department, unit and/or facility where the employee reports and/or in which the job is to be performed.
         /// </summary>
-        [DataMember(Name = "employmentUnit", Order = 212)]
+        [DataMember(Name = "employmentUnit", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> EmploymentUnit { get; set; }
 
         /// <summary>
         /// An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value.
         /// </summary>
-        [DataMember(Name = "estimatedSalary", Order = 213)]
+        [DataMember(Name = "estimatedSalary", Order = 215)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IMonetaryAmount, IMonetaryAmountDistribution, decimal?> EstimatedSalary { get; set; }
 
         /// <summary>
         /// Description of skills and experience needed for the position or Occupation.
         /// </summary>
-        [DataMember(Name = "experienceRequirements", Order = 214)]
+        [DataMember(Name = "experienceRequirements", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ExperienceRequirements { get; set; }
 
         /// <summary>
         /// Organization offering the job position.
         /// </summary>
-        [DataMember(Name = "hiringOrganization", Order = 215)]
+        [DataMember(Name = "hiringOrganization", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> HiringOrganization { get; set; }
 
         /// <summary>
         /// Description of bonus and commission compensation aspects of the job.
         /// </summary>
-        [DataMember(Name = "incentiveCompensation", Order = 216)]
+        [DataMember(Name = "incentiveCompensation", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> IncentiveCompensation { get; set; }
 
         /// <summary>
         /// The industry associated with the job position.
         /// </summary>
-        [DataMember(Name = "industry", Order = 217)]
+        [DataMember(Name = "industry", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Industry { get; set; }
 
         /// <summary>
         /// Description of benefits associated with the job.
         /// </summary>
-        [DataMember(Name = "jobBenefits", Order = 218)]
+        [DataMember(Name = "jobBenefits", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> JobBenefits { get; set; }
 
         /// <summary>
         /// An indicator as to whether a position is available for an immediate start.
         /// </summary>
-        [DataMember(Name = "jobImmediateStart", Order = 219)]
+        [DataMember(Name = "jobImmediateStart", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> JobImmediateStart { get; set; }
 
         /// <summary>
         /// A (typically single) geographic location associated with the job position.
         /// </summary>
-        [DataMember(Name = "jobLocation", Order = 220)]
+        [DataMember(Name = "jobLocation", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> JobLocation { get; set; }
 
         /// <summary>
         /// A description of the job location (e.g TELECOMMUTE for telecommute jobs).
         /// </summary>
-        [DataMember(Name = "jobLocationType", Order = 221)]
+        [DataMember(Name = "jobLocationType", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> JobLocationType { get; set; }
 
         /// <summary>
         /// The date on which a successful applicant for this job would be expected to start work. Choose a specific date in the future or use the jobImmediateStart property to indicate the position is to be filled as soon as possible.
         /// </summary>
-        [DataMember(Name = "jobStartDate", Order = 222)]
+        [DataMember(Name = "jobStartDate", Order = 224)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, string> JobStartDate { get; set; }
 
@@ -281,70 +320,91 @@
         /// A category describing the job, preferably using a term from a taxonomy such as &lt;a href="http://www.onetcenter.org/taxonomy.html"&gt;BLS O*NET-SOC&lt;/a&gt;, &lt;a href="https://www.ilo.org/public/english/bureau/stat/isco/isco08/"&gt;ISCO-08&lt;/a&gt; or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.&lt;br/&gt;&lt;br/&gt;
         /// Note: for historical reasons, any textual label and formal code provided as a literal may be assumed to be from O*NET-SOC.
         /// </summary>
-        [DataMember(Name = "occupationalCategory", Order = 223)]
+        [DataMember(Name = "occupationalCategory", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> OccupationalCategory { get; set; }
 
         /// <summary>
+        /// A description of the types of physical activity associated with the job. Defined terms such as those in O*net may be used, but note that there is no way to specify the level of ability as well as its nature when using a defined term.
+        /// </summary>
+        [DataMember(Name = "physicalRequirement", Order = 226)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> PhysicalRequirement { get; set; }
+
+        /// <summary>
         /// Specific qualifications required for this role or Occupation.
         /// </summary>
-        [DataMember(Name = "qualifications", Order = 224)]
+        [DataMember(Name = "qualifications", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Qualifications { get; set; }
 
         /// <summary>
         /// The Occupation for the JobPosting.
         /// </summary>
-        [DataMember(Name = "relevantOccupation", Order = 225)]
+        [DataMember(Name = "relevantOccupation", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOccupation> RelevantOccupation { get; set; }
 
         /// <summary>
         /// Responsibilities associated with this role or Occupation.
         /// </summary>
-        [DataMember(Name = "responsibilities", Order = 226)]
+        [DataMember(Name = "responsibilities", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Responsibilities { get; set; }
 
         /// <summary>
         /// The currency (coded using &lt;a href="http://en.wikipedia.org/wiki/ISO_4217"&gt;ISO 4217&lt;/a&gt; ) used for the main salary information in this job posting or for this employee.
         /// </summary>
-        [DataMember(Name = "salaryCurrency", Order = 227)]
+        [DataMember(Name = "salaryCurrency", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SalaryCurrency { get; set; }
 
         /// <summary>
+        /// A description of any security clearance requirements of the job.
+        /// </summary>
+        [DataMember(Name = "securityClearanceRequirement", Order = 231)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> SecurityClearanceRequirement { get; set; }
+
+        /// <summary>
+        /// A description of any sensory requirements and levels necessary to function on the job, including hearing and vision. Defined terms such as those in O*net may be used, but note that there is no way to specify the level of ability as well as its nature when using a defined term.
+        /// </summary>
+        [DataMember(Name = "sensoryRequirement", Order = 232)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> SensoryRequirement { get; set; }
+
+        /// <summary>
         /// A statement of knowledge, skill, ability, task or any other assertion expressing a competency that is desired or required to fulfill this role or to work in this occupation.
         /// </summary>
-        [DataMember(Name = "skills", Order = 228)]
+        [DataMember(Name = "skills", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Skills { get; set; }
 
         /// <summary>
         /// Any special commitments associated with this job posting. Valid entries include VeteranCommit, MilitarySpouseCommit, etc.
         /// </summary>
-        [DataMember(Name = "specialCommitments", Order = 229)]
+        [DataMember(Name = "specialCommitments", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SpecialCommitments { get; set; }
 
         /// <summary>
         /// The number of positions open for this job posting. Use a positive integer. Do not use if the number of positions is unclear or not known.
         /// </summary>
-        [DataMember(Name = "totalJobOpenings", Order = 230)]
+        [DataMember(Name = "totalJobOpenings", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> TotalJobOpenings { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        [DataMember(Name = "validThrough", Order = 231)]
+        [DataMember(Name = "validThrough", Order = 236)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The typical working hours for this job (e.g. 1st shift, night shift, 8am-5pm).
         /// </summary>
-        [DataMember(Name = "workHours", Order = 232)]
+        [DataMember(Name = "workHours", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> WorkHours { get; set; }
 
@@ -364,9 +424,11 @@
             return this.Type == other.Type &&
                 this.Title == other.Title &&
                 this.ApplicantLocationRequirements == other.ApplicantLocationRequirements &&
+                this.ApplicationContact == other.ApplicationContact &&
                 this.BaseSalary == other.BaseSalary &&
                 this.DatePosted == other.DatePosted &&
                 this.EducationRequirements == other.EducationRequirements &&
+                this.EmployerOverview == other.EmployerOverview &&
                 this.EmploymentType == other.EmploymentType &&
                 this.EmploymentUnit == other.EmploymentUnit &&
                 this.EstimatedSalary == other.EstimatedSalary &&
@@ -380,10 +442,13 @@
                 this.JobLocationType == other.JobLocationType &&
                 this.JobStartDate == other.JobStartDate &&
                 this.OccupationalCategory == other.OccupationalCategory &&
+                this.PhysicalRequirement == other.PhysicalRequirement &&
                 this.Qualifications == other.Qualifications &&
                 this.RelevantOccupation == other.RelevantOccupation &&
                 this.Responsibilities == other.Responsibilities &&
                 this.SalaryCurrency == other.SalaryCurrency &&
+                this.SecurityClearanceRequirement == other.SecurityClearanceRequirement &&
+                this.SensoryRequirement == other.SensoryRequirement &&
                 this.Skills == other.Skills &&
                 this.SpecialCommitments == other.SpecialCommitments &&
                 this.TotalJobOpenings == other.TotalJobOpenings &&
@@ -399,9 +464,11 @@
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.Title)
             .And(this.ApplicantLocationRequirements)
+            .And(this.ApplicationContact)
             .And(this.BaseSalary)
             .And(this.DatePosted)
             .And(this.EducationRequirements)
+            .And(this.EmployerOverview)
             .And(this.EmploymentType)
             .And(this.EmploymentUnit)
             .And(this.EstimatedSalary)
@@ -415,10 +482,13 @@
             .And(this.JobLocationType)
             .And(this.JobStartDate)
             .And(this.OccupationalCategory)
+            .And(this.PhysicalRequirement)
             .And(this.Qualifications)
             .And(this.RelevantOccupation)
             .And(this.Responsibilities)
             .And(this.SalaryCurrency)
+            .And(this.SecurityClearanceRequirement)
+            .And(this.SensoryRequirement)
             .And(this.Skills)
             .And(this.SpecialCommitments)
             .And(this.TotalJobOpenings)

--- a/Source/Schema.NET/core/MediaGallery.cs
+++ b/Source/Schema.NET/core/MediaGallery.cs
@@ -1,0 +1,50 @@
+﻿namespace Schema.NET
+{
+    using System;
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Web page type: Media gallery page. A mixed-media page that can contains media such as images, videos, and other multimedia.
+    /// </summary>
+    public partial interface IMediaGallery : ICollectionPage
+    {
+    }
+
+    /// <summary>
+    /// Web page type: Media gallery page. A mixed-media page that can contains media such as images, videos, and other multimedia.
+    /// </summary>
+    [DataContract]
+    public partial class MediaGallery : CollectionPage, IMediaGallery, IEquatable<MediaGallery>
+    {
+        /// <summary>
+        /// Gets the name of the type as specified by schema.org.
+        /// </summary>
+        [DataMember(Name = "@type", Order = 1)]
+        public override string Type => "MediaGallery";
+
+        /// <inheritdoc/>
+        public bool Equals(MediaGallery other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.Type == other.Type &&
+                base.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => this.Equals(obj as MediaGallery);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Of(this.Type)
+            .And(base.GetHashCode());
+    }
+}

--- a/Source/Schema.NET/core/MedicalCondition.cs
+++ b/Source/Schema.NET/core/MedicalCondition.cs
@@ -15,11 +15,6 @@
         Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
-        /// Specifying a cause of something in general. e.g in medicine , one of the causative agent(s) that are most directly responsible for the pathophysiologic process that eventually results in the occurrence.
-        /// </summary>
-        OneOrMany<IMedicalCause> Cause { get; set; }
-
-        /// <summary>
         /// One of a set of differential diagnoses for the condition. Specifically, a closely-related or competing diagnosis typically considered later in the cognitive process whereby this medical condition is distinguished from others most likely responsible for a similar collection of signs and symptoms to reach the most parsimonious diagnosis or diagnoses in a patient.
         /// </summary>
         OneOrMany<IDDxElement> DifferentialDiagnosis { get; set; }
@@ -90,11 +85,6 @@
         Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
         /// <summary>
-        /// A more specific type of the condition, where applicable, for example 'Type 1 Diabetes', 'Type 2 Diabetes', or 'Gestational Diabetes' for Diabetes.
-        /// </summary>
-        OneOrMany<string> Subtype { get; set; }
-
-        /// <summary>
         /// A medical test typically performed given this condition.
         /// </summary>
         OneOrMany<IMedicalTest> TypicalTest { get; set; }
@@ -120,121 +110,107 @@
         public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
-        /// Specifying a cause of something in general. e.g in medicine , one of the causative agent(s) that are most directly responsible for the pathophysiologic process that eventually results in the occurrence.
-        /// </summary>
-        [DataMember(Name = "cause", Order = 207)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual OneOrMany<IMedicalCause> Cause { get; set; }
-
-        /// <summary>
         /// One of a set of differential diagnoses for the condition. Specifically, a closely-related or competing diagnosis typically considered later in the cognitive process whereby this medical condition is distinguished from others most likely responsible for a similar collection of signs and symptoms to reach the most parsimonious diagnosis or diagnoses in a patient.
         /// </summary>
-        [DataMember(Name = "differentialDiagnosis", Order = 208)]
+        [DataMember(Name = "differentialDiagnosis", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDDxElement> DifferentialDiagnosis { get; set; }
 
         /// <summary>
         /// Specifying a drug or medicine used in a medication procedure
         /// </summary>
-        [DataMember(Name = "drug", Order = 209)]
+        [DataMember(Name = "drug", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDrug> Drug { get; set; }
 
         /// <summary>
         /// The characteristics of associated patients, such as age, gender, race etc.
         /// </summary>
-        [DataMember(Name = "epidemiology", Order = 210)]
+        [DataMember(Name = "epidemiology", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Epidemiology { get; set; }
 
         /// <summary>
         /// The likely outcome in either the short term or long term of the medical condition.
         /// </summary>
-        [DataMember(Name = "expectedPrognosis", Order = 211)]
+        [DataMember(Name = "expectedPrognosis", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ExpectedPrognosis { get; set; }
 
         /// <summary>
         /// The expected progression of the condition if it is not treated and allowed to progress naturally.
         /// </summary>
-        [DataMember(Name = "naturalProgression", Order = 212)]
+        [DataMember(Name = "naturalProgression", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> NaturalProgression { get; set; }
 
         /// <summary>
         /// Changes in the normal mechanical, physical, and biochemical functions that are associated with this activity or condition.
         /// </summary>
-        [DataMember(Name = "pathophysiology", Order = 213)]
+        [DataMember(Name = "pathophysiology", Order = 212)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Pathophysiology { get; set; }
 
         /// <summary>
         /// A possible unexpected and unfavorable evolution of a medical condition. Complications may include worsening of the signs or symptoms of the disease, extension of the condition to other organ systems, etc.
         /// </summary>
-        [DataMember(Name = "possibleComplication", Order = 214)]
+        [DataMember(Name = "possibleComplication", Order = 213)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PossibleComplication { get; set; }
 
         /// <summary>
         /// A possible treatment to address this condition, sign or symptom.
         /// </summary>
-        [DataMember(Name = "possibleTreatment", Order = 215)]
+        [DataMember(Name = "possibleTreatment", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IMedicalTherapy> PossibleTreatment { get; set; }
 
         /// <summary>
         /// A preventative therapy used to prevent an initial occurrence of the medical condition, such as vaccination.
         /// </summary>
-        [DataMember(Name = "primaryPrevention", Order = 216)]
+        [DataMember(Name = "primaryPrevention", Order = 215)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalTherapy> PrimaryPrevention { get; set; }
 
         /// <summary>
         /// A modifiable or non-modifiable factor that increases the risk of a patient contracting this condition, e.g. age,  coexisting condition.
         /// </summary>
-        [DataMember(Name = "riskFactor", Order = 217)]
+        [DataMember(Name = "riskFactor", Order = 216)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalRiskFactor> RiskFactor { get; set; }
 
         /// <summary>
         /// A preventative therapy used to prevent reoccurrence of the medical condition after an initial episode of the condition.
         /// </summary>
-        [DataMember(Name = "secondaryPrevention", Order = 218)]
+        [DataMember(Name = "secondaryPrevention", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalTherapy> SecondaryPrevention { get; set; }
 
         /// <summary>
         /// A sign or symptom of this condition. Signs are objective or physically observable manifestations of the medical condition while symptoms are the subjective experience of the medical condition.
         /// </summary>
-        [DataMember(Name = "signOrSymptom", Order = 219)]
+        [DataMember(Name = "signOrSymptom", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalSignOrSymptom> SignOrSymptom { get; set; }
 
         /// <summary>
         /// The stage of the condition, if applicable.
         /// </summary>
-        [DataMember(Name = "stage", Order = 220)]
+        [DataMember(Name = "stage", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalConditionStage> Stage { get; set; }
 
         /// <summary>
         /// The status of the study (enumerated).
         /// </summary>
-        [DataMember(Name = "status", Order = 221)]
+        [DataMember(Name = "status", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
         /// <summary>
-        /// A more specific type of the condition, where applicable, for example 'Type 1 Diabetes', 'Type 2 Diabetes', or 'Gestational Diabetes' for Diabetes.
-        /// </summary>
-        [DataMember(Name = "subtype", Order = 222)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> Subtype { get; set; }
-
-        /// <summary>
         /// A medical test typically performed given this condition.
         /// </summary>
-        [DataMember(Name = "typicalTest", Order = 223)]
+        [DataMember(Name = "typicalTest", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalTest> TypicalTest { get; set; }
 
@@ -253,7 +229,6 @@
 
             return this.Type == other.Type &&
                 this.AssociatedAnatomy == other.AssociatedAnatomy &&
-                this.Cause == other.Cause &&
                 this.DifferentialDiagnosis == other.DifferentialDiagnosis &&
                 this.Drug == other.Drug &&
                 this.Epidemiology == other.Epidemiology &&
@@ -268,7 +243,6 @@
                 this.SignOrSymptom == other.SignOrSymptom &&
                 this.Stage == other.Stage &&
                 this.Status == other.Status &&
-                this.Subtype == other.Subtype &&
                 this.TypicalTest == other.TypicalTest &&
                 base.Equals(other);
         }
@@ -279,7 +253,6 @@
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.AssociatedAnatomy)
-            .And(this.Cause)
             .And(this.DifferentialDiagnosis)
             .And(this.Drug)
             .And(this.Epidemiology)
@@ -294,7 +267,6 @@
             .And(this.SignOrSymptom)
             .And(this.Stage)
             .And(this.Status)
-            .And(this.Subtype)
             .And(this.TypicalTest)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/MedicalDevice.cs
+++ b/Source/Schema.NET/core/MedicalDevice.cs
@@ -20,11 +20,6 @@
         Values<IMedicalContraindication, string> Contraindication { get; set; }
 
         /// <summary>
-        /// A factor that indicates use of this therapy for treatment and/or prevention of a condition, symptom, etc. For therapies such as drugs, indications can include both officially-approved indications as well as off-label uses. These can be distinguished by using the ApprovedIndication subtype of MedicalIndication.
-        /// </summary>
-        OneOrMany<IMedicalIndication> Indication { get; set; }
-
-        /// <summary>
         /// A description of the postoperative procedures, care, and/or followups for this device.
         /// </summary>
         OneOrMany<string> PostOp { get; set; }
@@ -38,11 +33,6 @@
         /// A description of the procedure involved in setting up, using, and/or installing the device.
         /// </summary>
         OneOrMany<string> Procedure { get; set; }
-
-        /// <summary>
-        /// A goal towards an action is taken. Can be concrete or abstract.
-        /// </summary>
-        Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
 
         /// <summary>
         /// A possible serious complication and/or serious side effect of this therapy. Serious adverse outcomes include those that are life-threatening; result in death, disability, or permanent damage; require hospitalization or prolong existing hospitalization; cause congenital anomalies or birth defects; or jeopardize the patient and may require medical or surgical intervention to prevent one of the outcomes in this definition.
@@ -77,44 +67,30 @@
         public Values<IMedicalContraindication, string> Contraindication { get; set; }
 
         /// <summary>
-        /// A factor that indicates use of this therapy for treatment and/or prevention of a condition, symptom, etc. For therapies such as drugs, indications can include both officially-approved indications as well as off-label uses. These can be distinguished by using the ApprovedIndication subtype of MedicalIndication.
-        /// </summary>
-        [DataMember(Name = "indication", Order = 208)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IMedicalIndication> Indication { get; set; }
-
-        /// <summary>
         /// A description of the postoperative procedures, care, and/or followups for this device.
         /// </summary>
-        [DataMember(Name = "postOp", Order = 209)]
+        [DataMember(Name = "postOp", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PostOp { get; set; }
 
         /// <summary>
         /// A description of the workup, testing, and other preparations required before implanting this device.
         /// </summary>
-        [DataMember(Name = "preOp", Order = 210)]
+        [DataMember(Name = "preOp", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PreOp { get; set; }
 
         /// <summary>
         /// A description of the procedure involved in setting up, using, and/or installing the device.
         /// </summary>
-        [DataMember(Name = "procedure", Order = 211)]
+        [DataMember(Name = "procedure", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Procedure { get; set; }
 
         /// <summary>
-        /// A goal towards an action is taken. Can be concrete or abstract.
-        /// </summary>
-        [DataMember(Name = "purpose", Order = 212)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
-
-        /// <summary>
         /// A possible serious complication and/or serious side effect of this therapy. Serious adverse outcomes include those that are life-threatening; result in death, disability, or permanent damage; require hospitalization or prolong existing hospitalization; cause congenital anomalies or birth defects; or jeopardize the patient and may require medical or surgical intervention to prevent one of the outcomes in this definition.
         /// </summary>
-        [DataMember(Name = "seriousAdverseOutcome", Order = 213)]
+        [DataMember(Name = "seriousAdverseOutcome", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalEntity> SeriousAdverseOutcome { get; set; }
 
@@ -134,11 +110,9 @@
             return this.Type == other.Type &&
                 this.AdverseOutcome == other.AdverseOutcome &&
                 this.Contraindication == other.Contraindication &&
-                this.Indication == other.Indication &&
                 this.PostOp == other.PostOp &&
                 this.PreOp == other.PreOp &&
                 this.Procedure == other.Procedure &&
-                this.Purpose == other.Purpose &&
                 this.SeriousAdverseOutcome == other.SeriousAdverseOutcome &&
                 base.Equals(other);
         }
@@ -150,11 +124,9 @@
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.AdverseOutcome)
             .And(this.Contraindication)
-            .And(this.Indication)
             .And(this.PostOp)
             .And(this.PreOp)
             .And(this.Procedure)
-            .And(this.Purpose)
             .And(this.SeriousAdverseOutcome)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/MedicalProcedure.cs
+++ b/Source/Schema.NET/core/MedicalProcedure.cs
@@ -25,16 +25,6 @@
         OneOrMany<string> HowPerformed { get; set; }
 
         /// <summary>
-        /// A factor that indicates use of this therapy for treatment and/or prevention of a condition, symptom, etc. For therapies such as drugs, indications can include both officially-approved indications as well as off-label uses. These can be distinguished by using the ApprovedIndication subtype of MedicalIndication.
-        /// </summary>
-        OneOrMany<IMedicalIndication> Indication { get; set; }
-
-        /// <summary>
-        /// Expected or actual outcomes of the study.
-        /// </summary>
-        Values<IMedicalEntity, string> Outcome { get; set; }
-
-        /// <summary>
         /// Typical preparation that a patient must undergo before having the procedure performed.
         /// </summary>
         Values<IMedicalEntity, string> Preparation { get; set; }
@@ -84,37 +74,23 @@
         public OneOrMany<string> HowPerformed { get; set; }
 
         /// <summary>
-        /// A factor that indicates use of this therapy for treatment and/or prevention of a condition, symptom, etc. For therapies such as drugs, indications can include both officially-approved indications as well as off-label uses. These can be distinguished by using the ApprovedIndication subtype of MedicalIndication.
-        /// </summary>
-        [DataMember(Name = "indication", Order = 209)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public virtual OneOrMany<IMedicalIndication> Indication { get; set; }
-
-        /// <summary>
-        /// Expected or actual outcomes of the study.
-        /// </summary>
-        [DataMember(Name = "outcome", Order = 210)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalEntity, string> Outcome { get; set; }
-
-        /// <summary>
         /// Typical preparation that a patient must undergo before having the procedure performed.
         /// </summary>
-        [DataMember(Name = "preparation", Order = 211)]
+        [DataMember(Name = "preparation", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IMedicalEntity, string> Preparation { get; set; }
 
         /// <summary>
         /// The type of procedure, for example Surgical, Noninvasive, or Percutaneous.
         /// </summary>
-        [DataMember(Name = "procedureType", Order = 212)]
+        [DataMember(Name = "procedureType", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<MedicalProcedureType?> ProcedureType { get; set; }
 
         /// <summary>
         /// The status of the study (enumerated).
         /// </summary>
-        [DataMember(Name = "status", Order = 213)]
+        [DataMember(Name = "status", Order = 211)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
@@ -135,8 +111,6 @@
                 this.BodyLocation == other.BodyLocation &&
                 this.Followup == other.Followup &&
                 this.HowPerformed == other.HowPerformed &&
-                this.Indication == other.Indication &&
-                this.Outcome == other.Outcome &&
                 this.Preparation == other.Preparation &&
                 this.ProcedureType == other.ProcedureType &&
                 this.Status == other.Status &&
@@ -151,8 +125,6 @@
             .And(this.BodyLocation)
             .And(this.Followup)
             .And(this.HowPerformed)
-            .And(this.Indication)
-            .And(this.Outcome)
             .And(this.Preparation)
             .And(this.ProcedureType)
             .And(this.Status)

--- a/Source/Schema.NET/core/MedicalSignOrSymptom.cs
+++ b/Source/Schema.NET/core/MedicalSignOrSymptom.cs
@@ -24,16 +24,9 @@
         public override string Type => "MedicalSignOrSymptom";
 
         /// <summary>
-        /// Specifying a cause of something in general. e.g in medicine , one of the causative agent(s) that are most directly responsible for the pathophysiologic process that eventually results in the occurrence.
-        /// </summary>
-        [DataMember(Name = "cause", Order = 306)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public override OneOrMany<IMedicalCause> Cause { get; set; }
-
-        /// <summary>
         /// A possible treatment to address this condition, sign or symptom.
         /// </summary>
-        [DataMember(Name = "possibleTreatment", Order = 307)]
+        [DataMember(Name = "possibleTreatment", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IMedicalTherapy> PossibleTreatment { get; set; }
 
@@ -51,7 +44,6 @@
             }
 
             return this.Type == other.Type &&
-                this.Cause == other.Cause &&
                 this.PossibleTreatment == other.PossibleTreatment &&
                 base.Equals(other);
         }
@@ -61,7 +53,6 @@
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
-            .And(this.Cause)
             .And(this.PossibleTreatment)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/MedicalStudy.cs
+++ b/Source/Schema.NET/core/MedicalStudy.cs
@@ -15,16 +15,6 @@
         OneOrMany<IMedicalCondition> HealthCondition { get; set; }
 
         /// <summary>
-        /// Expected or actual outcomes of the study.
-        /// </summary>
-        Values<IMedicalEntity, string> Outcome { get; set; }
-
-        /// <summary>
-        /// Any characteristics of the population used in the study, e.g. 'males under 65'.
-        /// </summary>
-        OneOrMany<string> Population { get; set; }
-
-        /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
         Values<IOrganization, IPerson> Sponsor { get; set; }
@@ -65,44 +55,30 @@
         public OneOrMany<IMedicalCondition> HealthCondition { get; set; }
 
         /// <summary>
-        /// Expected or actual outcomes of the study.
-        /// </summary>
-        [DataMember(Name = "outcome", Order = 207)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IMedicalEntity, string> Outcome { get; set; }
-
-        /// <summary>
-        /// Any characteristics of the population used in the study, e.g. 'males under 65'.
-        /// </summary>
-        [DataMember(Name = "population", Order = 208)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> Population { get; set; }
-
-        /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 209)]
+        [DataMember(Name = "sponsor", Order = 207)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The status of the study (enumerated).
         /// </summary>
-        [DataMember(Name = "status", Order = 210)]
+        [DataMember(Name = "status", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<EventStatusType?, MedicalStudyStatus?, string> Status { get; set; }
 
         /// <summary>
         /// The location in which the study is taking/took place.
         /// </summary>
-        [DataMember(Name = "studyLocation", Order = 211)]
+        [DataMember(Name = "studyLocation", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAdministrativeArea> StudyLocation { get; set; }
 
         /// <summary>
         /// A subject of the study, i.e. one of the medical conditions, therapies, devices, drugs, etc. investigated by the study.
         /// </summary>
-        [DataMember(Name = "studySubject", Order = 212)]
+        [DataMember(Name = "studySubject", Order = 210)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMedicalEntity> StudySubject { get; set; }
 
@@ -121,8 +97,6 @@
 
             return this.Type == other.Type &&
                 this.HealthCondition == other.HealthCondition &&
-                this.Outcome == other.Outcome &&
-                this.Population == other.Population &&
                 this.Sponsor == other.Sponsor &&
                 this.Status == other.Status &&
                 this.StudyLocation == other.StudyLocation &&
@@ -136,8 +110,6 @@
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.HealthCondition)
-            .And(this.Outcome)
-            .And(this.Population)
             .And(this.Sponsor)
             .And(this.Status)
             .And(this.StudyLocation)

--- a/Source/Schema.NET/core/MedicalTrial.cs
+++ b/Source/Schema.NET/core/MedicalTrial.cs
@@ -10,11 +10,6 @@
     public partial interface IMedicalTrial : IMedicalStudy
     {
         /// <summary>
-        /// The phase of the clinical trial.
-        /// </summary>
-        OneOrMany<string> Phase { get; set; }
-
-        /// <summary>
         /// Specifics about the trial design (enumerated).
         /// </summary>
         OneOrMany<MedicalTrialDesign?> TrialDesign { get; set; }
@@ -33,16 +28,9 @@
         public override string Type => "MedicalTrial";
 
         /// <summary>
-        /// The phase of the clinical trial.
-        /// </summary>
-        [DataMember(Name = "phase", Order = 306)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> Phase { get; set; }
-
-        /// <summary>
         /// Specifics about the trial design (enumerated).
         /// </summary>
-        [DataMember(Name = "trialDesign", Order = 307)]
+        [DataMember(Name = "trialDesign", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<MedicalTrialDesign?> TrialDesign { get; set; }
 
@@ -60,7 +48,6 @@
             }
 
             return this.Type == other.Type &&
-                this.Phase == other.Phase &&
                 this.TrialDesign == other.TrialDesign &&
                 base.Equals(other);
         }
@@ -70,7 +57,6 @@
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
-            .And(this.Phase)
             .And(this.TrialDesign)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/MenuItem.cs
+++ b/Source/Schema.NET/core/MenuItem.cs
@@ -20,9 +20,9 @@
         OneOrMany<INutritionInformation> Nutrition { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        OneOrMany<IOffer> Offers { get; set; }
+        Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// Indicates a dietary restriction or guideline for which this recipe or menu item is suitable, e.g. diabetic, halal etc.
@@ -57,11 +57,11 @@
         public OneOrMany<INutritionInformation> Nutrition { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "offers", Order = 208)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// Indicates a dietary restriction or guideline for which this recipe or menu item is suitable, e.g. diabetic, halal etc.

--- a/Source/Schema.NET/core/Movie.cs
+++ b/Source/Schema.NET/core/Movie.cs
@@ -45,6 +45,13 @@
         Values<ILanguage, string> SubtitleLanguage { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing at the most general/abstract level, a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" has a titleEIDR of  "10.5240/7EC7-228A-510A-053E-CBB8-J". This title (or work) may have several variants, which EIDR calls "edits". See &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        Values<string, Uri> TitleEIDR { get; set; }
+
+        /// <summary>
         /// The trailer of a movie or tv/radio series, season, episode, etc.
         /// </summary>
         OneOrMany<IVideoObject> Trailer { get; set; }
@@ -112,9 +119,18 @@
         public Values<ILanguage, string> SubtitleLanguage { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing at the most general/abstract level, a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" has a titleEIDR of  "10.5240/7EC7-228A-510A-053E-CBB8-J". This title (or work) may have several variants, which EIDR calls "edits". See &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "titleEIDR", Order = 213)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> TitleEIDR { get; set; }
+
+        /// <summary>
         /// The trailer of a movie or tv/radio series, season, episode, etc.
         /// </summary>
-        [DataMember(Name = "trailer", Order = 213)]
+        [DataMember(Name = "trailer", Order = 214)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IVideoObject> Trailer { get; set; }
 
@@ -139,6 +155,7 @@
                 this.MusicBy == other.MusicBy &&
                 this.ProductionCompany == other.ProductionCompany &&
                 this.SubtitleLanguage == other.SubtitleLanguage &&
+                this.TitleEIDR == other.TitleEIDR &&
                 this.Trailer == other.Trailer &&
                 base.Equals(other);
         }
@@ -155,6 +172,7 @@
             .And(this.MusicBy)
             .And(this.ProductionCompany)
             .And(this.SubtitleLanguage)
+            .And(this.TitleEIDR)
             .And(this.Trailer)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/Muscle.cs
+++ b/Source/Schema.NET/core/Muscle.cs
@@ -10,11 +10,6 @@
     public partial interface IMuscle : IAnatomicalStructure
     {
         /// <summary>
-        /// Obsolete term for &lt;a class="localLink" href="http://schema.org/muscleAction"&gt;muscleAction&lt;/a&gt;. Not to be confused with &lt;a class="localLink" href="http://schema.org/potentialAction"&gt;potentialAction&lt;/a&gt;.
-        /// </summary>
-        OneOrMany<string> Action { get; set; }
-
-        /// <summary>
         /// The muscle whose action counteracts the specified muscle.
         /// </summary>
         OneOrMany<IMuscle> Antagonist { get; set; }
@@ -38,11 +33,6 @@
         /// The underlying innervation associated with the muscle.
         /// </summary>
         OneOrMany<INerve> Nerve { get; set; }
-
-        /// <summary>
-        /// The place or point where a muscle arises.
-        /// </summary>
-        OneOrMany<IAnatomicalStructure> Origin { get; set; }
     }
 
     /// <summary>
@@ -58,53 +48,39 @@
         public override string Type => "Muscle";
 
         /// <summary>
-        /// Obsolete term for &lt;a class="localLink" href="http://schema.org/muscleAction"&gt;muscleAction&lt;/a&gt;. Not to be confused with &lt;a class="localLink" href="http://schema.org/potentialAction"&gt;potentialAction&lt;/a&gt;.
-        /// </summary>
-        [DataMember(Name = "action", Order = 306)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<string> Action { get; set; }
-
-        /// <summary>
         /// The muscle whose action counteracts the specified muscle.
         /// </summary>
-        [DataMember(Name = "antagonist", Order = 307)]
+        [DataMember(Name = "antagonist", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMuscle> Antagonist { get; set; }
 
         /// <summary>
         /// The blood vessel that carries blood from the heart to the muscle.
         /// </summary>
-        [DataMember(Name = "bloodSupply", Order = 308)]
+        [DataMember(Name = "bloodSupply", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IVessel> BloodSupply { get; set; }
 
         /// <summary>
         /// The place of attachment of a muscle, or what the muscle moves.
         /// </summary>
-        [DataMember(Name = "insertion", Order = 309)]
+        [DataMember(Name = "insertion", Order = 308)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAnatomicalStructure> Insertion { get; set; }
 
         /// <summary>
         /// The movement the muscle generates.
         /// </summary>
-        [DataMember(Name = "muscleAction", Order = 310)]
+        [DataMember(Name = "muscleAction", Order = 309)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> MuscleAction { get; set; }
 
         /// <summary>
         /// The underlying innervation associated with the muscle.
         /// </summary>
-        [DataMember(Name = "nerve", Order = 311)]
+        [DataMember(Name = "nerve", Order = 310)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<INerve> Nerve { get; set; }
-
-        /// <summary>
-        /// The place or point where a muscle arises.
-        /// </summary>
-        [DataMember(Name = "origin", Order = 312)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IAnatomicalStructure> Origin { get; set; }
 
         /// <inheritdoc/>
         public bool Equals(Muscle other)
@@ -120,13 +96,11 @@
             }
 
             return this.Type == other.Type &&
-                this.Action == other.Action &&
                 this.Antagonist == other.Antagonist &&
                 this.BloodSupply == other.BloodSupply &&
                 this.Insertion == other.Insertion &&
                 this.MuscleAction == other.MuscleAction &&
                 this.Nerve == other.Nerve &&
-                this.Origin == other.Origin &&
                 base.Equals(other);
         }
 
@@ -135,13 +109,11 @@
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
-            .And(this.Action)
             .And(this.Antagonist)
             .And(this.BloodSupply)
             .And(this.Insertion)
             .And(this.MuscleAction)
             .And(this.Nerve)
-            .And(this.Origin)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/Offer.cs
+++ b/Source/Schema.NET/core/Offer.cs
@@ -6,6 +6,7 @@
 
     /// <summary>
     /// An offer to transfer some rights to an item or to provide a service — for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.&lt;br/&gt;&lt;br/&gt;
+    /// Note: As the &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; property, which identifies the form of offer (e.g. sell, lease, repair, dispose), defaults to http://purl.org/goodrelations/v1#Sell; an Offer without a defined businessFunction value can be assumed to be an offer to sell.&lt;br/&gt;&lt;br/&gt;
     /// For &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GTIN&lt;/a&gt;-related fields, see &lt;a href="http://www.gs1.org/barcodes/support/check_digit_calculator"&gt;Check Digit calculator&lt;/a&gt; and &lt;a href="http://www.gs1us.org/resources/standards/gtin-validation-guide"&gt;validation guide&lt;/a&gt; from &lt;a href="http://www.gs1.org/"&gt;GS1&lt;/a&gt;.
     /// </summary>
     public partial interface IOffer : IIntangible
@@ -148,9 +149,14 @@
         OneOrMany<OfferItemCondition?> ItemCondition { get; set; }
 
         /// <summary>
-        /// The item being offered.
+        /// An item being offered (or demanded). The transactional nature of the offer or demand is documented using &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt;, e.g. sell, lease etc. While several common expected types are listed explicitly in this definition, others can be used. Using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        Values<IProduct, IService> ItemOffered { get; set; }
+        Values<IAggregateOffer, ICreativeWork, IEvent, IMenuItem, IProduct, IService, ITrip> ItemOffered { get; set; }
+
+        /// <summary>
+        /// Length of the lease for some &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;, either particular to some &lt;a class="localLink" href="http://schema.org/Offer"&gt;Offer&lt;/a&gt; or in some cases intrinsic to the property.
+        /// </summary>
+        Values<TimeSpan?, IQuantitativeValue> LeaseLength { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
@@ -228,6 +234,7 @@
 
     /// <summary>
     /// An offer to transfer some rights to an item or to provide a service — for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.&lt;br/&gt;&lt;br/&gt;
+    /// Note: As the &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; property, which identifies the form of offer (e.g. sell, lease, repair, dispose), defaults to http://purl.org/goodrelations/v1#Sell; an Offer without a defined businessFunction value can be assumed to be an offer to sell.&lt;br/&gt;&lt;br/&gt;
     /// For &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GTIN&lt;/a&gt;-related fields, see &lt;a href="http://www.gs1.org/barcodes/support/check_digit_calculator"&gt;Check Digit calculator&lt;/a&gt; and &lt;a href="http://www.gs1us.org/resources/standards/gtin-validation-guide"&gt;validation guide&lt;/a&gt; from &lt;a href="http://www.gs1.org/"&gt;GS1&lt;/a&gt;.
     /// </summary>
     [DataContract]
@@ -431,23 +438,30 @@
         public OneOrMany<OfferItemCondition?> ItemCondition { get; set; }
 
         /// <summary>
-        /// The item being offered.
+        /// An item being offered (or demanded). The transactional nature of the offer or demand is documented using &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt;, e.g. sell, lease etc. While several common expected types are listed explicitly in this definition, others can be used. Using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "itemOffered", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IProduct, IService> ItemOffered { get; set; }
+        public Values<IAggregateOffer, ICreativeWork, IEvent, IMenuItem, IProduct, IService, ITrip> ItemOffered { get; set; }
+
+        /// <summary>
+        /// Length of the lease for some &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt;, either particular to some &lt;a class="localLink" href="http://schema.org/Offer"&gt;Offer&lt;/a&gt; or in some cases intrinsic to the property.
+        /// </summary>
+        [DataMember(Name = "leaseLength", Order = 234)]
+        [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
+        public Values<TimeSpan?, IQuantitativeValue> LeaseLength { get; set; }
 
         /// <summary>
         /// The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "mpn", Order = 234)]
+        [DataMember(Name = "mpn", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Mpn { get; set; }
 
         /// <summary>
         /// A pointer to the organization or person making the offer.
         /// </summary>
-        [DataMember(Name = "offeredBy", Order = 235)]
+        [DataMember(Name = "offeredBy", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> OfferedBy { get; set; }
 
@@ -461,7 +475,7 @@
         /// &lt;li&gt;Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        [DataMember(Name = "price", Order = 236)]
+        [DataMember(Name = "price", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<decimal?, string> Price { get; set; }
 
@@ -469,70 +483,70 @@
         /// The currency of the price, or a price component when attached to &lt;a class="localLink" href="http://schema.org/PriceSpecification"&gt;PriceSpecification&lt;/a&gt; and its subtypes.&lt;br/&gt;&lt;br/&gt;
         /// Use standard formats: &lt;a href="http://en.wikipedia.org/wiki/ISO_4217"&gt;ISO 4217 currency format&lt;/a&gt; e.g. "USD"; &lt;a href="https://en.wikipedia.org/wiki/List_of_cryptocurrencies"&gt;Ticker symbol&lt;/a&gt; for cryptocurrencies e.g. "BTC"; well known names for &lt;a href="https://en.wikipedia.org/wiki/Local_exchange_trading_system"&gt;Local Exchange Tradings Systems&lt;/a&gt; (LETS) and other currency types e.g. "Ithaca HOUR".
         /// </summary>
-        [DataMember(Name = "priceCurrency", Order = 237)]
+        [DataMember(Name = "priceCurrency", Order = 238)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PriceCurrency { get; set; }
 
         /// <summary>
         /// One or more detailed price specifications, indicating the unit price and delivery or payment charges.
         /// </summary>
-        [DataMember(Name = "priceSpecification", Order = 238)]
+        [DataMember(Name = "priceSpecification", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPriceSpecification> PriceSpecification { get; set; }
 
         /// <summary>
         /// The date after which the price is no longer available.
         /// </summary>
-        [DataMember(Name = "priceValidUntil", Order = 239)]
+        [DataMember(Name = "priceValidUntil", Order = 240)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> PriceValidUntil { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 240)]
+        [DataMember(Name = "review", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider.
         /// </summary>
-        [DataMember(Name = "seller", Order = 241)]
+        [DataMember(Name = "seller", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Seller { get; set; }
 
         /// <summary>
         /// The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer.
         /// </summary>
-        [DataMember(Name = "serialNumber", Order = 242)]
+        [DataMember(Name = "serialNumber", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> SerialNumber { get; set; }
 
         /// <summary>
         /// The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers.
         /// </summary>
-        [DataMember(Name = "sku", Order = 243)]
+        [DataMember(Name = "sku", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Sku { get; set; }
 
         /// <summary>
         /// The date when the item becomes valid.
         /// </summary>
-        [DataMember(Name = "validFrom", Order = 244)]
+        [DataMember(Name = "validFrom", Order = 245)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> ValidFrom { get; set; }
 
         /// <summary>
         /// The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
         /// </summary>
-        [DataMember(Name = "validThrough", Order = 245)]
+        [DataMember(Name = "validThrough", Order = 246)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> ValidThrough { get; set; }
 
         /// <summary>
         /// The warranty promise(s) included in the offer.
         /// </summary>
-        [DataMember(Name = "warranty", Order = 246)]
+        [DataMember(Name = "warranty", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IWarrantyPromise> Warranty { get; set; }
 
@@ -578,6 +592,7 @@
                 this.InventoryLevel == other.InventoryLevel &&
                 this.ItemCondition == other.ItemCondition &&
                 this.ItemOffered == other.ItemOffered &&
+                this.LeaseLength == other.LeaseLength &&
                 this.Mpn == other.Mpn &&
                 this.OfferedBy == other.OfferedBy &&
                 this.Price == other.Price &&
@@ -627,6 +642,7 @@
             .And(this.InventoryLevel)
             .And(this.ItemCondition)
             .And(this.ItemOffered)
+            .And(this.LeaseLength)
             .And(this.Mpn)
             .And(this.OfferedBy)
             .And(this.Price)

--- a/Source/Schema.NET/core/Organization.cs
+++ b/Source/Schema.NET/core/Organization.cs
@@ -140,6 +140,11 @@
         OneOrMany<IPlace> HasPOS { get; set; }
 
         /// <summary>
+        /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
+        /// </summary>
+        OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
+
+        /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
         OneOrMany<string> IsicV4 { get; set; }
@@ -461,107 +466,114 @@
         public OneOrMany<IPlace> HasPOS { get; set; }
 
         /// <summary>
+        /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
+        /// </summary>
+        [DataMember(Name = "interactionStatistic", Order = 132)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
+
+        /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 132)]
+        [DataMember(Name = "isicV4", Order = 133)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        [DataMember(Name = "knowsAbout", Order = 133)]
+        [DataMember(Name = "knowsAbout", Order = 134)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "knowsLanguage", Order = 134)]
+        [DataMember(Name = "knowsLanguage", Order = 135)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
         /// </summary>
-        [DataMember(Name = "legalName", Order = 135)]
+        [DataMember(Name = "legalName", Order = 136)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LegalName { get; set; }
 
         /// <summary>
         /// An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.
         /// </summary>
-        [DataMember(Name = "leiCode", Order = 136)]
+        [DataMember(Name = "leiCode", Order = 137)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LeiCode { get; set; }
 
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        [DataMember(Name = "location", Order = 137)]
+        [DataMember(Name = "location", Order = 138)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 138)]
+        [DataMember(Name = "logo", Order = 139)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
         /// </summary>
-        [DataMember(Name = "makesOffer", Order = 139)]
+        [DataMember(Name = "makesOffer", Order = 140)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> MakesOffer { get; set; }
 
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        [DataMember(Name = "member", Order = 140)]
+        [DataMember(Name = "member", Order = 141)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        [DataMember(Name = "memberOf", Order = 141)]
+        [DataMember(Name = "memberOf", Order = 142)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
         /// </summary>
-        [DataMember(Name = "naics", Order = 142)]
+        [DataMember(Name = "naics", Order = 143)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Naics { get; set; }
 
         /// <summary>
         /// The number of employees in an organization e.g. business.
         /// </summary>
-        [DataMember(Name = "numberOfEmployees", Order = 143)]
+        [DataMember(Name = "numberOfEmployees", Order = 144)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IQuantitativeValue> NumberOfEmployees { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt; is also available and can be used to make basic funder information machine-readable.
         /// </summary>
-        [DataMember(Name = "ownershipFundingInfo", Order = 144)]
+        [DataMember(Name = "ownershipFundingInfo", Order = 145)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        [DataMember(Name = "owns", Order = 145)]
+        [DataMember(Name = "owns", Order = 146)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
         /// </summary>
-        [DataMember(Name = "parentOrganization", Order = 146)]
+        [DataMember(Name = "parentOrganization", Order = 147)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> ParentOrganization { get; set; }
 
@@ -569,70 +581,70 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 147)]
+        [DataMember(Name = "publishingPrinciples", Order = 148)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 148)]
+        [DataMember(Name = "review", Order = 149)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A pointer to products or services sought by the organization or person (demand).
         /// </summary>
-        [DataMember(Name = "seeks", Order = 149)]
+        [DataMember(Name = "seeks", Order = 150)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDemand> Seeks { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 150)]
+        [DataMember(Name = "slogan", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 151)]
+        [DataMember(Name = "sponsor", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
         /// </summary>
-        [DataMember(Name = "subOrganization", Order = 152)]
+        [DataMember(Name = "subOrganization", Order = 153)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SubOrganization { get; set; }
 
         /// <summary>
         /// The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain.
         /// </summary>
-        [DataMember(Name = "taxID", Order = 153)]
+        [DataMember(Name = "taxID", Order = 154)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TaxID { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 154)]
+        [DataMember(Name = "telephone", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Telephone { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (typically a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement about policy on use of unnamed sources and the decision process required.
         /// </summary>
-        [DataMember(Name = "unnamedSourcesPolicy", Order = 155)]
+        [DataMember(Name = "unnamedSourcesPolicy", Order = 156)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
         /// </summary>
-        [DataMember(Name = "vatID", Order = 156)]
+        [DataMember(Name = "vatID", Order = 157)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> VatID { get; set; }
 
@@ -676,6 +688,7 @@
                 this.GlobalLocationNumber == other.GlobalLocationNumber &&
                 this.HasOfferCatalog == other.HasOfferCatalog &&
                 this.HasPOS == other.HasPOS &&
+                this.InteractionStatistic == other.InteractionStatistic &&
                 this.IsicV4 == other.IsicV4 &&
                 this.KnowsAbout == other.KnowsAbout &&
                 this.KnowsLanguage == other.KnowsLanguage &&
@@ -735,6 +748,7 @@
             .And(this.GlobalLocationNumber)
             .And(this.HasOfferCatalog)
             .And(this.HasPOS)
+            .And(this.InteractionStatistic)
             .And(this.IsicV4)
             .And(this.KnowsAbout)
             .And(this.KnowsLanguage)

--- a/Source/Schema.NET/core/PayAction.cs
+++ b/Source/Schema.NET/core/PayAction.cs
@@ -10,11 +10,6 @@
     public partial interface IPayAction : ITradeAction
     {
         /// <summary>
-        /// A goal towards an action is taken. Can be concrete or abstract.
-        /// </summary>
-        Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
-
-        /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
         Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
@@ -33,16 +28,9 @@
         public override string Type => "PayAction";
 
         /// <summary>
-        /// A goal towards an action is taken. Can be concrete or abstract.
-        /// </summary>
-        [DataMember(Name = "purpose", Order = 306)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<MedicalDevicePurpose?, IThing> Purpose { get; set; }
-
-        /// <summary>
         /// A sub property of participant. The participant who is at the receiving end of the action.
         /// </summary>
-        [DataMember(Name = "recipient", Order = 307)]
+        [DataMember(Name = "recipient", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAudience, IContactPoint, IOrganization, IPerson> Recipient { get; set; }
 
@@ -60,7 +48,6 @@
             }
 
             return this.Type == other.Type &&
-                this.Purpose == other.Purpose &&
                 this.Recipient == other.Recipient &&
                 base.Equals(other);
         }
@@ -70,7 +57,6 @@
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCode.Of(this.Type)
-            .And(this.Purpose)
             .And(this.Recipient)
             .And(base.GetHashCode());
     }

--- a/Source/Schema.NET/core/Person.cs
+++ b/Source/Schema.NET/core/Person.cs
@@ -160,6 +160,11 @@
         OneOrMany<string> HonorificSuffix { get; set; }
 
         /// <summary>
+        /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
+        /// </summary>
+        OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
+
+        /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
         OneOrMany<string> IsicV4 { get; set; }
@@ -509,93 +514,100 @@
         public OneOrMany<string> HonorificSuffix { get; set; }
 
         /// <summary>
+        /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
+        /// </summary>
+        [DataMember(Name = "interactionStatistic", Order = 136)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
+
+        /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 136)]
+        [DataMember(Name = "isicV4", Order = 137)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// The job title of the person (for example, Financial Manager).
         /// </summary>
-        [DataMember(Name = "jobTitle", Order = 137)]
+        [DataMember(Name = "jobTitle", Order = 138)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> JobTitle { get; set; }
 
         /// <summary>
         /// The most generic bi-directional social/work relation.
         /// </summary>
-        [DataMember(Name = "knows", Order = 138)]
+        [DataMember(Name = "knows", Order = 139)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Knows { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        [DataMember(Name = "knowsAbout", Order = 139)]
+        [DataMember(Name = "knowsAbout", Order = 140)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "knowsLanguage", Order = 140)]
+        [DataMember(Name = "knowsLanguage", Order = 141)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
         /// </summary>
-        [DataMember(Name = "makesOffer", Order = 141)]
+        [DataMember(Name = "makesOffer", Order = 142)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOffer> MakesOffer { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        [DataMember(Name = "memberOf", Order = 142)]
+        [DataMember(Name = "memberOf", Order = 143)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
         /// </summary>
-        [DataMember(Name = "naics", Order = 143)]
+        [DataMember(Name = "naics", Order = 144)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Naics { get; set; }
 
         /// <summary>
         /// Nationality of the person.
         /// </summary>
-        [DataMember(Name = "nationality", Order = 144)]
+        [DataMember(Name = "nationality", Order = 145)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICountry> Nationality { get; set; }
 
         /// <summary>
         /// The total financial value of the person as calculated by subtracting assets from liabilities.
         /// </summary>
-        [DataMember(Name = "netWorth", Order = 145)]
+        [DataMember(Name = "netWorth", Order = 146)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IMonetaryAmount, IPriceSpecification> NetWorth { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        [DataMember(Name = "owns", Order = 146)]
+        [DataMember(Name = "owns", Order = 147)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// A parent of this person.
         /// </summary>
-        [DataMember(Name = "parent", Order = 147)]
+        [DataMember(Name = "parent", Order = 148)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Parent { get; set; }
 
         /// <summary>
         /// Event that this person is a performer or participant in.
         /// </summary>
-        [DataMember(Name = "performerIn", Order = 148)]
+        [DataMember(Name = "performerIn", Order = 149)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> PerformerIn { get; set; }
 
@@ -603,84 +615,84 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 149)]
+        [DataMember(Name = "publishingPrinciples", Order = 150)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The most generic familial relation.
         /// </summary>
-        [DataMember(Name = "relatedTo", Order = 150)]
+        [DataMember(Name = "relatedTo", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> RelatedTo { get; set; }
 
         /// <summary>
         /// A pointer to products or services sought by the organization or person (demand).
         /// </summary>
-        [DataMember(Name = "seeks", Order = 151)]
+        [DataMember(Name = "seeks", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDemand> Seeks { get; set; }
 
         /// <summary>
         /// A sibling of the person.
         /// </summary>
-        [DataMember(Name = "sibling", Order = 152)]
+        [DataMember(Name = "sibling", Order = 153)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Sibling { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 153)]
+        [DataMember(Name = "sponsor", Order = 154)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// The person's spouse.
         /// </summary>
-        [DataMember(Name = "spouse", Order = 154)]
+        [DataMember(Name = "spouse", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Spouse { get; set; }
 
         /// <summary>
         /// The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain.
         /// </summary>
-        [DataMember(Name = "taxID", Order = 155)]
+        [DataMember(Name = "taxID", Order = 156)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TaxID { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 156)]
+        [DataMember(Name = "telephone", Order = 157)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Telephone { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
         /// </summary>
-        [DataMember(Name = "vatID", Order = 157)]
+        [DataMember(Name = "vatID", Order = 158)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> VatID { get; set; }
 
         /// <summary>
         /// The weight of the product or person.
         /// </summary>
-        [DataMember(Name = "weight", Order = 158)]
+        [DataMember(Name = "weight", Order = 159)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IQuantitativeValue> Weight { get; set; }
 
         /// <summary>
         /// A contact location for a person's place of work.
         /// </summary>
-        [DataMember(Name = "workLocation", Order = 159)]
+        [DataMember(Name = "workLocation", Order = 160)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IContactPoint, IPlace> WorkLocation { get; set; }
 
         /// <summary>
         /// Organizations that the person works for.
         /// </summary>
-        [DataMember(Name = "worksFor", Order = 160)]
+        [DataMember(Name = "worksFor", Order = 161)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> WorksFor { get; set; }
 
@@ -728,6 +740,7 @@
                 this.HomeLocation == other.HomeLocation &&
                 this.HonorificPrefix == other.HonorificPrefix &&
                 this.HonorificSuffix == other.HonorificSuffix &&
+                this.InteractionStatistic == other.InteractionStatistic &&
                 this.IsicV4 == other.IsicV4 &&
                 this.JobTitle == other.JobTitle &&
                 this.Knows == other.Knows &&
@@ -791,6 +804,7 @@
             .And(this.HomeLocation)
             .And(this.HonorificPrefix)
             .And(this.HonorificSuffix)
+            .And(this.InteractionStatistic)
             .And(this.IsicV4)
             .And(this.JobTitle)
             .And(this.Knows)

--- a/Source/Schema.NET/core/Place.cs
+++ b/Source/Schema.NET/core/Place.cs
@@ -117,6 +117,11 @@
         OneOrMany<string> GlobalLocationNumber { get; set; }
 
         /// <summary>
+        /// Indicates whether some facility (e.g. &lt;a class="localLink" href="http://schema.org/FoodEstablishment"&gt;FoodEstablishment&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt;) offers a service that can be used by driving through in a car. In the case of &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt; such facilities could potentially help with social distancing from other potentially-infected users.
+        /// </summary>
+        OneOrMany<bool?> HasDriveThroughService { get; set; }
+
+        /// <summary>
         /// A URL to a map of the place.
         /// </summary>
         Values<IMap, Uri> HasMap { get; set; }
@@ -191,6 +196,11 @@
         /// The telephone number.
         /// </summary>
         OneOrMany<string> Telephone { get; set; }
+
+        /// <summary>
+        /// A page providing information on how to book a tour of some &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt;, such as an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; in a real estate setting, as well as other kinds of tours as appropriate.
+        /// </summary>
+        OneOrMany<Uri> TourBookingPage { get; set; }
     }
 
     /// <summary>
@@ -355,93 +365,100 @@
         public OneOrMany<string> GlobalLocationNumber { get; set; }
 
         /// <summary>
+        /// Indicates whether some facility (e.g. &lt;a class="localLink" href="http://schema.org/FoodEstablishment"&gt;FoodEstablishment&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt;) offers a service that can be used by driving through in a car. In the case of &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt; such facilities could potentially help with social distancing from other potentially-infected users.
+        /// </summary>
+        [DataMember(Name = "hasDriveThroughService", Order = 127)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public OneOrMany<bool?> HasDriveThroughService { get; set; }
+
+        /// <summary>
         /// A URL to a map of the place.
         /// </summary>
-        [DataMember(Name = "hasMap", Order = 127)]
+        [DataMember(Name = "hasMap", Order = 128)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 128)]
+        [DataMember(Name = "isAccessibleForFree", Order = 129)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 129)]
+        [DataMember(Name = "isicV4", Order = 130)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "latitude", Order = 130)]
+        [DataMember(Name = "latitude", Order = 131)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 131)]
+        [DataMember(Name = "logo", Order = 132)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "longitude", Order = 132)]
+        [DataMember(Name = "longitude", Order = 133)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
         /// </summary>
-        [DataMember(Name = "maximumAttendeeCapacity", Order = 133)]
+        [DataMember(Name = "maximumAttendeeCapacity", Order = 134)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
         /// The opening hours of a certain place.
         /// </summary>
-        [DataMember(Name = "openingHoursSpecification", Order = 134)]
+        [DataMember(Name = "openingHoursSpecification", Order = 135)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOpeningHoursSpecification> OpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// A photograph of this place.
         /// </summary>
-        [DataMember(Name = "photo", Order = 135)]
+        [DataMember(Name = "photo", Order = 136)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
         /// </summary>
-        [DataMember(Name = "publicAccess", Order = 136)]
+        [DataMember(Name = "publicAccess", Order = 137)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> PublicAccess { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 137)]
+        [DataMember(Name = "review", Order = 138)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 138)]
+        [DataMember(Name = "slogan", Order = 139)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room.
         /// </summary>
-        [DataMember(Name = "smokingAllowed", Order = 139)]
+        [DataMember(Name = "smokingAllowed", Order = 140)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> SmokingAllowed { get; set; }
 
@@ -449,16 +466,23 @@
         /// The special opening hours of a certain place.&lt;br/&gt;&lt;br/&gt;
         /// Use this to explicitly override general opening hours brought in scope by &lt;a class="localLink" href="http://schema.org/openingHoursSpecification"&gt;openingHoursSpecification&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/openingHours"&gt;openingHours&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "specialOpeningHoursSpecification", Order = 140)]
+        [DataMember(Name = "specialOpeningHoursSpecification", Order = 141)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOpeningHoursSpecification> SpecialOpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 141)]
+        [DataMember(Name = "telephone", Order = 142)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Telephone { get; set; }
+
+        /// <summary>
+        /// A page providing information on how to book a tour of some &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt;, such as an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; in a real estate setting, as well as other kinds of tours as appropriate.
+        /// </summary>
+        [DataMember(Name = "tourBookingPage", Order = 143)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public virtual OneOrMany<Uri> TourBookingPage { get; set; }
 
         /// <inheritdoc/>
         public bool Equals(Place other)
@@ -495,6 +519,7 @@
                 this.GeoTouches == other.GeoTouches &&
                 this.GeoWithin == other.GeoWithin &&
                 this.GlobalLocationNumber == other.GlobalLocationNumber &&
+                this.HasDriveThroughService == other.HasDriveThroughService &&
                 this.HasMap == other.HasMap &&
                 this.IsAccessibleForFree == other.IsAccessibleForFree &&
                 this.IsicV4 == other.IsicV4 &&
@@ -510,6 +535,7 @@
                 this.SmokingAllowed == other.SmokingAllowed &&
                 this.SpecialOpeningHoursSpecification == other.SpecialOpeningHoursSpecification &&
                 this.Telephone == other.Telephone &&
+                this.TourBookingPage == other.TourBookingPage &&
                 base.Equals(other);
         }
 
@@ -539,6 +565,7 @@
             .And(this.GeoTouches)
             .And(this.GeoWithin)
             .And(this.GlobalLocationNumber)
+            .And(this.HasDriveThroughService)
             .And(this.HasMap)
             .And(this.IsAccessibleForFree)
             .And(this.IsicV4)
@@ -554,6 +581,7 @@
             .And(this.SmokingAllowed)
             .And(this.SpecialOpeningHoursSpecification)
             .And(this.Telephone)
+            .And(this.TourBookingPage)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/Product.cs
+++ b/Source/Schema.NET/core/Product.cs
@@ -136,9 +136,9 @@
         OneOrMany<string> Nsn { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        OneOrMany<IOffer> Offers { get; set; }
+        Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The product identifier, such as ISBN. For example: &lt;code&gt;meta itemprop="productID" content="isbn:123-456-789"&lt;/code&gt;.
@@ -375,11 +375,11 @@
         public OneOrMany<string> Nsn { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "offers", Order = 131)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The product identifier, such as ISBN. For example: &lt;code&gt;meta itemprop="productID" content="isbn:123-456-789"&lt;/code&gt;.

--- a/Source/Schema.NET/core/Service.cs
+++ b/Source/Schema.NET/core/Service.cs
@@ -75,9 +75,9 @@
         Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        OneOrMany<IOffer> Offers { get; set; }
+        Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
@@ -219,11 +219,11 @@
         public Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "offers", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.

--- a/Source/Schema.NET/core/SportsEvent.cs
+++ b/Source/Schema.NET/core/SportsEvent.cs
@@ -23,6 +23,11 @@
         /// The home team in a sports event.
         /// </summary>
         Values<IPerson, ISportsTeam> HomeTeam { get; set; }
+
+        /// <summary>
+        /// A type of sport (e.g. Baseball).
+        /// </summary>
+        Values<string, Uri> Sport { get; set; }
     }
 
     /// <summary>
@@ -58,6 +63,13 @@
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IPerson, ISportsTeam> HomeTeam { get; set; }
 
+        /// <summary>
+        /// A type of sport (e.g. Baseball).
+        /// </summary>
+        [DataMember(Name = "sport", Order = 209)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> Sport { get; set; }
+
         /// <inheritdoc/>
         public bool Equals(SportsEvent other)
         {
@@ -75,6 +87,7 @@
                 this.AwayTeam == other.AwayTeam &&
                 this.Competitor == other.Competitor &&
                 this.HomeTeam == other.HomeTeam &&
+                this.Sport == other.Sport &&
                 base.Equals(other);
         }
 
@@ -86,6 +99,7 @@
             .And(this.AwayTeam)
             .And(this.Competitor)
             .And(this.HomeTeam)
+            .And(this.Sport)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/TVEpisode.cs
+++ b/Source/Schema.NET/core/TVEpisode.cs
@@ -18,6 +18,13 @@
         /// Languages in which subtitles/captions are available, in &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard format&lt;/a&gt;.
         /// </summary>
         Values<ILanguage, string> SubtitleLanguage { get; set; }
+
+        /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing at the most general/abstract level, a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" has a titleEIDR of  "10.5240/7EC7-228A-510A-053E-CBB8-J". This title (or work) may have several variants, which EIDR calls "edits". See &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        Values<string, Uri> TitleEIDR { get; set; }
     }
 
     /// <summary>
@@ -46,6 +53,15 @@
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> SubtitleLanguage { get; set; }
 
+        /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing at the most general/abstract level, a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" has a titleEIDR of  "10.5240/7EC7-228A-510A-053E-CBB8-J". This title (or work) may have several variants, which EIDR calls "edits". See &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "titleEIDR", Order = 308)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> TitleEIDR { get; set; }
+
         /// <inheritdoc/>
         public bool Equals(TVEpisode other)
         {
@@ -62,6 +78,7 @@
             return this.Type == other.Type &&
                 this.CountryOfOrigin == other.CountryOfOrigin &&
                 this.SubtitleLanguage == other.SubtitleLanguage &&
+                this.TitleEIDR == other.TitleEIDR &&
                 base.Equals(other);
         }
 
@@ -72,6 +89,7 @@
         public override int GetHashCode() => HashCode.Of(this.Type)
             .And(this.CountryOfOrigin)
             .And(this.SubtitleLanguage)
+            .And(this.TitleEIDR)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/TherapeuticProcedure.cs
+++ b/Source/Schema.NET/core/TherapeuticProcedure.cs
@@ -58,13 +58,6 @@
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IDrug> Drug { get; set; }
 
-        /// <summary>
-        /// A factor that indicates use of this therapy for treatment and/or prevention of a condition, symptom, etc. For therapies such as drugs, indications can include both officially-approved indications as well as off-label uses. These can be distinguished by using the ApprovedIndication subtype of MedicalIndication.
-        /// </summary>
-        [DataMember(Name = "indication", Order = 309)]
-        [JsonConverter(typeof(ValuesJsonConverter))]
-        public override OneOrMany<IMedicalIndication> Indication { get; set; }
-
         /// <inheritdoc/>
         public bool Equals(TherapeuticProcedure other)
         {
@@ -82,7 +75,6 @@
                 this.AdverseOutcome == other.AdverseOutcome &&
                 this.DoseSchedule == other.DoseSchedule &&
                 this.Drug == other.Drug &&
-                this.Indication == other.Indication &&
                 base.Equals(other);
         }
 
@@ -94,7 +86,6 @@
             .And(this.AdverseOutcome)
             .And(this.DoseSchedule)
             .And(this.Drug)
-            .And(this.Indication)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/Trip.cs
+++ b/Source/Schema.NET/core/Trip.cs
@@ -25,9 +25,9 @@
         Values<IItemList, IPlace> Itinerary { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        OneOrMany<IOffer> Offers { get; set; }
+        Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// Identifies that this &lt;a class="localLink" href="http://schema.org/Trip"&gt;Trip&lt;/a&gt; is a subTrip of another Trip.  For example Day 1, Day 2, etc. of a multi-day trip.
@@ -79,11 +79,11 @@
         public Values<IItemList, IPlace> Itinerary { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
         [DataMember(Name = "offers", Order = 209)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// Identifies that this &lt;a class="localLink" href="http://schema.org/Trip"&gt;Trip&lt;/a&gt; is a subTrip of another Trip.  For example Day 1, Day 2, etc. of a multi-day trip.

--- a/Source/Schema.NET/core/VideoGallery.cs
+++ b/Source/Schema.NET/core/VideoGallery.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Web page type: Video gallery page.
     /// </summary>
-    public partial interface IVideoGallery : ICollectionPage
+    public partial interface IVideoGallery : IMediaGallery
     {
     }
 
@@ -15,7 +15,7 @@
     /// Web page type: Video gallery page.
     /// </summary>
     [DataContract]
-    public partial class VideoGallery : CollectionPage, IVideoGallery, IEquatable<VideoGallery>
+    public partial class VideoGallery : MediaGallery, IVideoGallery, IEquatable<VideoGallery>
     {
         /// <summary>
         /// Gets the name of the type as specified by schema.org.

--- a/Source/Schema.NET/core/combined/CivicStructureAndEmergencyService.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndEmergencyService.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, EmergencyService for more information.
     /// </summary>
-    public partial interface ICivicStructureAndEmergencyService : ICivicStructure, IEmergencyService
+    public partial interface ICivicStructureAndEmergencyService : IEmergencyService, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CivicStructureAndEmergencyServiceAndMedicalOrganization.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndEmergencyServiceAndMedicalOrganization.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, EmergencyService, MedicalOrganization for more information.
     /// </summary>
-    public partial interface ICivicStructureAndEmergencyServiceAndMedicalOrganization : ICivicStructure, IEmergencyService, IMedicalOrganization
+    public partial interface ICivicStructureAndEmergencyServiceAndMedicalOrganization : IEmergencyService, IMedicalOrganization, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CivicStructureAndEntertainmentBusiness.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndEntertainmentBusiness.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, EntertainmentBusiness for more information.
     /// </summary>
-    public partial interface ICivicStructureAndEntertainmentBusiness : ICivicStructure, IEntertainmentBusiness
+    public partial interface ICivicStructureAndEntertainmentBusiness : IEntertainmentBusiness, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CivicStructureAndLodgingBusiness.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndLodgingBusiness.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, LodgingBusiness for more information.
     /// </summary>
-    public partial interface ICivicStructureAndLodgingBusiness : ICivicStructure, ILodgingBusiness
+    public partial interface ICivicStructureAndLodgingBusiness : ILodgingBusiness, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CivicStructureAndSportsActivityLocation.cs
+++ b/Source/Schema.NET/core/combined/CivicStructureAndSportsActivityLocation.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See CivicStructure, SportsActivityLocation for more information.
     /// </summary>
-    public partial interface ICivicStructureAndSportsActivityLocation : ICivicStructure, ISportsActivityLocation
+    public partial interface ICivicStructureAndSportsActivityLocation : ISportsActivityLocation, ICivicStructure
     {
     }
 

--- a/Source/Schema.NET/core/combined/CreativeWorkAndItemListAndListItem.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndItemListAndListItem.cs
@@ -94,79 +94,86 @@
         public OneOrMany<IPerson> AccountablePerson { get; set; }
 
         /// <summary>
+        /// Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item.
+        /// </summary>
+        [DataMember(Name = "acquireLicensePage", Order = 216)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> AcquireLicensePage { get; set; }
+
+        /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
         /// </summary>
-        [DataMember(Name = "aggregateRating", Order = 216)]
+        [DataMember(Name = "aggregateRating", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAggregateRating> AggregateRating { get; set; }
 
         /// <summary>
         /// A secondary title of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "alternativeHeadline", Order = 217)]
+        [DataMember(Name = "alternativeHeadline", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> AlternativeHeadline { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for encoding.
         /// </summary>
-        [DataMember(Name = "associatedMedia", Order = 218)]
+        [DataMember(Name = "associatedMedia", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> AssociatedMedia { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
         /// </summary>
-        [DataMember(Name = "audience", Order = 219)]
+        [DataMember(Name = "audience", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAudience> Audience { get; set; }
 
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        [DataMember(Name = "audio", Order = 220)]
+        [DataMember(Name = "audio", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        [DataMember(Name = "author", Order = 221)]
+        [DataMember(Name = "author", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
         /// </summary>
-        [DataMember(Name = "award", Order = 222)]
+        [DataMember(Name = "award", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Award { get; set; }
 
         /// <summary>
         /// Fictional person connected with a creative work.
         /// </summary>
-        [DataMember(Name = "character", Order = 223)]
+        [DataMember(Name = "character", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Character { get; set; }
 
         /// <summary>
         /// A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
         /// </summary>
-        [DataMember(Name = "citation", Order = 224)]
+        [DataMember(Name = "citation", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
         /// </summary>
-        [DataMember(Name = "comment", Order = 225)]
+        [DataMember(Name = "comment", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IComment> Comment { get; set; }
 
         /// <summary>
         /// The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
         /// </summary>
-        [DataMember(Name = "commentCount", Order = 226)]
+        [DataMember(Name = "commentCount", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CommentCount { get; set; }
 
@@ -174,126 +181,135 @@
         /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
         /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
         /// </summary>
-        [DataMember(Name = "conditionsOfAccess", Order = 227)]
+        [DataMember(Name = "conditionsOfAccess", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ConditionsOfAccess { get; set; }
 
         /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 228)]
+        [DataMember(Name = "contentLocation", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 229)]
+        [DataMember(Name = "contentRating", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 230)]
+        [DataMember(Name = "contentReferenceTime", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 231)]
+        [DataMember(Name = "contributor", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 232)]
+        [DataMember(Name = "copyrightHolder", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 233)]
+        [DataMember(Name = "copyrightYear", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 234)]
+        [DataMember(Name = "correction", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Correction { get; set; }
 
         /// <summary>
         /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
         /// </summary>
-        [DataMember(Name = "creativeWorkStatus", Order = 235)]
+        [DataMember(Name = "creativeWorkStatus", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 236)]
+        [DataMember(Name = "creator", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 237)]
+        [DataMember(Name = "dateCreated", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 238)]
+        [DataMember(Name = "dateModified", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 239)]
+        [DataMember(Name = "datePublished", Order = 240)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 240)]
+        [DataMember(Name = "discussionUrl", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing a specific edit / edition for a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" whose &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "editEIDR", Order = 242)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> EditEIDR { get; set; }
+
+        /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 241)]
+        [DataMember(Name = "editor", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 242)]
+        [DataMember(Name = "educationalAlignment", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 243)]
+        [DataMember(Name = "educationalUse", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 244)]
+        [DataMember(Name = "encoding", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -302,105 +318,105 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 245)]
+        [DataMember(Name = "encodingFormat", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 246)]
+        [DataMember(Name = "exampleOfWork", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 247)]
+        [DataMember(Name = "expires", Order = 249)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 248)]
+        [DataMember(Name = "funder", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 249)]
+        [DataMember(Name = "genre", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 250)]
+        [DataMember(Name = "hasPart", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 251)]
+        [DataMember(Name = "headline", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 252)]
+        [DataMember(Name = "inLanguage", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 253)]
+        [DataMember(Name = "interactionStatistic", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 254)]
+        [DataMember(Name = "interactivityType", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 255)]
+        [DataMember(Name = "isAccessibleForFree", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 256)]
+        [DataMember(Name = "isBasedOn", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 257)]
+        [DataMember(Name = "isFamilyFriendly", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 258)]
+        [DataMember(Name = "isPartOf", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.
         /// </summary>
-        [DataMember(Name = "item", Order = 259)]
+        [DataMember(Name = "item", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Item { get; set; }
 
@@ -409,147 +425,147 @@
         /// Text values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.&lt;br/&gt;&lt;br/&gt;
         /// Note: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases.
         /// </summary>
-        [DataMember(Name = "itemListElement", Order = 260)]
+        [DataMember(Name = "itemListElement", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IListItem, string, IThing> ItemListElement { get; set; }
 
         /// <summary>
         /// Type of ordering (e.g. Ascending, Descending, Unordered).
         /// </summary>
-        [DataMember(Name = "itemListOrder", Order = 261)]
+        [DataMember(Name = "itemListOrder", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ItemListOrderType?, string> ItemListOrder { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 262)]
+        [DataMember(Name = "keywords", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 263)]
+        [DataMember(Name = "learningResourceType", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 264)]
+        [DataMember(Name = "license", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 265)]
+        [DataMember(Name = "locationCreated", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 266)]
+        [DataMember(Name = "mainEntity", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
         /// </summary>
-        [DataMember(Name = "maintainer", Order = 267)]
+        [DataMember(Name = "maintainer", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Maintainer { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 268)]
+        [DataMember(Name = "material", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 269)]
+        [DataMember(Name = "materialExtent", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 270)]
+        [DataMember(Name = "mentions", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// A link to the ListItem that follows the current one.
         /// </summary>
-        [DataMember(Name = "nextItem", Order = 271)]
+        [DataMember(Name = "nextItem", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> NextItem { get; set; }
 
         /// <summary>
         /// The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list.
         /// </summary>
-        [DataMember(Name = "numberOfItems", Order = 272)]
+        [DataMember(Name = "numberOfItems", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> NumberOfItems { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 273)]
+        [DataMember(Name = "offers", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 274)]
+        [DataMember(Name = "position", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.
         /// </summary>
-        [DataMember(Name = "previousItem", Order = 275)]
+        [DataMember(Name = "previousItem", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> PreviousItem { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 276)]
+        [DataMember(Name = "producer", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 277)]
+        [DataMember(Name = "provider", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 278)]
+        [DataMember(Name = "publication", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 279)]
+        [DataMember(Name = "publisher", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 280)]
+        [DataMember(Name = "publisherImprint", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -557,49 +573,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 281)]
+        [DataMember(Name = "publishingPrinciples", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 282)]
+        [DataMember(Name = "recordedAt", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 283)]
+        [DataMember(Name = "releasedEvent", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 284)]
+        [DataMember(Name = "review", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 285)]
+        [DataMember(Name = "schemaVersion", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 286)]
+        [DataMember(Name = "sdDatePublished", Order = 288)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 287)]
+        [DataMember(Name = "sdLicense", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -607,14 +623,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 288)]
+        [DataMember(Name = "sdPublisher", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 289)]
+        [DataMember(Name = "sourceOrganization", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -622,7 +638,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 290)]
+        [DataMember(Name = "spatial", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -631,14 +647,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 291)]
+        [DataMember(Name = "spatialCoverage", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 292)]
+        [DataMember(Name = "sponsor", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -646,7 +662,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 293)]
+        [DataMember(Name = "temporal", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -656,77 +672,85 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 294)]
+        [DataMember(Name = "temporalCoverage", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 295)]
+        [DataMember(Name = "text", Order = 297)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 296)]
+        [DataMember(Name = "thumbnailUrl", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 297)]
+        [DataMember(Name = "timeRequired", Order = 299)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 298)]
+        [DataMember(Name = "translationOfWork", Order = 300)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 299)]
+        [DataMember(Name = "translator", Order = 301)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 300)]
+        [DataMember(Name = "typicalAgeRange", Order = 302)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
+        /// The schema.org &lt;a class="localLink" href="http://schema.org/usageInfo"&gt;usageInfo&lt;/a&gt; property indicates further information about a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.&lt;br/&gt;&lt;br/&gt;
+        /// This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+        /// </summary>
+        [DataMember(Name = "usageInfo", Order = 303)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> UsageInfo { get; set; }
+
+        /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 301)]
+        [DataMember(Name = "version", Order = 304)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 302)]
+        [DataMember(Name = "video", Order = 305)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 303)]
+        [DataMember(Name = "workExample", Order = 306)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 304)]
+        [DataMember(Name = "workTranslation", Order = 307)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -754,6 +778,7 @@
                 this.AccessMode == other.AccessMode &&
                 this.AccessModeSufficient == other.AccessModeSufficient &&
                 this.AccountablePerson == other.AccountablePerson &&
+                this.AcquireLicensePage == other.AcquireLicensePage &&
                 this.AggregateRating == other.AggregateRating &&
                 this.AlternativeHeadline == other.AlternativeHeadline &&
                 this.AssociatedMedia == other.AssociatedMedia &&
@@ -779,6 +804,7 @@
                 this.DateModified == other.DateModified &&
                 this.DatePublished == other.DatePublished &&
                 this.DiscussionUrl == other.DiscussionUrl &&
+                this.EditEIDR == other.EditEIDR &&
                 this.Editor == other.Editor &&
                 this.EducationalAlignment == other.EducationalAlignment &&
                 this.EducationalUse == other.EducationalUse &&
@@ -839,6 +865,7 @@
                 this.TranslationOfWork == other.TranslationOfWork &&
                 this.Translator == other.Translator &&
                 this.TypicalAgeRange == other.TypicalAgeRange &&
+                this.UsageInfo == other.UsageInfo &&
                 this.Version == other.Version &&
                 this.Video == other.Video &&
                 this.WorkExample == other.WorkExample &&
@@ -861,6 +888,7 @@
             .And(this.AccessMode)
             .And(this.AccessModeSufficient)
             .And(this.AccountablePerson)
+            .And(this.AcquireLicensePage)
             .And(this.AggregateRating)
             .And(this.AlternativeHeadline)
             .And(this.AssociatedMedia)
@@ -886,6 +914,7 @@
             .And(this.DateModified)
             .And(this.DatePublished)
             .And(this.DiscussionUrl)
+            .And(this.EditEIDR)
             .And(this.Editor)
             .And(this.EducationalAlignment)
             .And(this.EducationalUse)
@@ -946,6 +975,7 @@
             .And(this.TranslationOfWork)
             .And(this.Translator)
             .And(this.TypicalAgeRange)
+            .And(this.UsageInfo)
             .And(this.Version)
             .And(this.Video)
             .And(this.WorkExample)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndItemListAndListItem.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndItemListAndListItem.cs
@@ -126,7 +126,7 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip> Audio { get; set; }
+        public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
@@ -260,7 +260,7 @@
         /// </summary>
         [DataMember(Name = "datePublished", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?> DatePublished { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -395,7 +395,7 @@
         /// </summary>
         [DataMember(Name = "isPartOf", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<ICreativeWork> IsPartOf { get; set; }
+        public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.
@@ -456,93 +456,100 @@
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
+        /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+        /// </summary>
+        [DataMember(Name = "maintainer", Order = 267)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<IOrganization, IPerson> Maintainer { get; set; }
+
+        /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 267)]
+        [DataMember(Name = "material", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 268)]
+        [DataMember(Name = "materialExtent", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 269)]
+        [DataMember(Name = "mentions", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// A link to the ListItem that follows the current one.
         /// </summary>
-        [DataMember(Name = "nextItem", Order = 270)]
+        [DataMember(Name = "nextItem", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> NextItem { get; set; }
 
         /// <summary>
         /// The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list.
         /// </summary>
-        [DataMember(Name = "numberOfItems", Order = 271)]
+        [DataMember(Name = "numberOfItems", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> NumberOfItems { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 272)]
+        [DataMember(Name = "offers", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 273)]
+        [DataMember(Name = "position", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.
         /// </summary>
-        [DataMember(Name = "previousItem", Order = 274)]
+        [DataMember(Name = "previousItem", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> PreviousItem { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 275)]
+        [DataMember(Name = "producer", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 276)]
+        [DataMember(Name = "provider", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 277)]
+        [DataMember(Name = "publication", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 278)]
+        [DataMember(Name = "publisher", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 279)]
+        [DataMember(Name = "publisherImprint", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -550,49 +557,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 280)]
+        [DataMember(Name = "publishingPrinciples", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 281)]
+        [DataMember(Name = "recordedAt", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 282)]
+        [DataMember(Name = "releasedEvent", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 283)]
+        [DataMember(Name = "review", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 284)]
+        [DataMember(Name = "schemaVersion", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 285)]
+        [DataMember(Name = "sdDatePublished", Order = 286)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 286)]
+        [DataMember(Name = "sdLicense", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -600,14 +607,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 287)]
+        [DataMember(Name = "sdPublisher", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 288)]
+        [DataMember(Name = "sourceOrganization", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -615,7 +622,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 289)]
+        [DataMember(Name = "spatial", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -624,14 +631,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 290)]
+        [DataMember(Name = "spatialCoverage", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 291)]
+        [DataMember(Name = "sponsor", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -639,7 +646,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 292)]
+        [DataMember(Name = "temporal", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -649,77 +656,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 293)]
+        [DataMember(Name = "temporalCoverage", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 294)]
+        [DataMember(Name = "text", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 295)]
+        [DataMember(Name = "thumbnailUrl", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 296)]
+        [DataMember(Name = "timeRequired", Order = 297)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 297)]
+        [DataMember(Name = "translationOfWork", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 298)]
+        [DataMember(Name = "translator", Order = 299)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 299)]
+        [DataMember(Name = "typicalAgeRange", Order = 300)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 300)]
+        [DataMember(Name = "version", Order = 301)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 301)]
+        [DataMember(Name = "video", Order = 302)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 302)]
+        [DataMember(Name = "workExample", Order = 303)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 303)]
+        [DataMember(Name = "workTranslation", Order = 304)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -798,6 +805,7 @@
                 this.License == other.License &&
                 this.LocationCreated == other.LocationCreated &&
                 this.MainEntity == other.MainEntity &&
+                this.Maintainer == other.Maintainer &&
                 this.Material == other.Material &&
                 this.MaterialExtent == other.MaterialExtent &&
                 this.Mentions == other.Mentions &&
@@ -904,6 +912,7 @@
             .And(this.License)
             .And(this.LocationCreated)
             .And(this.MainEntity)
+            .And(this.Maintainer)
             .And(this.Material)
             .And(this.MaterialExtent)
             .And(this.Mentions)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndLifestyleModification.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndLifestyleModification.cs
@@ -94,79 +94,86 @@
         public OneOrMany<IPerson> AccountablePerson { get; set; }
 
         /// <summary>
+        /// Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item.
+        /// </summary>
+        [DataMember(Name = "acquireLicensePage", Order = 216)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> AcquireLicensePage { get; set; }
+
+        /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
         /// </summary>
-        [DataMember(Name = "aggregateRating", Order = 216)]
+        [DataMember(Name = "aggregateRating", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAggregateRating> AggregateRating { get; set; }
 
         /// <summary>
         /// A secondary title of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "alternativeHeadline", Order = 217)]
+        [DataMember(Name = "alternativeHeadline", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> AlternativeHeadline { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for encoding.
         /// </summary>
-        [DataMember(Name = "associatedMedia", Order = 218)]
+        [DataMember(Name = "associatedMedia", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> AssociatedMedia { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
         /// </summary>
-        [DataMember(Name = "audience", Order = 219)]
+        [DataMember(Name = "audience", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAudience> Audience { get; set; }
 
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        [DataMember(Name = "audio", Order = 220)]
+        [DataMember(Name = "audio", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        [DataMember(Name = "author", Order = 221)]
+        [DataMember(Name = "author", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
         /// </summary>
-        [DataMember(Name = "award", Order = 222)]
+        [DataMember(Name = "award", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Award { get; set; }
 
         /// <summary>
         /// Fictional person connected with a creative work.
         /// </summary>
-        [DataMember(Name = "character", Order = 223)]
+        [DataMember(Name = "character", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Character { get; set; }
 
         /// <summary>
         /// A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
         /// </summary>
-        [DataMember(Name = "citation", Order = 224)]
+        [DataMember(Name = "citation", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
         /// </summary>
-        [DataMember(Name = "comment", Order = 225)]
+        [DataMember(Name = "comment", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IComment> Comment { get; set; }
 
         /// <summary>
         /// The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
         /// </summary>
-        [DataMember(Name = "commentCount", Order = 226)]
+        [DataMember(Name = "commentCount", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CommentCount { get; set; }
 
@@ -174,126 +181,135 @@
         /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
         /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
         /// </summary>
-        [DataMember(Name = "conditionsOfAccess", Order = 227)]
+        [DataMember(Name = "conditionsOfAccess", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ConditionsOfAccess { get; set; }
 
         /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 228)]
+        [DataMember(Name = "contentLocation", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 229)]
+        [DataMember(Name = "contentRating", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 230)]
+        [DataMember(Name = "contentReferenceTime", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 231)]
+        [DataMember(Name = "contributor", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 232)]
+        [DataMember(Name = "copyrightHolder", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 233)]
+        [DataMember(Name = "copyrightYear", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 234)]
+        [DataMember(Name = "correction", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Correction { get; set; }
 
         /// <summary>
         /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
         /// </summary>
-        [DataMember(Name = "creativeWorkStatus", Order = 235)]
+        [DataMember(Name = "creativeWorkStatus", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 236)]
+        [DataMember(Name = "creator", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 237)]
+        [DataMember(Name = "dateCreated", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 238)]
+        [DataMember(Name = "dateModified", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 239)]
+        [DataMember(Name = "datePublished", Order = 240)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 240)]
+        [DataMember(Name = "discussionUrl", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing a specific edit / edition for a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" whose &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "editEIDR", Order = 242)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> EditEIDR { get; set; }
+
+        /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 241)]
+        [DataMember(Name = "editor", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 242)]
+        [DataMember(Name = "educationalAlignment", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 243)]
+        [DataMember(Name = "educationalUse", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 244)]
+        [DataMember(Name = "encoding", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -302,210 +318,210 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 245)]
+        [DataMember(Name = "encodingFormat", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 246)]
+        [DataMember(Name = "exampleOfWork", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 247)]
+        [DataMember(Name = "expires", Order = 249)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 248)]
+        [DataMember(Name = "funder", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 249)]
+        [DataMember(Name = "genre", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 250)]
+        [DataMember(Name = "hasPart", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 251)]
+        [DataMember(Name = "headline", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 252)]
+        [DataMember(Name = "inLanguage", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 253)]
+        [DataMember(Name = "interactionStatistic", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 254)]
+        [DataMember(Name = "interactivityType", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 255)]
+        [DataMember(Name = "isAccessibleForFree", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 256)]
+        [DataMember(Name = "isBasedOn", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 257)]
+        [DataMember(Name = "isFamilyFriendly", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 258)]
+        [DataMember(Name = "isPartOf", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 259)]
+        [DataMember(Name = "keywords", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 260)]
+        [DataMember(Name = "learningResourceType", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 261)]
+        [DataMember(Name = "license", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 262)]
+        [DataMember(Name = "locationCreated", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 263)]
+        [DataMember(Name = "mainEntity", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
         /// </summary>
-        [DataMember(Name = "maintainer", Order = 264)]
+        [DataMember(Name = "maintainer", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Maintainer { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 265)]
+        [DataMember(Name = "material", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 266)]
+        [DataMember(Name = "materialExtent", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 267)]
+        [DataMember(Name = "mentions", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 268)]
+        [DataMember(Name = "offers", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 269)]
+        [DataMember(Name = "position", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 270)]
+        [DataMember(Name = "producer", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 271)]
+        [DataMember(Name = "provider", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 272)]
+        [DataMember(Name = "publication", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 273)]
+        [DataMember(Name = "publisher", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 274)]
+        [DataMember(Name = "publisherImprint", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -513,49 +529,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 275)]
+        [DataMember(Name = "publishingPrinciples", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 276)]
+        [DataMember(Name = "recordedAt", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 277)]
+        [DataMember(Name = "releasedEvent", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 278)]
+        [DataMember(Name = "review", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 279)]
+        [DataMember(Name = "schemaVersion", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 280)]
+        [DataMember(Name = "sdDatePublished", Order = 282)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 281)]
+        [DataMember(Name = "sdLicense", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -563,14 +579,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 282)]
+        [DataMember(Name = "sdPublisher", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 283)]
+        [DataMember(Name = "sourceOrganization", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -578,7 +594,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 284)]
+        [DataMember(Name = "spatial", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -587,14 +603,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 285)]
+        [DataMember(Name = "spatialCoverage", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 286)]
+        [DataMember(Name = "sponsor", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -602,7 +618,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 287)]
+        [DataMember(Name = "temporal", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -612,77 +628,85 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 288)]
+        [DataMember(Name = "temporalCoverage", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 289)]
+        [DataMember(Name = "text", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 290)]
+        [DataMember(Name = "thumbnailUrl", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 291)]
+        [DataMember(Name = "timeRequired", Order = 293)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 292)]
+        [DataMember(Name = "translationOfWork", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 293)]
+        [DataMember(Name = "translator", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 294)]
+        [DataMember(Name = "typicalAgeRange", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
+        /// The schema.org &lt;a class="localLink" href="http://schema.org/usageInfo"&gt;usageInfo&lt;/a&gt; property indicates further information about a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.&lt;br/&gt;&lt;br/&gt;
+        /// This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+        /// </summary>
+        [DataMember(Name = "usageInfo", Order = 297)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> UsageInfo { get; set; }
+
+        /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 295)]
+        [DataMember(Name = "version", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 296)]
+        [DataMember(Name = "video", Order = 299)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 297)]
+        [DataMember(Name = "workExample", Order = 300)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 298)]
+        [DataMember(Name = "workTranslation", Order = 301)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -710,6 +734,7 @@
                 this.AccessMode == other.AccessMode &&
                 this.AccessModeSufficient == other.AccessModeSufficient &&
                 this.AccountablePerson == other.AccountablePerson &&
+                this.AcquireLicensePage == other.AcquireLicensePage &&
                 this.AggregateRating == other.AggregateRating &&
                 this.AlternativeHeadline == other.AlternativeHeadline &&
                 this.AssociatedMedia == other.AssociatedMedia &&
@@ -735,6 +760,7 @@
                 this.DateModified == other.DateModified &&
                 this.DatePublished == other.DatePublished &&
                 this.DiscussionUrl == other.DiscussionUrl &&
+                this.EditEIDR == other.EditEIDR &&
                 this.Editor == other.Editor &&
                 this.EducationalAlignment == other.EducationalAlignment &&
                 this.EducationalUse == other.EducationalUse &&
@@ -789,6 +815,7 @@
                 this.TranslationOfWork == other.TranslationOfWork &&
                 this.Translator == other.Translator &&
                 this.TypicalAgeRange == other.TypicalAgeRange &&
+                this.UsageInfo == other.UsageInfo &&
                 this.Version == other.Version &&
                 this.Video == other.Video &&
                 this.WorkExample == other.WorkExample &&
@@ -811,6 +838,7 @@
             .And(this.AccessMode)
             .And(this.AccessModeSufficient)
             .And(this.AccountablePerson)
+            .And(this.AcquireLicensePage)
             .And(this.AggregateRating)
             .And(this.AlternativeHeadline)
             .And(this.AssociatedMedia)
@@ -836,6 +864,7 @@
             .And(this.DateModified)
             .And(this.DatePublished)
             .And(this.DiscussionUrl)
+            .And(this.EditEIDR)
             .And(this.Editor)
             .And(this.EducationalAlignment)
             .And(this.EducationalUse)
@@ -890,6 +919,7 @@
             .And(this.TranslationOfWork)
             .And(this.Translator)
             .And(this.TypicalAgeRange)
+            .And(this.UsageInfo)
             .And(this.Version)
             .And(this.Video)
             .And(this.WorkExample)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndLifestyleModification.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndLifestyleModification.cs
@@ -126,7 +126,7 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip> Audio { get; set; }
+        public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
@@ -260,7 +260,7 @@
         /// </summary>
         [DataMember(Name = "datePublished", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?> DatePublished { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -395,7 +395,7 @@
         /// </summary>
         [DataMember(Name = "isPartOf", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<ICreativeWork> IsPartOf { get; set; }
+        public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
@@ -433,72 +433,79 @@
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
+        /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+        /// </summary>
+        [DataMember(Name = "maintainer", Order = 264)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<IOrganization, IPerson> Maintainer { get; set; }
+
+        /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 264)]
+        [DataMember(Name = "material", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 265)]
+        [DataMember(Name = "materialExtent", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 266)]
+        [DataMember(Name = "mentions", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 267)]
+        [DataMember(Name = "offers", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 268)]
+        [DataMember(Name = "position", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 269)]
+        [DataMember(Name = "producer", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 270)]
+        [DataMember(Name = "provider", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 271)]
+        [DataMember(Name = "publication", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 272)]
+        [DataMember(Name = "publisher", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 273)]
+        [DataMember(Name = "publisherImprint", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -506,49 +513,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 274)]
+        [DataMember(Name = "publishingPrinciples", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 275)]
+        [DataMember(Name = "recordedAt", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 276)]
+        [DataMember(Name = "releasedEvent", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 277)]
+        [DataMember(Name = "review", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 278)]
+        [DataMember(Name = "schemaVersion", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 279)]
+        [DataMember(Name = "sdDatePublished", Order = 280)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 280)]
+        [DataMember(Name = "sdLicense", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -556,14 +563,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 281)]
+        [DataMember(Name = "sdPublisher", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 282)]
+        [DataMember(Name = "sourceOrganization", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -571,7 +578,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 283)]
+        [DataMember(Name = "spatial", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -580,14 +587,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 284)]
+        [DataMember(Name = "spatialCoverage", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 285)]
+        [DataMember(Name = "sponsor", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -595,7 +602,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 286)]
+        [DataMember(Name = "temporal", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -605,77 +612,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 287)]
+        [DataMember(Name = "temporalCoverage", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 288)]
+        [DataMember(Name = "text", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 289)]
+        [DataMember(Name = "thumbnailUrl", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 290)]
+        [DataMember(Name = "timeRequired", Order = 291)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 291)]
+        [DataMember(Name = "translationOfWork", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 292)]
+        [DataMember(Name = "translator", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 293)]
+        [DataMember(Name = "typicalAgeRange", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 294)]
+        [DataMember(Name = "version", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 295)]
+        [DataMember(Name = "video", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 296)]
+        [DataMember(Name = "workExample", Order = 297)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 297)]
+        [DataMember(Name = "workTranslation", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -751,6 +758,7 @@
                 this.License == other.License &&
                 this.LocationCreated == other.LocationCreated &&
                 this.MainEntity == other.MainEntity &&
+                this.Maintainer == other.Maintainer &&
                 this.Material == other.Material &&
                 this.MaterialExtent == other.MaterialExtent &&
                 this.Mentions == other.Mentions &&
@@ -851,6 +859,7 @@
             .And(this.License)
             .And(this.LocationCreated)
             .And(this.MainEntity)
+            .And(this.Maintainer)
             .And(this.Material)
             .And(this.MaterialExtent)
             .And(this.Mentions)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndListItem.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndListItem.cs
@@ -94,79 +94,86 @@
         public OneOrMany<IPerson> AccountablePerson { get; set; }
 
         /// <summary>
+        /// Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item.
+        /// </summary>
+        [DataMember(Name = "acquireLicensePage", Order = 216)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> AcquireLicensePage { get; set; }
+
+        /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
         /// </summary>
-        [DataMember(Name = "aggregateRating", Order = 216)]
+        [DataMember(Name = "aggregateRating", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAggregateRating> AggregateRating { get; set; }
 
         /// <summary>
         /// A secondary title of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "alternativeHeadline", Order = 217)]
+        [DataMember(Name = "alternativeHeadline", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> AlternativeHeadline { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for encoding.
         /// </summary>
-        [DataMember(Name = "associatedMedia", Order = 218)]
+        [DataMember(Name = "associatedMedia", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> AssociatedMedia { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
         /// </summary>
-        [DataMember(Name = "audience", Order = 219)]
+        [DataMember(Name = "audience", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAudience> Audience { get; set; }
 
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        [DataMember(Name = "audio", Order = 220)]
+        [DataMember(Name = "audio", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        [DataMember(Name = "author", Order = 221)]
+        [DataMember(Name = "author", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
         /// </summary>
-        [DataMember(Name = "award", Order = 222)]
+        [DataMember(Name = "award", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Award { get; set; }
 
         /// <summary>
         /// Fictional person connected with a creative work.
         /// </summary>
-        [DataMember(Name = "character", Order = 223)]
+        [DataMember(Name = "character", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Character { get; set; }
 
         /// <summary>
         /// A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
         /// </summary>
-        [DataMember(Name = "citation", Order = 224)]
+        [DataMember(Name = "citation", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
         /// </summary>
-        [DataMember(Name = "comment", Order = 225)]
+        [DataMember(Name = "comment", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IComment> Comment { get; set; }
 
         /// <summary>
         /// The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
         /// </summary>
-        [DataMember(Name = "commentCount", Order = 226)]
+        [DataMember(Name = "commentCount", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CommentCount { get; set; }
 
@@ -174,126 +181,135 @@
         /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
         /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
         /// </summary>
-        [DataMember(Name = "conditionsOfAccess", Order = 227)]
+        [DataMember(Name = "conditionsOfAccess", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ConditionsOfAccess { get; set; }
 
         /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 228)]
+        [DataMember(Name = "contentLocation", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 229)]
+        [DataMember(Name = "contentRating", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 230)]
+        [DataMember(Name = "contentReferenceTime", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 231)]
+        [DataMember(Name = "contributor", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 232)]
+        [DataMember(Name = "copyrightHolder", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 233)]
+        [DataMember(Name = "copyrightYear", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 234)]
+        [DataMember(Name = "correction", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Correction { get; set; }
 
         /// <summary>
         /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
         /// </summary>
-        [DataMember(Name = "creativeWorkStatus", Order = 235)]
+        [DataMember(Name = "creativeWorkStatus", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 236)]
+        [DataMember(Name = "creator", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 237)]
+        [DataMember(Name = "dateCreated", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 238)]
+        [DataMember(Name = "dateModified", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 239)]
+        [DataMember(Name = "datePublished", Order = 240)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 240)]
+        [DataMember(Name = "discussionUrl", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing a specific edit / edition for a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" whose &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "editEIDR", Order = 242)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> EditEIDR { get; set; }
+
+        /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 241)]
+        [DataMember(Name = "editor", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 242)]
+        [DataMember(Name = "educationalAlignment", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 243)]
+        [DataMember(Name = "educationalUse", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 244)]
+        [DataMember(Name = "encoding", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -302,231 +318,231 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 245)]
+        [DataMember(Name = "encodingFormat", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 246)]
+        [DataMember(Name = "exampleOfWork", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 247)]
+        [DataMember(Name = "expires", Order = 249)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 248)]
+        [DataMember(Name = "funder", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 249)]
+        [DataMember(Name = "genre", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 250)]
+        [DataMember(Name = "hasPart", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 251)]
+        [DataMember(Name = "headline", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 252)]
+        [DataMember(Name = "inLanguage", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 253)]
+        [DataMember(Name = "interactionStatistic", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 254)]
+        [DataMember(Name = "interactivityType", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 255)]
+        [DataMember(Name = "isAccessibleForFree", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 256)]
+        [DataMember(Name = "isBasedOn", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 257)]
+        [DataMember(Name = "isFamilyFriendly", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 258)]
+        [DataMember(Name = "isPartOf", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.
         /// </summary>
-        [DataMember(Name = "item", Order = 259)]
+        [DataMember(Name = "item", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Item { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 260)]
+        [DataMember(Name = "keywords", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 261)]
+        [DataMember(Name = "learningResourceType", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 262)]
+        [DataMember(Name = "license", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 263)]
+        [DataMember(Name = "locationCreated", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 264)]
+        [DataMember(Name = "mainEntity", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
         /// </summary>
-        [DataMember(Name = "maintainer", Order = 265)]
+        [DataMember(Name = "maintainer", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Maintainer { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 266)]
+        [DataMember(Name = "material", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 267)]
+        [DataMember(Name = "materialExtent", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 268)]
+        [DataMember(Name = "mentions", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// A link to the ListItem that follows the current one.
         /// </summary>
-        [DataMember(Name = "nextItem", Order = 269)]
+        [DataMember(Name = "nextItem", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> NextItem { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 270)]
+        [DataMember(Name = "offers", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 271)]
+        [DataMember(Name = "position", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.
         /// </summary>
-        [DataMember(Name = "previousItem", Order = 272)]
+        [DataMember(Name = "previousItem", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> PreviousItem { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 273)]
+        [DataMember(Name = "producer", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 274)]
+        [DataMember(Name = "provider", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 275)]
+        [DataMember(Name = "publication", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 276)]
+        [DataMember(Name = "publisher", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 277)]
+        [DataMember(Name = "publisherImprint", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -534,49 +550,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 278)]
+        [DataMember(Name = "publishingPrinciples", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 279)]
+        [DataMember(Name = "recordedAt", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 280)]
+        [DataMember(Name = "releasedEvent", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 281)]
+        [DataMember(Name = "review", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 282)]
+        [DataMember(Name = "schemaVersion", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 283)]
+        [DataMember(Name = "sdDatePublished", Order = 285)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 284)]
+        [DataMember(Name = "sdLicense", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -584,14 +600,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 285)]
+        [DataMember(Name = "sdPublisher", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 286)]
+        [DataMember(Name = "sourceOrganization", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -599,7 +615,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 287)]
+        [DataMember(Name = "spatial", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -608,14 +624,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 288)]
+        [DataMember(Name = "spatialCoverage", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 289)]
+        [DataMember(Name = "sponsor", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -623,7 +639,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 290)]
+        [DataMember(Name = "temporal", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -633,77 +649,85 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 291)]
+        [DataMember(Name = "temporalCoverage", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 292)]
+        [DataMember(Name = "text", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 293)]
+        [DataMember(Name = "thumbnailUrl", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 294)]
+        [DataMember(Name = "timeRequired", Order = 296)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 295)]
+        [DataMember(Name = "translationOfWork", Order = 297)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 296)]
+        [DataMember(Name = "translator", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 297)]
+        [DataMember(Name = "typicalAgeRange", Order = 299)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
+        /// The schema.org &lt;a class="localLink" href="http://schema.org/usageInfo"&gt;usageInfo&lt;/a&gt; property indicates further information about a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.&lt;br/&gt;&lt;br/&gt;
+        /// This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+        /// </summary>
+        [DataMember(Name = "usageInfo", Order = 300)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> UsageInfo { get; set; }
+
+        /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 298)]
+        [DataMember(Name = "version", Order = 301)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 299)]
+        [DataMember(Name = "video", Order = 302)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 300)]
+        [DataMember(Name = "workExample", Order = 303)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 301)]
+        [DataMember(Name = "workTranslation", Order = 304)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -731,6 +755,7 @@
                 this.AccessMode == other.AccessMode &&
                 this.AccessModeSufficient == other.AccessModeSufficient &&
                 this.AccountablePerson == other.AccountablePerson &&
+                this.AcquireLicensePage == other.AcquireLicensePage &&
                 this.AggregateRating == other.AggregateRating &&
                 this.AlternativeHeadline == other.AlternativeHeadline &&
                 this.AssociatedMedia == other.AssociatedMedia &&
@@ -756,6 +781,7 @@
                 this.DateModified == other.DateModified &&
                 this.DatePublished == other.DatePublished &&
                 this.DiscussionUrl == other.DiscussionUrl &&
+                this.EditEIDR == other.EditEIDR &&
                 this.Editor == other.Editor &&
                 this.EducationalAlignment == other.EducationalAlignment &&
                 this.EducationalUse == other.EducationalUse &&
@@ -813,6 +839,7 @@
                 this.TranslationOfWork == other.TranslationOfWork &&
                 this.Translator == other.Translator &&
                 this.TypicalAgeRange == other.TypicalAgeRange &&
+                this.UsageInfo == other.UsageInfo &&
                 this.Version == other.Version &&
                 this.Video == other.Video &&
                 this.WorkExample == other.WorkExample &&
@@ -835,6 +862,7 @@
             .And(this.AccessMode)
             .And(this.AccessModeSufficient)
             .And(this.AccountablePerson)
+            .And(this.AcquireLicensePage)
             .And(this.AggregateRating)
             .And(this.AlternativeHeadline)
             .And(this.AssociatedMedia)
@@ -860,6 +888,7 @@
             .And(this.DateModified)
             .And(this.DatePublished)
             .And(this.DiscussionUrl)
+            .And(this.EditEIDR)
             .And(this.Editor)
             .And(this.EducationalAlignment)
             .And(this.EducationalUse)
@@ -917,6 +946,7 @@
             .And(this.TranslationOfWork)
             .And(this.Translator)
             .And(this.TypicalAgeRange)
+            .And(this.UsageInfo)
             .And(this.Version)
             .And(this.Video)
             .And(this.WorkExample)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndListItem.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndListItem.cs
@@ -126,7 +126,7 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip> Audio { get; set; }
+        public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
@@ -260,7 +260,7 @@
         /// </summary>
         [DataMember(Name = "datePublished", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?> DatePublished { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -395,7 +395,7 @@
         /// </summary>
         [DataMember(Name = "isPartOf", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<ICreativeWork> IsPartOf { get; set; }
+        public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’.
@@ -440,86 +440,93 @@
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
+        /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+        /// </summary>
+        [DataMember(Name = "maintainer", Order = 265)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<IOrganization, IPerson> Maintainer { get; set; }
+
+        /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 265)]
+        [DataMember(Name = "material", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 266)]
+        [DataMember(Name = "materialExtent", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 267)]
+        [DataMember(Name = "mentions", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// A link to the ListItem that follows the current one.
         /// </summary>
-        [DataMember(Name = "nextItem", Order = 268)]
+        [DataMember(Name = "nextItem", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> NextItem { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 269)]
+        [DataMember(Name = "offers", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 270)]
+        [DataMember(Name = "position", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// A link to the ListItem that preceeds the current one.
         /// </summary>
-        [DataMember(Name = "previousItem", Order = 271)]
+        [DataMember(Name = "previousItem", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IListItem> PreviousItem { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 272)]
+        [DataMember(Name = "producer", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 273)]
+        [DataMember(Name = "provider", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 274)]
+        [DataMember(Name = "publication", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 275)]
+        [DataMember(Name = "publisher", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 276)]
+        [DataMember(Name = "publisherImprint", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -527,49 +534,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 277)]
+        [DataMember(Name = "publishingPrinciples", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 278)]
+        [DataMember(Name = "recordedAt", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 279)]
+        [DataMember(Name = "releasedEvent", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 280)]
+        [DataMember(Name = "review", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 281)]
+        [DataMember(Name = "schemaVersion", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 282)]
+        [DataMember(Name = "sdDatePublished", Order = 283)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 283)]
+        [DataMember(Name = "sdLicense", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -577,14 +584,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 284)]
+        [DataMember(Name = "sdPublisher", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 285)]
+        [DataMember(Name = "sourceOrganization", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -592,7 +599,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 286)]
+        [DataMember(Name = "spatial", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -601,14 +608,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 287)]
+        [DataMember(Name = "spatialCoverage", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 288)]
+        [DataMember(Name = "sponsor", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -616,7 +623,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 289)]
+        [DataMember(Name = "temporal", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -626,77 +633,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 290)]
+        [DataMember(Name = "temporalCoverage", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 291)]
+        [DataMember(Name = "text", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 292)]
+        [DataMember(Name = "thumbnailUrl", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 293)]
+        [DataMember(Name = "timeRequired", Order = 294)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 294)]
+        [DataMember(Name = "translationOfWork", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 295)]
+        [DataMember(Name = "translator", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 296)]
+        [DataMember(Name = "typicalAgeRange", Order = 297)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 297)]
+        [DataMember(Name = "version", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 298)]
+        [DataMember(Name = "video", Order = 299)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 299)]
+        [DataMember(Name = "workExample", Order = 300)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 300)]
+        [DataMember(Name = "workTranslation", Order = 301)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -773,6 +780,7 @@
                 this.License == other.License &&
                 this.LocationCreated == other.LocationCreated &&
                 this.MainEntity == other.MainEntity &&
+                this.Maintainer == other.Maintainer &&
                 this.Material == other.Material &&
                 this.MaterialExtent == other.MaterialExtent &&
                 this.Mentions == other.Mentions &&
@@ -876,6 +884,7 @@
             .And(this.License)
             .And(this.LocationCreated)
             .And(this.MainEntity)
+            .And(this.Maintainer)
             .And(this.Material)
             .And(this.MaterialExtent)
             .And(this.Mentions)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndPhysicalActivity.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndPhysicalActivity.cs
@@ -133,7 +133,7 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 321)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip> Audio { get; set; }
+        public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
@@ -274,7 +274,7 @@
         /// </summary>
         [DataMember(Name = "datePublished", Order = 341)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?> DatePublished { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -416,7 +416,7 @@
         /// </summary>
         [DataMember(Name = "isPartOf", Order = 361)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<ICreativeWork> IsPartOf { get; set; }
+        public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
@@ -454,79 +454,86 @@
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
+        /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+        /// </summary>
+        [DataMember(Name = "maintainer", Order = 367)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<IOrganization, IPerson> Maintainer { get; set; }
+
+        /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 367)]
+        [DataMember(Name = "material", Order = 368)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 368)]
+        [DataMember(Name = "materialExtent", Order = 369)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 369)]
+        [DataMember(Name = "mentions", Order = 370)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 370)]
+        [DataMember(Name = "offers", Order = 371)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// Changes in the normal mechanical, physical, and biochemical functions that are associated with this activity or condition.
         /// </summary>
-        [DataMember(Name = "pathophysiology", Order = 371)]
+        [DataMember(Name = "pathophysiology", Order = 372)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Pathophysiology { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 372)]
+        [DataMember(Name = "position", Order = 373)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 373)]
+        [DataMember(Name = "producer", Order = 374)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 374)]
+        [DataMember(Name = "provider", Order = 375)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 375)]
+        [DataMember(Name = "publication", Order = 376)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 376)]
+        [DataMember(Name = "publisher", Order = 377)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 377)]
+        [DataMember(Name = "publisherImprint", Order = 378)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -534,49 +541,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 378)]
+        [DataMember(Name = "publishingPrinciples", Order = 379)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 379)]
+        [DataMember(Name = "recordedAt", Order = 380)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 380)]
+        [DataMember(Name = "releasedEvent", Order = 381)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 381)]
+        [DataMember(Name = "review", Order = 382)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 382)]
+        [DataMember(Name = "schemaVersion", Order = 383)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 383)]
+        [DataMember(Name = "sdDatePublished", Order = 384)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 384)]
+        [DataMember(Name = "sdLicense", Order = 385)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -584,14 +591,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 385)]
+        [DataMember(Name = "sdPublisher", Order = 386)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 386)]
+        [DataMember(Name = "sourceOrganization", Order = 387)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -599,7 +606,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 387)]
+        [DataMember(Name = "spatial", Order = 388)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -608,14 +615,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 388)]
+        [DataMember(Name = "spatialCoverage", Order = 389)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 389)]
+        [DataMember(Name = "sponsor", Order = 390)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -623,7 +630,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 390)]
+        [DataMember(Name = "temporal", Order = 391)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -633,77 +640,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 391)]
+        [DataMember(Name = "temporalCoverage", Order = 392)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 392)]
+        [DataMember(Name = "text", Order = 393)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 393)]
+        [DataMember(Name = "thumbnailUrl", Order = 394)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 394)]
+        [DataMember(Name = "timeRequired", Order = 395)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 395)]
+        [DataMember(Name = "translationOfWork", Order = 396)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 396)]
+        [DataMember(Name = "translator", Order = 397)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 397)]
+        [DataMember(Name = "typicalAgeRange", Order = 398)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 398)]
+        [DataMember(Name = "version", Order = 399)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 399)]
+        [DataMember(Name = "video", Order = 400)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 400)]
+        [DataMember(Name = "workExample", Order = 401)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 401)]
+        [DataMember(Name = "workTranslation", Order = 402)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -782,6 +789,7 @@
                 this.License == other.License &&
                 this.LocationCreated == other.LocationCreated &&
                 this.MainEntity == other.MainEntity &&
+                this.Maintainer == other.Maintainer &&
                 this.Material == other.Material &&
                 this.MaterialExtent == other.MaterialExtent &&
                 this.Mentions == other.Mentions &&
@@ -886,6 +894,7 @@
             .And(this.License)
             .And(this.LocationCreated)
             .And(this.MainEntity)
+            .And(this.Maintainer)
             .And(this.Material)
             .And(this.MaterialExtent)
             .And(this.Mentions)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndPhysicalActivity.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndPhysicalActivity.cs
@@ -94,93 +94,100 @@
         public OneOrMany<IPerson> AccountablePerson { get; set; }
 
         /// <summary>
+        /// Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item.
+        /// </summary>
+        [DataMember(Name = "acquireLicensePage", Order = 316)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> AcquireLicensePage { get; set; }
+
+        /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
         /// </summary>
-        [DataMember(Name = "aggregateRating", Order = 316)]
+        [DataMember(Name = "aggregateRating", Order = 317)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAggregateRating> AggregateRating { get; set; }
 
         /// <summary>
         /// A secondary title of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "alternativeHeadline", Order = 317)]
+        [DataMember(Name = "alternativeHeadline", Order = 318)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> AlternativeHeadline { get; set; }
 
         /// <summary>
         /// The anatomy of the underlying organ system or structures associated with this entity.
         /// </summary>
-        [DataMember(Name = "associatedAnatomy", Order = 318)]
+        [DataMember(Name = "associatedAnatomy", Order = 319)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAnatomicalStructure, IAnatomicalSystem, ISuperficialAnatomy> AssociatedAnatomy { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for encoding.
         /// </summary>
-        [DataMember(Name = "associatedMedia", Order = 319)]
+        [DataMember(Name = "associatedMedia", Order = 320)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> AssociatedMedia { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
         /// </summary>
-        [DataMember(Name = "audience", Order = 320)]
+        [DataMember(Name = "audience", Order = 321)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAudience> Audience { get; set; }
 
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        [DataMember(Name = "audio", Order = 321)]
+        [DataMember(Name = "audio", Order = 322)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        [DataMember(Name = "author", Order = 322)]
+        [DataMember(Name = "author", Order = 323)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
         /// </summary>
-        [DataMember(Name = "award", Order = 323)]
+        [DataMember(Name = "award", Order = 324)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Award { get; set; }
 
         /// <summary>
         /// A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
         /// </summary>
-        [DataMember(Name = "category", Order = 324)]
+        [DataMember(Name = "category", Order = 325)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<PhysicalActivityCategory?, string, IThing> Category { get; set; }
 
         /// <summary>
         /// Fictional person connected with a creative work.
         /// </summary>
-        [DataMember(Name = "character", Order = 325)]
+        [DataMember(Name = "character", Order = 326)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Character { get; set; }
 
         /// <summary>
         /// A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
         /// </summary>
-        [DataMember(Name = "citation", Order = 326)]
+        [DataMember(Name = "citation", Order = 327)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
         /// </summary>
-        [DataMember(Name = "comment", Order = 327)]
+        [DataMember(Name = "comment", Order = 328)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IComment> Comment { get; set; }
 
         /// <summary>
         /// The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
         /// </summary>
-        [DataMember(Name = "commentCount", Order = 328)]
+        [DataMember(Name = "commentCount", Order = 329)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CommentCount { get; set; }
 
@@ -188,126 +195,135 @@
         /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
         /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
         /// </summary>
-        [DataMember(Name = "conditionsOfAccess", Order = 329)]
+        [DataMember(Name = "conditionsOfAccess", Order = 330)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ConditionsOfAccess { get; set; }
 
         /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 330)]
+        [DataMember(Name = "contentLocation", Order = 331)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 331)]
+        [DataMember(Name = "contentRating", Order = 332)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 332)]
+        [DataMember(Name = "contentReferenceTime", Order = 333)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 333)]
+        [DataMember(Name = "contributor", Order = 334)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 334)]
+        [DataMember(Name = "copyrightHolder", Order = 335)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 335)]
+        [DataMember(Name = "copyrightYear", Order = 336)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 336)]
+        [DataMember(Name = "correction", Order = 337)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Correction { get; set; }
 
         /// <summary>
         /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
         /// </summary>
-        [DataMember(Name = "creativeWorkStatus", Order = 337)]
+        [DataMember(Name = "creativeWorkStatus", Order = 338)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 338)]
+        [DataMember(Name = "creator", Order = 339)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 339)]
+        [DataMember(Name = "dateCreated", Order = 340)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 340)]
+        [DataMember(Name = "dateModified", Order = 341)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 341)]
+        [DataMember(Name = "datePublished", Order = 342)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 342)]
+        [DataMember(Name = "discussionUrl", Order = 343)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing a specific edit / edition for a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" whose &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "editEIDR", Order = 344)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> EditEIDR { get; set; }
+
+        /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 343)]
+        [DataMember(Name = "editor", Order = 345)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 344)]
+        [DataMember(Name = "educationalAlignment", Order = 346)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 345)]
+        [DataMember(Name = "educationalUse", Order = 347)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 346)]
+        [DataMember(Name = "encoding", Order = 348)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -316,224 +332,224 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 347)]
+        [DataMember(Name = "encodingFormat", Order = 349)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// The characteristics of associated patients, such as age, gender, race etc.
         /// </summary>
-        [DataMember(Name = "epidemiology", Order = 348)]
+        [DataMember(Name = "epidemiology", Order = 350)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Epidemiology { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 349)]
+        [DataMember(Name = "exampleOfWork", Order = 351)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 350)]
+        [DataMember(Name = "expires", Order = 352)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 351)]
+        [DataMember(Name = "funder", Order = 353)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 352)]
+        [DataMember(Name = "genre", Order = 354)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 353)]
+        [DataMember(Name = "hasPart", Order = 355)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 354)]
+        [DataMember(Name = "headline", Order = 356)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 355)]
+        [DataMember(Name = "inLanguage", Order = 357)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 356)]
+        [DataMember(Name = "interactionStatistic", Order = 358)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 357)]
+        [DataMember(Name = "interactivityType", Order = 359)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 358)]
+        [DataMember(Name = "isAccessibleForFree", Order = 360)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 359)]
+        [DataMember(Name = "isBasedOn", Order = 361)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 360)]
+        [DataMember(Name = "isFamilyFriendly", Order = 362)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 361)]
+        [DataMember(Name = "isPartOf", Order = 363)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 362)]
+        [DataMember(Name = "keywords", Order = 364)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 363)]
+        [DataMember(Name = "learningResourceType", Order = 365)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 364)]
+        [DataMember(Name = "license", Order = 366)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 365)]
+        [DataMember(Name = "locationCreated", Order = 367)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 366)]
+        [DataMember(Name = "mainEntity", Order = 368)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
         /// </summary>
-        [DataMember(Name = "maintainer", Order = 367)]
+        [DataMember(Name = "maintainer", Order = 369)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Maintainer { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 368)]
+        [DataMember(Name = "material", Order = 370)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 369)]
+        [DataMember(Name = "materialExtent", Order = 371)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 370)]
+        [DataMember(Name = "mentions", Order = 372)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 371)]
+        [DataMember(Name = "offers", Order = 373)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// Changes in the normal mechanical, physical, and biochemical functions that are associated with this activity or condition.
         /// </summary>
-        [DataMember(Name = "pathophysiology", Order = 372)]
+        [DataMember(Name = "pathophysiology", Order = 374)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Pathophysiology { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 373)]
+        [DataMember(Name = "position", Order = 375)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 374)]
+        [DataMember(Name = "producer", Order = 376)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 375)]
+        [DataMember(Name = "provider", Order = 377)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 376)]
+        [DataMember(Name = "publication", Order = 378)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 377)]
+        [DataMember(Name = "publisher", Order = 379)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 378)]
+        [DataMember(Name = "publisherImprint", Order = 380)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -541,49 +557,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 379)]
+        [DataMember(Name = "publishingPrinciples", Order = 381)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 380)]
+        [DataMember(Name = "recordedAt", Order = 382)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 381)]
+        [DataMember(Name = "releasedEvent", Order = 383)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 382)]
+        [DataMember(Name = "review", Order = 384)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 383)]
+        [DataMember(Name = "schemaVersion", Order = 385)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 384)]
+        [DataMember(Name = "sdDatePublished", Order = 386)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 385)]
+        [DataMember(Name = "sdLicense", Order = 387)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -591,14 +607,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 386)]
+        [DataMember(Name = "sdPublisher", Order = 388)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 387)]
+        [DataMember(Name = "sourceOrganization", Order = 389)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -606,7 +622,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 388)]
+        [DataMember(Name = "spatial", Order = 390)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -615,14 +631,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 389)]
+        [DataMember(Name = "spatialCoverage", Order = 391)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 390)]
+        [DataMember(Name = "sponsor", Order = 392)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -630,7 +646,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 391)]
+        [DataMember(Name = "temporal", Order = 393)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -640,77 +656,85 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 392)]
+        [DataMember(Name = "temporalCoverage", Order = 394)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 393)]
+        [DataMember(Name = "text", Order = 395)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 394)]
+        [DataMember(Name = "thumbnailUrl", Order = 396)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 395)]
+        [DataMember(Name = "timeRequired", Order = 397)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 396)]
+        [DataMember(Name = "translationOfWork", Order = 398)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 397)]
+        [DataMember(Name = "translator", Order = 399)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 398)]
+        [DataMember(Name = "typicalAgeRange", Order = 400)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
+        /// The schema.org &lt;a class="localLink" href="http://schema.org/usageInfo"&gt;usageInfo&lt;/a&gt; property indicates further information about a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.&lt;br/&gt;&lt;br/&gt;
+        /// This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+        /// </summary>
+        [DataMember(Name = "usageInfo", Order = 401)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> UsageInfo { get; set; }
+
+        /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 399)]
+        [DataMember(Name = "version", Order = 402)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 400)]
+        [DataMember(Name = "video", Order = 403)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 401)]
+        [DataMember(Name = "workExample", Order = 404)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 402)]
+        [DataMember(Name = "workTranslation", Order = 405)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -738,6 +762,7 @@
                 this.AccessMode == other.AccessMode &&
                 this.AccessModeSufficient == other.AccessModeSufficient &&
                 this.AccountablePerson == other.AccountablePerson &&
+                this.AcquireLicensePage == other.AcquireLicensePage &&
                 this.AggregateRating == other.AggregateRating &&
                 this.AlternativeHeadline == other.AlternativeHeadline &&
                 this.AssociatedAnatomy == other.AssociatedAnatomy &&
@@ -765,6 +790,7 @@
                 this.DateModified == other.DateModified &&
                 this.DatePublished == other.DatePublished &&
                 this.DiscussionUrl == other.DiscussionUrl &&
+                this.EditEIDR == other.EditEIDR &&
                 this.Editor == other.Editor &&
                 this.EducationalAlignment == other.EducationalAlignment &&
                 this.EducationalUse == other.EducationalUse &&
@@ -821,6 +847,7 @@
                 this.TranslationOfWork == other.TranslationOfWork &&
                 this.Translator == other.Translator &&
                 this.TypicalAgeRange == other.TypicalAgeRange &&
+                this.UsageInfo == other.UsageInfo &&
                 this.Version == other.Version &&
                 this.Video == other.Video &&
                 this.WorkExample == other.WorkExample &&
@@ -843,6 +870,7 @@
             .And(this.AccessMode)
             .And(this.AccessModeSufficient)
             .And(this.AccountablePerson)
+            .And(this.AcquireLicensePage)
             .And(this.AggregateRating)
             .And(this.AlternativeHeadline)
             .And(this.AssociatedAnatomy)
@@ -870,6 +898,7 @@
             .And(this.DateModified)
             .And(this.DatePublished)
             .And(this.DiscussionUrl)
+            .And(this.EditEIDR)
             .And(this.Editor)
             .And(this.EducationalAlignment)
             .And(this.EducationalUse)
@@ -926,6 +955,7 @@
             .And(this.TranslationOfWork)
             .And(this.Translator)
             .And(this.TypicalAgeRange)
+            .And(this.UsageInfo)
             .And(this.Version)
             .And(this.Video)
             .And(this.WorkExample)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndSeries.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndSeries.cs
@@ -94,79 +94,86 @@
         public OneOrMany<IPerson> AccountablePerson { get; set; }
 
         /// <summary>
+        /// Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item.
+        /// </summary>
+        [DataMember(Name = "acquireLicensePage", Order = 216)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> AcquireLicensePage { get; set; }
+
+        /// <summary>
         /// The overall rating, based on a collection of reviews or ratings, of the item.
         /// </summary>
-        [DataMember(Name = "aggregateRating", Order = 216)]
+        [DataMember(Name = "aggregateRating", Order = 217)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAggregateRating> AggregateRating { get; set; }
 
         /// <summary>
         /// A secondary title of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "alternativeHeadline", Order = 217)]
+        [DataMember(Name = "alternativeHeadline", Order = 218)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> AlternativeHeadline { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for encoding.
         /// </summary>
-        [DataMember(Name = "associatedMedia", Order = 218)]
+        [DataMember(Name = "associatedMedia", Order = 219)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> AssociatedMedia { get; set; }
 
         /// <summary>
         /// An intended audience, i.e. a group for whom something was created.
         /// </summary>
-        [DataMember(Name = "audience", Order = 219)]
+        [DataMember(Name = "audience", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAudience> Audience { get; set; }
 
         /// <summary>
         /// An embedded audio object.
         /// </summary>
-        [DataMember(Name = "audio", Order = 220)]
+        [DataMember(Name = "audio", Order = 221)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
         /// </summary>
-        [DataMember(Name = "author", Order = 221)]
+        [DataMember(Name = "author", Order = 222)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Author { get; set; }
 
         /// <summary>
         /// An award won by or for this item.
         /// </summary>
-        [DataMember(Name = "award", Order = 222)]
+        [DataMember(Name = "award", Order = 223)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Award { get; set; }
 
         /// <summary>
         /// Fictional person connected with a creative work.
         /// </summary>
-        [DataMember(Name = "character", Order = 223)]
+        [DataMember(Name = "character", Order = 224)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Character { get; set; }
 
         /// <summary>
         /// A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
         /// </summary>
-        [DataMember(Name = "citation", Order = 224)]
+        [DataMember(Name = "citation", Order = 225)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, string> Citation { get; set; }
 
         /// <summary>
         /// Comments, typically from users.
         /// </summary>
-        [DataMember(Name = "comment", Order = 225)]
+        [DataMember(Name = "comment", Order = 226)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IComment> Comment { get; set; }
 
         /// <summary>
         /// The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
         /// </summary>
-        [DataMember(Name = "commentCount", Order = 226)]
+        [DataMember(Name = "commentCount", Order = 227)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CommentCount { get; set; }
 
@@ -174,126 +181,135 @@
         /// Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an &lt;a class="localLink" href="http://schema.org/ArchiveComponent"&gt;ArchiveComponent&lt;/a&gt; held by an &lt;a class="localLink" href="http://schema.org/ArchiveOrganization"&gt;ArchiveOrganization&lt;/a&gt;. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.&lt;br/&gt;&lt;br/&gt;
         /// For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
         /// </summary>
-        [DataMember(Name = "conditionsOfAccess", Order = 227)]
+        [DataMember(Name = "conditionsOfAccess", Order = 228)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> ConditionsOfAccess { get; set; }
 
         /// <summary>
         /// The location depicted or described in the content. For example, the location in a photograph or painting.
         /// </summary>
-        [DataMember(Name = "contentLocation", Order = 228)]
+        [DataMember(Name = "contentLocation", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> ContentLocation { get; set; }
 
         /// <summary>
         /// Official rating of a piece of content&amp;#x2014;for example,'MPAA PG-13'.
         /// </summary>
-        [DataMember(Name = "contentRating", Order = 229)]
+        [DataMember(Name = "contentRating", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IRating, string> ContentRating { get; set; }
 
         /// <summary>
         /// The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
         /// </summary>
-        [DataMember(Name = "contentReferenceTime", Order = 230)]
+        [DataMember(Name = "contentReferenceTime", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<DateTimeOffset?> ContentReferenceTime { get; set; }
 
         /// <summary>
         /// A secondary contributor to the CreativeWork or Event.
         /// </summary>
-        [DataMember(Name = "contributor", Order = 231)]
+        [DataMember(Name = "contributor", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Contributor { get; set; }
 
         /// <summary>
         /// The party holding the legal copyright to the CreativeWork.
         /// </summary>
-        [DataMember(Name = "copyrightHolder", Order = 232)]
+        [DataMember(Name = "copyrightHolder", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> CopyrightHolder { get; set; }
 
         /// <summary>
         /// The year during which the claimed copyright for the CreativeWork was first asserted.
         /// </summary>
-        [DataMember(Name = "copyrightYear", Order = 233)]
+        [DataMember(Name = "copyrightYear", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<int?> CopyrightYear { get; set; }
 
         /// <summary>
         /// Indicates a correction to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;, either via a &lt;a class="localLink" href="http://schema.org/CorrectionComment"&gt;CorrectionComment&lt;/a&gt;, textually or in another document.
         /// </summary>
-        [DataMember(Name = "correction", Order = 234)]
+        [DataMember(Name = "correction", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Correction { get; set; }
 
         /// <summary>
         /// The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle.
         /// </summary>
-        [DataMember(Name = "creativeWorkStatus", Order = 235)]
+        [DataMember(Name = "creativeWorkStatus", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> CreativeWorkStatus { get; set; }
 
         /// <summary>
         /// The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
         /// </summary>
-        [DataMember(Name = "creator", Order = 236)]
+        [DataMember(Name = "creator", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Creator { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was created or the item was added to a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateCreated", Order = 237)]
+        [DataMember(Name = "dateCreated", Order = 238)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateCreated { get; set; }
 
         /// <summary>
         /// The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
         /// </summary>
-        [DataMember(Name = "dateModified", Order = 238)]
+        [DataMember(Name = "dateModified", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DateModified { get; set; }
 
         /// <summary>
         /// Date of first broadcast/publication.
         /// </summary>
-        [DataMember(Name = "datePublished", Order = 239)]
+        [DataMember(Name = "datePublished", Order = 240)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
         /// </summary>
-        [DataMember(Name = "discussionUrl", Order = 240)]
+        [DataMember(Name = "discussionUrl", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> DiscussionUrl { get; set; }
 
         /// <summary>
+        /// An &lt;a href="https://eidr.org/"&gt;[EIDR]&lt;/a&gt; (Entertainment Identifier Registry) &lt;a class="localLink" href="http://schema.org/identifier"&gt;identifier&lt;/a&gt; representing a specific edit / edition for a work of film or television.&lt;br/&gt;&lt;br/&gt;
+        /// For example, the motion picture known as "Ghostbusters" whose &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".&lt;br/&gt;&lt;br/&gt;
+        /// Since schema.org types like &lt;a class="localLink" href="http://schema.org/Movie"&gt;Movie&lt;/a&gt; and &lt;a class="localLink" href="http://schema.org/TVEpisode"&gt;TVEpisode&lt;/a&gt; can be used for both works and their multiple expressions, it is possible to use &lt;a class="localLink" href="http://schema.org/titleEIDR"&gt;titleEIDR&lt;/a&gt; alone (for a general description), or alongside &lt;a class="localLink" href="http://schema.org/editEIDR"&gt;editEIDR&lt;/a&gt; for a more edit-specific description.
+        /// </summary>
+        [DataMember(Name = "editEIDR", Order = 242)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<string, Uri> EditEIDR { get; set; }
+
+        /// <summary>
         /// Specifies the Person who edited the CreativeWork.
         /// </summary>
-        [DataMember(Name = "editor", Order = 241)]
+        [DataMember(Name = "editor", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPerson> Editor { get; set; }
 
         /// <summary>
         /// An alignment to an established educational framework.
         /// </summary>
-        [DataMember(Name = "educationalAlignment", Order = 242)]
+        [DataMember(Name = "educationalAlignment", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IAlignmentObject> EducationalAlignment { get; set; }
 
         /// <summary>
         /// The purpose of a work in the context of education; for example, 'assignment', 'group work'.
         /// </summary>
-        [DataMember(Name = "educationalUse", Order = 243)]
+        [DataMember(Name = "educationalUse", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> EducationalUse { get; set; }
 
         /// <summary>
         /// A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.
         /// </summary>
-        [DataMember(Name = "encoding", Order = 244)]
+        [DataMember(Name = "encoding", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IMediaObject> Encoding { get; set; }
 
@@ -302,210 +318,210 @@
         /// In cases where a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; has several media type representations, &lt;a class="localLink" href="http://schema.org/encoding"&gt;encoding&lt;/a&gt; can be used to indicate each &lt;a class="localLink" href="http://schema.org/MediaObject"&gt;MediaObject&lt;/a&gt; alongside particular &lt;a class="localLink" href="http://schema.org/encodingFormat"&gt;encodingFormat&lt;/a&gt; information.&lt;br/&gt;&lt;br/&gt;
         /// Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
         /// </summary>
-        [DataMember(Name = "encodingFormat", Order = 245)]
+        [DataMember(Name = "encodingFormat", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> EncodingFormat { get; set; }
 
         /// <summary>
         /// A creative work that this work is an example/instance/realization/derivation of.
         /// </summary>
-        [DataMember(Name = "exampleOfWork", Order = 246)]
+        [DataMember(Name = "exampleOfWork", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> ExampleOfWork { get; set; }
 
         /// <summary>
         /// Date the content expires and is no longer useful or available. For example a &lt;a class="localLink" href="http://schema.org/VideoObject"&gt;VideoObject&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt; whose availability or relevance is time-limited, or a &lt;a class="localLink" href="http://schema.org/ClaimReview"&gt;ClaimReview&lt;/a&gt; fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
         /// </summary>
-        [DataMember(Name = "expires", Order = 247)]
+        [DataMember(Name = "expires", Order = 249)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> Expires { get; set; }
 
         /// <summary>
         /// A person or organization that supports (sponsors) something through some kind of financial contribution.
         /// </summary>
-        [DataMember(Name = "funder", Order = 248)]
+        [DataMember(Name = "funder", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Funder { get; set; }
 
         /// <summary>
         /// Genre of the creative work, broadcast channel or group.
         /// </summary>
-        [DataMember(Name = "genre", Order = 249)]
+        [DataMember(Name = "genre", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> Genre { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).
         /// </summary>
-        [DataMember(Name = "hasPart", Order = 250)]
+        [DataMember(Name = "hasPart", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> HasPart { get; set; }
 
         /// <summary>
         /// Headline of the article.
         /// </summary>
-        [DataMember(Name = "headline", Order = 251)]
+        [DataMember(Name = "headline", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Headline { get; set; }
 
         /// <summary>
         /// The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;. See also &lt;a class="localLink" href="http://schema.org/availableLanguage"&gt;availableLanguage&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "inLanguage", Order = 252)]
+        [DataMember(Name = "inLanguage", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ILanguage, string> InLanguage { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 253)]
+        [DataMember(Name = "interactionStatistic", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
         /// </summary>
-        [DataMember(Name = "interactivityType", Order = 254)]
+        [DataMember(Name = "interactivityType", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> InteractivityType { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 255)]
+        [DataMember(Name = "isAccessibleForFree", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// A resource from which this work is derived or from which it is a modification or adaption.
         /// </summary>
-        [DataMember(Name = "isBasedOn", Order = 256)]
+        [DataMember(Name = "isBasedOn", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, IProduct, Uri> IsBasedOn { get; set; }
 
         /// <summary>
         /// Indicates whether this content is family friendly.
         /// </summary>
-        [DataMember(Name = "isFamilyFriendly", Order = 257)]
+        [DataMember(Name = "isFamilyFriendly", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<bool?> IsFamilyFriendly { get; set; }
 
         /// <summary>
         /// Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.
         /// </summary>
-        [DataMember(Name = "isPartOf", Order = 258)]
+        [DataMember(Name = "isPartOf", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
         /// </summary>
-        [DataMember(Name = "keywords", Order = 259)]
+        [DataMember(Name = "keywords", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Keywords { get; set; }
 
         /// <summary>
         /// The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
         /// </summary>
-        [DataMember(Name = "learningResourceType", Order = 260)]
+        [DataMember(Name = "learningResourceType", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> LearningResourceType { get; set; }
 
         /// <summary>
         /// A license document that applies to this content, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "license", Order = 261)]
+        [DataMember(Name = "license", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> License { get; set; }
 
         /// <summary>
         /// The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
         /// </summary>
-        [DataMember(Name = "locationCreated", Order = 262)]
+        [DataMember(Name = "locationCreated", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> LocationCreated { get; set; }
 
         /// <summary>
         /// Indicates the primary entity described in some page or other CreativeWork.
         /// </summary>
-        [DataMember(Name = "mainEntity", Order = 263)]
+        [DataMember(Name = "mainEntity", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
         /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
         /// </summary>
-        [DataMember(Name = "maintainer", Order = 264)]
+        [DataMember(Name = "maintainer", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Maintainer { get; set; }
 
         /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 265)]
+        [DataMember(Name = "material", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 266)]
+        [DataMember(Name = "materialExtent", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 267)]
+        [DataMember(Name = "mentions", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
         /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 268)]
+        [DataMember(Name = "offers", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 269)]
+        [DataMember(Name = "position", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 270)]
+        [DataMember(Name = "producer", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 271)]
+        [DataMember(Name = "provider", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 272)]
+        [DataMember(Name = "publication", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 273)]
+        [DataMember(Name = "publisher", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 274)]
+        [DataMember(Name = "publisherImprint", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -513,49 +529,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 275)]
+        [DataMember(Name = "publishingPrinciples", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 276)]
+        [DataMember(Name = "recordedAt", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 277)]
+        [DataMember(Name = "releasedEvent", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 278)]
+        [DataMember(Name = "review", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 279)]
+        [DataMember(Name = "schemaVersion", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 280)]
+        [DataMember(Name = "sdDatePublished", Order = 282)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 281)]
+        [DataMember(Name = "sdLicense", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -563,14 +579,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 282)]
+        [DataMember(Name = "sdPublisher", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 283)]
+        [DataMember(Name = "sourceOrganization", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -578,7 +594,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 284)]
+        [DataMember(Name = "spatial", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -587,14 +603,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 285)]
+        [DataMember(Name = "spatialCoverage", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 286)]
+        [DataMember(Name = "sponsor", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -602,7 +618,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 287)]
+        [DataMember(Name = "temporal", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -612,77 +628,85 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 288)]
+        [DataMember(Name = "temporalCoverage", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 289)]
+        [DataMember(Name = "text", Order = 291)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 290)]
+        [DataMember(Name = "thumbnailUrl", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 291)]
+        [DataMember(Name = "timeRequired", Order = 293)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 292)]
+        [DataMember(Name = "translationOfWork", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 293)]
+        [DataMember(Name = "translator", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 294)]
+        [DataMember(Name = "typicalAgeRange", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
+        /// The schema.org &lt;a class="localLink" href="http://schema.org/usageInfo"&gt;usageInfo&lt;/a&gt; property indicates further information about a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.&lt;br/&gt;&lt;br/&gt;
+        /// This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+        /// </summary>
+        [DataMember(Name = "usageInfo", Order = 297)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<ICreativeWork, Uri> UsageInfo { get; set; }
+
+        /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 295)]
+        [DataMember(Name = "version", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 296)]
+        [DataMember(Name = "video", Order = 299)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 297)]
+        [DataMember(Name = "workExample", Order = 300)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 298)]
+        [DataMember(Name = "workTranslation", Order = 301)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -710,6 +734,7 @@
                 this.AccessMode == other.AccessMode &&
                 this.AccessModeSufficient == other.AccessModeSufficient &&
                 this.AccountablePerson == other.AccountablePerson &&
+                this.AcquireLicensePage == other.AcquireLicensePage &&
                 this.AggregateRating == other.AggregateRating &&
                 this.AlternativeHeadline == other.AlternativeHeadline &&
                 this.AssociatedMedia == other.AssociatedMedia &&
@@ -735,6 +760,7 @@
                 this.DateModified == other.DateModified &&
                 this.DatePublished == other.DatePublished &&
                 this.DiscussionUrl == other.DiscussionUrl &&
+                this.EditEIDR == other.EditEIDR &&
                 this.Editor == other.Editor &&
                 this.EducationalAlignment == other.EducationalAlignment &&
                 this.EducationalUse == other.EducationalUse &&
@@ -789,6 +815,7 @@
                 this.TranslationOfWork == other.TranslationOfWork &&
                 this.Translator == other.Translator &&
                 this.TypicalAgeRange == other.TypicalAgeRange &&
+                this.UsageInfo == other.UsageInfo &&
                 this.Version == other.Version &&
                 this.Video == other.Video &&
                 this.WorkExample == other.WorkExample &&
@@ -811,6 +838,7 @@
             .And(this.AccessMode)
             .And(this.AccessModeSufficient)
             .And(this.AccountablePerson)
+            .And(this.AcquireLicensePage)
             .And(this.AggregateRating)
             .And(this.AlternativeHeadline)
             .And(this.AssociatedMedia)
@@ -836,6 +864,7 @@
             .And(this.DateModified)
             .And(this.DatePublished)
             .And(this.DiscussionUrl)
+            .And(this.EditEIDR)
             .And(this.Editor)
             .And(this.EducationalAlignment)
             .And(this.EducationalUse)
@@ -890,6 +919,7 @@
             .And(this.TranslationOfWork)
             .And(this.Translator)
             .And(this.TypicalAgeRange)
+            .And(this.UsageInfo)
             .And(this.Version)
             .And(this.Video)
             .And(this.WorkExample)

--- a/Source/Schema.NET/core/combined/CreativeWorkAndSeries.cs
+++ b/Source/Schema.NET/core/combined/CreativeWorkAndSeries.cs
@@ -126,7 +126,7 @@
         /// </summary>
         [DataMember(Name = "audio", Order = 220)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public Values<IAudioObject, IClip> Audio { get; set; }
+        public Values<IAudioObject, IClip, IMusicRecording> Audio { get; set; }
 
         /// <summary>
         /// The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
@@ -260,7 +260,7 @@
         /// </summary>
         [DataMember(Name = "datePublished", Order = 239)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
-        public Values<int?, DateTime?> DatePublished { get; set; }
+        public Values<int?, DateTime?, DateTimeOffset?> DatePublished { get; set; }
 
         /// <summary>
         /// A link to the page containing the comments of the CreativeWork.
@@ -395,7 +395,7 @@
         /// </summary>
         [DataMember(Name = "isPartOf", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<ICreativeWork> IsPartOf { get; set; }
+        public Values<ICreativeWork, Uri> IsPartOf { get; set; }
 
         /// <summary>
         /// Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
@@ -433,72 +433,79 @@
         public OneOrMany<IThing> MainEntity { get; set; }
 
         /// <summary>
+        /// A maintainer of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, software package (&lt;a class="localLink" href="http://schema.org/SoftwareApplication"&gt;SoftwareApplication&lt;/a&gt;), or other &lt;a class="localLink" href="http://schema.org/Project"&gt;Project&lt;/a&gt;. A maintainer is a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When &lt;a class="localLink" href="http://schema.org/maintainer"&gt;maintainer&lt;/a&gt; is applied to a specific version of something e.g. a particular version or packaging of a &lt;a class="localLink" href="http://schema.org/Dataset"&gt;Dataset&lt;/a&gt;, it is always  possible that the upstream source has a different maintainer. The &lt;a class="localLink" href="http://schema.org/isBasedOn"&gt;isBasedOn&lt;/a&gt; property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
+        /// </summary>
+        [DataMember(Name = "maintainer", Order = 264)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public Values<IOrganization, IPerson> Maintainer { get; set; }
+
+        /// <summary>
         /// A material that something is made from, e.g. leather, wool, cotton, paper.
         /// </summary>
-        [DataMember(Name = "material", Order = 264)]
+        [DataMember(Name = "material", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IProduct, string, Uri> Material { get; set; }
 
         /// <summary>
         /// The quantity of the materials being described or an expression of the physical space they occupy.
         /// </summary>
-        [DataMember(Name = "materialExtent", Order = 265)]
+        [DataMember(Name = "materialExtent", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IQuantitativeValue, string> MaterialExtent { get; set; }
 
         /// <summary>
         /// Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
-        [DataMember(Name = "mentions", Order = 266)]
+        [DataMember(Name = "mentions", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IThing> Mentions { get; set; }
 
         /// <summary>
-        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+        /// An offer to provide this item&amp;#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use &lt;a class="localLink" href="http://schema.org/businessFunction"&gt;businessFunction&lt;/a&gt; to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a &lt;a class="localLink" href="http://schema.org/Demand"&gt;Demand&lt;/a&gt;. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
         /// </summary>
-        [DataMember(Name = "offers", Order = 267)]
+        [DataMember(Name = "offers", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
-        public OneOrMany<IOffer> Offers { get; set; }
+        public Values<IDemand, IOffer> Offers { get; set; }
 
         /// <summary>
         /// The position of an item in a series or sequence of items.
         /// </summary>
-        [DataMember(Name = "position", Order = 268)]
+        [DataMember(Name = "position", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<int?, string> Position { get; set; }
 
         /// <summary>
         /// The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
         /// </summary>
-        [DataMember(Name = "producer", Order = 269)]
+        [DataMember(Name = "producer", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Producer { get; set; }
 
         /// <summary>
         /// The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller.
         /// </summary>
-        [DataMember(Name = "provider", Order = 270)]
+        [DataMember(Name = "provider", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Provider { get; set; }
 
         /// <summary>
         /// A publication event associated with the item.
         /// </summary>
-        [DataMember(Name = "publication", Order = 271)]
+        [DataMember(Name = "publication", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> Publication { get; set; }
 
         /// <summary>
         /// The publisher of the creative work.
         /// </summary>
-        [DataMember(Name = "publisher", Order = 272)]
+        [DataMember(Name = "publisher", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Publisher { get; set; }
 
         /// <summary>
         /// The publishing division which published the comic.
         /// </summary>
-        [DataMember(Name = "publisherImprint", Order = 273)]
+        [DataMember(Name = "publisherImprint", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> PublisherImprint { get; set; }
 
@@ -506,49 +513,49 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 274)]
+        [DataMember(Name = "publishingPrinciples", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.
         /// </summary>
-        [DataMember(Name = "recordedAt", Order = 275)]
+        [DataMember(Name = "recordedAt", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IEvent> RecordedAt { get; set; }
 
         /// <summary>
         /// The place and time the release was issued, expressed as a PublicationEvent.
         /// </summary>
-        [DataMember(Name = "releasedEvent", Order = 276)]
+        [DataMember(Name = "releasedEvent", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPublicationEvent> ReleasedEvent { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 277)]
+        [DataMember(Name = "review", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
         /// </summary>
-        [DataMember(Name = "schemaVersion", Order = 278)]
+        [DataMember(Name = "schemaVersion", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<string, Uri> SchemaVersion { get; set; }
 
         /// <summary>
         /// Indicates the date on which the current structured data was generated / published. Typically used alongside &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt;
         /// </summary>
-        [DataMember(Name = "sdDatePublished", Order = 279)]
+        [DataMember(Name = "sdDatePublished", Order = 280)]
         [JsonConverter(typeof(DateTimeToIso8601DateValuesJsonConverter))]
         public Values<int?, DateTime?> SdDatePublished { get; set; }
 
         /// <summary>
         /// A license document that applies to this structured data, typically indicated by URL.
         /// </summary>
-        [DataMember(Name = "sdLicense", Order = 280)]
+        [DataMember(Name = "sdLicense", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<ICreativeWork, Uri> SdLicense { get; set; }
 
@@ -556,14 +563,14 @@
         /// Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
         /// &lt;a class="localLink" href="http://schema.org/sdPublisher"&gt;sdPublisher&lt;/a&gt; property helps make such practices more explicit.
         /// </summary>
-        [DataMember(Name = "sdPublisher", Order = 281)]
+        [DataMember(Name = "sdPublisher", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> SdPublisher { get; set; }
 
         /// <summary>
         /// The Organization on whose behalf the creator was working.
         /// </summary>
-        [DataMember(Name = "sourceOrganization", Order = 282)]
+        [DataMember(Name = "sourceOrganization", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IOrganization> SourceOrganization { get; set; }
 
@@ -571,7 +578,7 @@
         /// The "spatial" property can be used in cases when more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/locationCreated"&gt;locationCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/spatialCoverage"&gt;spatialCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/contentLocation"&gt;contentLocation&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "spatial", Order = 283)]
+        [DataMember(Name = "spatial", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> Spatial { get; set; }
 
@@ -580,14 +587,14 @@
         ///       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
         ///       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
         /// </summary>
-        [DataMember(Name = "spatialCoverage", Order = 284)]
+        [DataMember(Name = "spatialCoverage", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<IPlace> SpatialCoverage { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 285)]
+        [DataMember(Name = "sponsor", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Sponsor { get; set; }
 
@@ -595,7 +602,7 @@
         /// The "temporal" property can be used in cases where more specific properties
         /// (e.g. &lt;a class="localLink" href="http://schema.org/temporalCoverage"&gt;temporalCoverage&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateCreated"&gt;dateCreated&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/dateModified"&gt;dateModified&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/datePublished"&gt;datePublished&lt;/a&gt;) are not known to be appropriate.
         /// </summary>
-        [DataMember(Name = "temporal", Order = 286)]
+        [DataMember(Name = "temporal", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string> Temporal { get; set; }
 
@@ -605,77 +612,77 @@
         ///       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".&lt;br/&gt;&lt;br/&gt;
         /// Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
         /// </summary>
-        [DataMember(Name = "temporalCoverage", Order = 287)]
+        [DataMember(Name = "temporalCoverage", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<DateTimeOffset?, string, Uri> TemporalCoverage { get; set; }
 
         /// <summary>
         /// The textual content of this CreativeWork.
         /// </summary>
-        [DataMember(Name = "text", Order = 288)]
+        [DataMember(Name = "text", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> Text { get; set; }
 
         /// <summary>
         /// A thumbnail image relevant to the Thing.
         /// </summary>
-        [DataMember(Name = "thumbnailUrl", Order = 289)]
+        [DataMember(Name = "thumbnailUrl", Order = 290)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<Uri> ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
         /// </summary>
-        [DataMember(Name = "timeRequired", Order = 290)]
+        [DataMember(Name = "timeRequired", Order = 291)]
         [JsonConverter(typeof(TimeSpanToISO8601DurationValuesJsonConverter))]
         public OneOrMany<TimeSpan?> TimeRequired { get; set; }
 
         /// <summary>
         /// The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”
         /// </summary>
-        [DataMember(Name = "translationOfWork", Order = 291)]
+        [DataMember(Name = "translationOfWork", Order = 292)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> TranslationOfWork { get; set; }
 
         /// <summary>
         /// Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
         /// </summary>
-        [DataMember(Name = "translator", Order = 292)]
+        [DataMember(Name = "translator", Order = 293)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IOrganization, IPerson> Translator { get; set; }
 
         /// <summary>
         /// The typical expected age range, e.g. '7-9', '11-'.
         /// </summary>
-        [DataMember(Name = "typicalAgeRange", Order = 293)]
+        [DataMember(Name = "typicalAgeRange", Order = 294)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> TypicalAgeRange { get; set; }
 
         /// <summary>
         /// The version of the CreativeWork embodied by a specified resource.
         /// </summary>
-        [DataMember(Name = "version", Order = 294)]
+        [DataMember(Name = "version", Order = 295)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<double?, string> Version { get; set; }
 
         /// <summary>
         /// An embedded video object.
         /// </summary>
-        [DataMember(Name = "video", Order = 295)]
+        [DataMember(Name = "video", Order = 296)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public Values<IClip, IVideoObject> Video { get; set; }
 
         /// <summary>
         /// Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.
         /// </summary>
-        [DataMember(Name = "workExample", Order = 296)]
+        [DataMember(Name = "workExample", Order = 297)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkExample { get; set; }
 
         /// <summary>
         /// A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.
         /// </summary>
-        [DataMember(Name = "workTranslation", Order = 297)]
+        [DataMember(Name = "workTranslation", Order = 298)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<ICreativeWork> WorkTranslation { get; set; }
 
@@ -751,6 +758,7 @@
                 this.License == other.License &&
                 this.LocationCreated == other.LocationCreated &&
                 this.MainEntity == other.MainEntity &&
+                this.Maintainer == other.Maintainer &&
                 this.Material == other.Material &&
                 this.MaterialExtent == other.MaterialExtent &&
                 this.Mentions == other.Mentions &&
@@ -851,6 +859,7 @@
             .And(this.License)
             .And(this.LocationCreated)
             .And(this.MainEntity)
+            .And(this.Maintainer)
             .And(this.Material)
             .And(this.MaterialExtent)
             .And(this.Mentions)

--- a/Source/Schema.NET/core/combined/LocalBusinessAndOrganization.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndOrganization.cs
@@ -214,86 +214,93 @@
         public override OneOrMany<IPlace> HasPOS { get; set; }
 
         /// <summary>
+        /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
+        /// </summary>
+        [DataMember(Name = "interactionStatistic", Order = 233)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
+
+        /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 233)]
+        [DataMember(Name = "isicV4", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        [DataMember(Name = "knowsAbout", Order = 234)]
+        [DataMember(Name = "knowsAbout", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "knowsLanguage", Order = 235)]
+        [DataMember(Name = "knowsLanguage", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
         /// </summary>
-        [DataMember(Name = "legalName", Order = 236)]
+        [DataMember(Name = "legalName", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> LegalName { get; set; }
 
         /// <summary>
         /// An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.
         /// </summary>
-        [DataMember(Name = "leiCode", Order = 237)]
+        [DataMember(Name = "leiCode", Order = 238)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> LeiCode { get; set; }
 
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        [DataMember(Name = "location", Order = 238)]
+        [DataMember(Name = "location", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 239)]
+        [DataMember(Name = "logo", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
         /// </summary>
-        [DataMember(Name = "makesOffer", Order = 240)]
+        [DataMember(Name = "makesOffer", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOffer> MakesOffer { get; set; }
 
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        [DataMember(Name = "member", Order = 241)]
+        [DataMember(Name = "member", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        [DataMember(Name = "memberOf", Order = 242)]
+        [DataMember(Name = "memberOf", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
         /// </summary>
-        [DataMember(Name = "naics", Order = 243)]
+        [DataMember(Name = "naics", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Naics { get; set; }
 
         /// <summary>
         /// The number of employees in an organization e.g. business.
         /// </summary>
-        [DataMember(Name = "numberOfEmployees", Order = 244)]
+        [DataMember(Name = "numberOfEmployees", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IQuantitativeValue> NumberOfEmployees { get; set; }
 
@@ -306,42 +313,42 @@
         /// &lt;li&gt;If a business is open 7 days a week, then it can be specified as &lt;code&gt;&amp;lt;time itemprop=&amp;quot;openingHours&amp;quot; datetime=&amp;quot;Mo-Su&amp;quot;&amp;gt;Monday through Sunday, all day&amp;lt;/time&amp;gt;&lt;/code&gt;.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        [DataMember(Name = "openingHours", Order = 245)]
+        [DataMember(Name = "openingHours", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> OpeningHours { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt; is also available and can be used to make basic funder information machine-readable.
         /// </summary>
-        [DataMember(Name = "ownershipFundingInfo", Order = 246)]
+        [DataMember(Name = "ownershipFundingInfo", Order = 247)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        [DataMember(Name = "owns", Order = 247)]
+        [DataMember(Name = "owns", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
         /// </summary>
-        [DataMember(Name = "parentOrganization", Order = 248)]
+        [DataMember(Name = "parentOrganization", Order = 249)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOrganization> ParentOrganization { get; set; }
 
         /// <summary>
         /// Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc.
         /// </summary>
-        [DataMember(Name = "paymentAccepted", Order = 249)]
+        [DataMember(Name = "paymentAccepted", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PaymentAccepted { get; set; }
 
         /// <summary>
         /// The price range of the business, for example &lt;code&gt;$$$&lt;/code&gt;.
         /// </summary>
-        [DataMember(Name = "priceRange", Order = 250)]
+        [DataMember(Name = "priceRange", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PriceRange { get; set; }
 
@@ -349,70 +356,70 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 251)]
+        [DataMember(Name = "publishingPrinciples", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 252)]
+        [DataMember(Name = "review", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A pointer to products or services sought by the organization or person (demand).
         /// </summary>
-        [DataMember(Name = "seeks", Order = 253)]
+        [DataMember(Name = "seeks", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IDemand> Seeks { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 254)]
+        [DataMember(Name = "slogan", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 255)]
+        [DataMember(Name = "sponsor", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
         /// </summary>
-        [DataMember(Name = "subOrganization", Order = 256)]
+        [DataMember(Name = "subOrganization", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOrganization> SubOrganization { get; set; }
 
         /// <summary>
         /// The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain.
         /// </summary>
-        [DataMember(Name = "taxID", Order = 257)]
+        [DataMember(Name = "taxID", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> TaxID { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 258)]
+        [DataMember(Name = "telephone", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Telephone { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (typically a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement about policy on use of unnamed sources and the decision process required.
         /// </summary>
-        [DataMember(Name = "unnamedSourcesPolicy", Order = 259)]
+        [DataMember(Name = "unnamedSourcesPolicy", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
         /// </summary>
-        [DataMember(Name = "vatID", Order = 260)]
+        [DataMember(Name = "vatID", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> VatID { get; set; }
 
@@ -457,6 +464,7 @@
                 this.GlobalLocationNumber == other.GlobalLocationNumber &&
                 this.HasOfferCatalog == other.HasOfferCatalog &&
                 this.HasPOS == other.HasPOS &&
+                this.InteractionStatistic == other.InteractionStatistic &&
                 this.IsicV4 == other.IsicV4 &&
                 this.KnowsAbout == other.KnowsAbout &&
                 this.KnowsLanguage == other.KnowsLanguage &&
@@ -520,6 +528,7 @@
             .And(this.GlobalLocationNumber)
             .And(this.HasOfferCatalog)
             .And(this.HasPOS)
+            .And(this.InteractionStatistic)
             .And(this.IsicV4)
             .And(this.KnowsAbout)
             .And(this.KnowsLanguage)

--- a/Source/Schema.NET/core/combined/LocalBusinessAndOrganizationAndPlace.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndOrganizationAndPlace.cs
@@ -314,142 +314,149 @@
         public override OneOrMany<string> GlobalLocationNumber { get; set; }
 
         /// <summary>
+        /// Indicates whether some facility (e.g. &lt;a class="localLink" href="http://schema.org/FoodEstablishment"&gt;FoodEstablishment&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt;) offers a service that can be used by driving through in a car. In the case of &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt; such facilities could potentially help with social distancing from other potentially-infected users.
+        /// </summary>
+        [DataMember(Name = "hasDriveThroughService", Order = 247)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<bool?> HasDriveThroughService { get; set; }
+
+        /// <summary>
         /// A URL to a map of the place.
         /// </summary>
-        [DataMember(Name = "hasMap", Order = 247)]
+        [DataMember(Name = "hasMap", Order = 248)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// Indicates an OfferCatalog listing for this Organization, Person, or Service.
         /// </summary>
-        [DataMember(Name = "hasOfferCatalog", Order = 248)]
+        [DataMember(Name = "hasOfferCatalog", Order = 249)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOfferCatalog> HasOfferCatalog { get; set; }
 
         /// <summary>
         /// Points-of-Sales operated by the organization or person.
         /// </summary>
-        [DataMember(Name = "hasPOS", Order = 249)]
+        [DataMember(Name = "hasPOS", Order = 250)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IPlace> HasPOS { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 250)]
+        [DataMember(Name = "interactionStatistic", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 251)]
+        [DataMember(Name = "isAccessibleForFree", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 252)]
+        [DataMember(Name = "isicV4", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        [DataMember(Name = "knowsAbout", Order = 253)]
+        [DataMember(Name = "knowsAbout", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "knowsLanguage", Order = 254)]
+        [DataMember(Name = "knowsLanguage", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "latitude", Order = 255)]
+        [DataMember(Name = "latitude", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
         /// </summary>
-        [DataMember(Name = "legalName", Order = 256)]
+        [DataMember(Name = "legalName", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> LegalName { get; set; }
 
         /// <summary>
         /// An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.
         /// </summary>
-        [DataMember(Name = "leiCode", Order = 257)]
+        [DataMember(Name = "leiCode", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> LeiCode { get; set; }
 
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        [DataMember(Name = "location", Order = 258)]
+        [DataMember(Name = "location", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 259)]
+        [DataMember(Name = "logo", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "longitude", Order = 260)]
+        [DataMember(Name = "longitude", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
         /// </summary>
-        [DataMember(Name = "makesOffer", Order = 261)]
+        [DataMember(Name = "makesOffer", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOffer> MakesOffer { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
         /// </summary>
-        [DataMember(Name = "maximumAttendeeCapacity", Order = 262)]
+        [DataMember(Name = "maximumAttendeeCapacity", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        [DataMember(Name = "member", Order = 263)]
+        [DataMember(Name = "member", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        [DataMember(Name = "memberOf", Order = 264)]
+        [DataMember(Name = "memberOf", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
         /// </summary>
-        [DataMember(Name = "naics", Order = 265)]
+        [DataMember(Name = "naics", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Naics { get; set; }
 
         /// <summary>
         /// The number of employees in an organization e.g. business.
         /// </summary>
-        [DataMember(Name = "numberOfEmployees", Order = 266)]
+        [DataMember(Name = "numberOfEmployees", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IQuantitativeValue> NumberOfEmployees { get; set; }
 
@@ -462,63 +469,63 @@
         /// &lt;li&gt;If a business is open 7 days a week, then it can be specified as &lt;code&gt;&amp;lt;time itemprop=&amp;quot;openingHours&amp;quot; datetime=&amp;quot;Mo-Su&amp;quot;&amp;gt;Monday through Sunday, all day&amp;lt;/time&amp;gt;&lt;/code&gt;.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        [DataMember(Name = "openingHours", Order = 267)]
+        [DataMember(Name = "openingHours", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> OpeningHours { get; set; }
 
         /// <summary>
         /// The opening hours of a certain place.
         /// </summary>
-        [DataMember(Name = "openingHoursSpecification", Order = 268)]
+        [DataMember(Name = "openingHoursSpecification", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOpeningHoursSpecification> OpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt; is also available and can be used to make basic funder information machine-readable.
         /// </summary>
-        [DataMember(Name = "ownershipFundingInfo", Order = 269)]
+        [DataMember(Name = "ownershipFundingInfo", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        [DataMember(Name = "owns", Order = 270)]
+        [DataMember(Name = "owns", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
         /// </summary>
-        [DataMember(Name = "parentOrganization", Order = 271)]
+        [DataMember(Name = "parentOrganization", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOrganization> ParentOrganization { get; set; }
 
         /// <summary>
         /// Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc.
         /// </summary>
-        [DataMember(Name = "paymentAccepted", Order = 272)]
+        [DataMember(Name = "paymentAccepted", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PaymentAccepted { get; set; }
 
         /// <summary>
         /// A photograph of this place.
         /// </summary>
-        [DataMember(Name = "photo", Order = 273)]
+        [DataMember(Name = "photo", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// The price range of the business, for example &lt;code&gt;$$$&lt;/code&gt;.
         /// </summary>
-        [DataMember(Name = "priceRange", Order = 274)]
+        [DataMember(Name = "priceRange", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PriceRange { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
         /// </summary>
-        [DataMember(Name = "publicAccess", Order = 275)]
+        [DataMember(Name = "publicAccess", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> PublicAccess { get; set; }
 
@@ -526,35 +533,35 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 276)]
+        [DataMember(Name = "publishingPrinciples", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 277)]
+        [DataMember(Name = "review", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A pointer to products or services sought by the organization or person (demand).
         /// </summary>
-        [DataMember(Name = "seeks", Order = 278)]
+        [DataMember(Name = "seeks", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IDemand> Seeks { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 279)]
+        [DataMember(Name = "slogan", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room.
         /// </summary>
-        [DataMember(Name = "smokingAllowed", Order = 280)]
+        [DataMember(Name = "smokingAllowed", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> SmokingAllowed { get; set; }
 
@@ -562,49 +569,56 @@
         /// The special opening hours of a certain place.&lt;br/&gt;&lt;br/&gt;
         /// Use this to explicitly override general opening hours brought in scope by &lt;a class="localLink" href="http://schema.org/openingHoursSpecification"&gt;openingHoursSpecification&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/openingHours"&gt;openingHours&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "specialOpeningHoursSpecification", Order = 281)]
+        [DataMember(Name = "specialOpeningHoursSpecification", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOpeningHoursSpecification> SpecialOpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 282)]
+        [DataMember(Name = "sponsor", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
         /// </summary>
-        [DataMember(Name = "subOrganization", Order = 283)]
+        [DataMember(Name = "subOrganization", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOrganization> SubOrganization { get; set; }
 
         /// <summary>
         /// The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain.
         /// </summary>
-        [DataMember(Name = "taxID", Order = 284)]
+        [DataMember(Name = "taxID", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> TaxID { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 285)]
+        [DataMember(Name = "telephone", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Telephone { get; set; }
 
         /// <summary>
+        /// A page providing information on how to book a tour of some &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt;, such as an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; in a real estate setting, as well as other kinds of tours as appropriate.
+        /// </summary>
+        [DataMember(Name = "tourBookingPage", Order = 287)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<Uri> TourBookingPage { get; set; }
+
+        /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (typically a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement about policy on use of unnamed sources and the decision process required.
         /// </summary>
-        [DataMember(Name = "unnamedSourcesPolicy", Order = 286)]
+        [DataMember(Name = "unnamedSourcesPolicy", Order = 288)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
         /// </summary>
-        [DataMember(Name = "vatID", Order = 287)]
+        [DataMember(Name = "vatID", Order = 289)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> VatID { get; set; }
 
@@ -663,6 +677,7 @@
                 this.GeoTouches == other.GeoTouches &&
                 this.GeoWithin == other.GeoWithin &&
                 this.GlobalLocationNumber == other.GlobalLocationNumber &&
+                this.HasDriveThroughService == other.HasDriveThroughService &&
                 this.HasMap == other.HasMap &&
                 this.HasOfferCatalog == other.HasOfferCatalog &&
                 this.HasPOS == other.HasPOS &&
@@ -702,6 +717,7 @@
                 this.SubOrganization == other.SubOrganization &&
                 this.TaxID == other.TaxID &&
                 this.Telephone == other.Telephone &&
+                this.TourBookingPage == other.TourBookingPage &&
                 this.UnnamedSourcesPolicy == other.UnnamedSourcesPolicy &&
                 this.VatID == other.VatID &&
                 base.Equals(other);
@@ -753,6 +769,7 @@
             .And(this.GeoTouches)
             .And(this.GeoWithin)
             .And(this.GlobalLocationNumber)
+            .And(this.HasDriveThroughService)
             .And(this.HasMap)
             .And(this.HasOfferCatalog)
             .And(this.HasPOS)
@@ -792,6 +809,7 @@
             .And(this.SubOrganization)
             .And(this.TaxID)
             .And(this.Telephone)
+            .And(this.TourBookingPage)
             .And(this.UnnamedSourcesPolicy)
             .And(this.VatID)
             .And(base.GetHashCode());

--- a/Source/Schema.NET/core/combined/LocalBusinessAndOrganizationAndPlace.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndOrganizationAndPlace.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See LocalBusiness, Organization, Place for more information.
     /// </summary>
-    public partial interface ILocalBusinessAndOrganizationAndPlace : IPlace, ILocalBusiness, IOrganization
+    public partial interface ILocalBusinessAndOrganizationAndPlace : ILocalBusiness, IOrganization, IPlace
     {
     }
 
@@ -335,114 +335,121 @@
         public override OneOrMany<IPlace> HasPOS { get; set; }
 
         /// <summary>
+        /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
+        /// </summary>
+        [DataMember(Name = "interactionStatistic", Order = 250)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
+
+        /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 250)]
+        [DataMember(Name = "isAccessibleForFree", Order = 251)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 251)]
+        [DataMember(Name = "isicV4", Order = 252)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        [DataMember(Name = "knowsAbout", Order = 252)]
+        [DataMember(Name = "knowsAbout", Order = 253)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "knowsLanguage", Order = 253)]
+        [DataMember(Name = "knowsLanguage", Order = 254)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "latitude", Order = 254)]
+        [DataMember(Name = "latitude", Order = 255)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
         /// </summary>
-        [DataMember(Name = "legalName", Order = 255)]
+        [DataMember(Name = "legalName", Order = 256)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> LegalName { get; set; }
 
         /// <summary>
         /// An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.
         /// </summary>
-        [DataMember(Name = "leiCode", Order = 256)]
+        [DataMember(Name = "leiCode", Order = 257)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> LeiCode { get; set; }
 
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        [DataMember(Name = "location", Order = 257)]
+        [DataMember(Name = "location", Order = 258)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 258)]
+        [DataMember(Name = "logo", Order = 259)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "longitude", Order = 259)]
+        [DataMember(Name = "longitude", Order = 260)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
         /// </summary>
-        [DataMember(Name = "makesOffer", Order = 260)]
+        [DataMember(Name = "makesOffer", Order = 261)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOffer> MakesOffer { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
         /// </summary>
-        [DataMember(Name = "maximumAttendeeCapacity", Order = 261)]
+        [DataMember(Name = "maximumAttendeeCapacity", Order = 262)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        [DataMember(Name = "member", Order = 262)]
+        [DataMember(Name = "member", Order = 263)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        [DataMember(Name = "memberOf", Order = 263)]
+        [DataMember(Name = "memberOf", Order = 264)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
         /// </summary>
-        [DataMember(Name = "naics", Order = 264)]
+        [DataMember(Name = "naics", Order = 265)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Naics { get; set; }
 
         /// <summary>
         /// The number of employees in an organization e.g. business.
         /// </summary>
-        [DataMember(Name = "numberOfEmployees", Order = 265)]
+        [DataMember(Name = "numberOfEmployees", Order = 266)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IQuantitativeValue> NumberOfEmployees { get; set; }
 
@@ -455,63 +462,63 @@
         /// &lt;li&gt;If a business is open 7 days a week, then it can be specified as &lt;code&gt;&amp;lt;time itemprop=&amp;quot;openingHours&amp;quot; datetime=&amp;quot;Mo-Su&amp;quot;&amp;gt;Monday through Sunday, all day&amp;lt;/time&amp;gt;&lt;/code&gt;.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        [DataMember(Name = "openingHours", Order = 266)]
+        [DataMember(Name = "openingHours", Order = 267)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> OpeningHours { get; set; }
 
         /// <summary>
         /// The opening hours of a certain place.
         /// </summary>
-        [DataMember(Name = "openingHoursSpecification", Order = 267)]
+        [DataMember(Name = "openingHoursSpecification", Order = 268)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOpeningHoursSpecification> OpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt; is also available and can be used to make basic funder information machine-readable.
         /// </summary>
-        [DataMember(Name = "ownershipFundingInfo", Order = 268)]
+        [DataMember(Name = "ownershipFundingInfo", Order = 269)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        [DataMember(Name = "owns", Order = 269)]
+        [DataMember(Name = "owns", Order = 270)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
         /// </summary>
-        [DataMember(Name = "parentOrganization", Order = 270)]
+        [DataMember(Name = "parentOrganization", Order = 271)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOrganization> ParentOrganization { get; set; }
 
         /// <summary>
         /// Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc.
         /// </summary>
-        [DataMember(Name = "paymentAccepted", Order = 271)]
+        [DataMember(Name = "paymentAccepted", Order = 272)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PaymentAccepted { get; set; }
 
         /// <summary>
         /// A photograph of this place.
         /// </summary>
-        [DataMember(Name = "photo", Order = 272)]
+        [DataMember(Name = "photo", Order = 273)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// The price range of the business, for example &lt;code&gt;$$$&lt;/code&gt;.
         /// </summary>
-        [DataMember(Name = "priceRange", Order = 273)]
+        [DataMember(Name = "priceRange", Order = 274)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PriceRange { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
         /// </summary>
-        [DataMember(Name = "publicAccess", Order = 274)]
+        [DataMember(Name = "publicAccess", Order = 275)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> PublicAccess { get; set; }
 
@@ -519,35 +526,35 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 275)]
+        [DataMember(Name = "publishingPrinciples", Order = 276)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 276)]
+        [DataMember(Name = "review", Order = 277)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A pointer to products or services sought by the organization or person (demand).
         /// </summary>
-        [DataMember(Name = "seeks", Order = 277)]
+        [DataMember(Name = "seeks", Order = 278)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IDemand> Seeks { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 278)]
+        [DataMember(Name = "slogan", Order = 279)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room.
         /// </summary>
-        [DataMember(Name = "smokingAllowed", Order = 279)]
+        [DataMember(Name = "smokingAllowed", Order = 280)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> SmokingAllowed { get; set; }
 
@@ -555,49 +562,49 @@
         /// The special opening hours of a certain place.&lt;br/&gt;&lt;br/&gt;
         /// Use this to explicitly override general opening hours brought in scope by &lt;a class="localLink" href="http://schema.org/openingHoursSpecification"&gt;openingHoursSpecification&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/openingHours"&gt;openingHours&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "specialOpeningHoursSpecification", Order = 280)]
+        [DataMember(Name = "specialOpeningHoursSpecification", Order = 281)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOpeningHoursSpecification> SpecialOpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 281)]
+        [DataMember(Name = "sponsor", Order = 282)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
         /// </summary>
-        [DataMember(Name = "subOrganization", Order = 282)]
+        [DataMember(Name = "subOrganization", Order = 283)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOrganization> SubOrganization { get; set; }
 
         /// <summary>
         /// The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain.
         /// </summary>
-        [DataMember(Name = "taxID", Order = 283)]
+        [DataMember(Name = "taxID", Order = 284)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> TaxID { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 284)]
+        [DataMember(Name = "telephone", Order = 285)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Telephone { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (typically a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement about policy on use of unnamed sources and the decision process required.
         /// </summary>
-        [DataMember(Name = "unnamedSourcesPolicy", Order = 285)]
+        [DataMember(Name = "unnamedSourcesPolicy", Order = 286)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
         /// </summary>
-        [DataMember(Name = "vatID", Order = 286)]
+        [DataMember(Name = "vatID", Order = 287)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> VatID { get; set; }
 
@@ -659,6 +666,7 @@
                 this.HasMap == other.HasMap &&
                 this.HasOfferCatalog == other.HasOfferCatalog &&
                 this.HasPOS == other.HasPOS &&
+                this.InteractionStatistic == other.InteractionStatistic &&
                 this.IsAccessibleForFree == other.IsAccessibleForFree &&
                 this.IsicV4 == other.IsicV4 &&
                 this.KnowsAbout == other.KnowsAbout &&
@@ -748,6 +756,7 @@
             .And(this.HasMap)
             .And(this.HasOfferCatalog)
             .And(this.HasPOS)
+            .And(this.InteractionStatistic)
             .And(this.IsAccessibleForFree)
             .And(this.IsicV4)
             .And(this.KnowsAbout)

--- a/Source/Schema.NET/core/combined/LocalBusinessAndPlace.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndPlace.cs
@@ -181,51 +181,58 @@
         public override OneOrMany<string> GlobalLocationNumber { get; set; }
 
         /// <summary>
+        /// Indicates whether some facility (e.g. &lt;a class="localLink" href="http://schema.org/FoodEstablishment"&gt;FoodEstablishment&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt;) offers a service that can be used by driving through in a car. In the case of &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt; such facilities could potentially help with social distancing from other potentially-infected users.
+        /// </summary>
+        [DataMember(Name = "hasDriveThroughService", Order = 228)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<bool?> HasDriveThroughService { get; set; }
+
+        /// <summary>
         /// A URL to a map of the place.
         /// </summary>
-        [DataMember(Name = "hasMap", Order = 228)]
+        [DataMember(Name = "hasMap", Order = 229)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 229)]
+        [DataMember(Name = "isAccessibleForFree", Order = 230)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 230)]
+        [DataMember(Name = "isicV4", Order = 231)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "latitude", Order = 231)]
+        [DataMember(Name = "latitude", Order = 232)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 232)]
+        [DataMember(Name = "logo", Order = 233)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "longitude", Order = 233)]
+        [DataMember(Name = "longitude", Order = 234)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
         /// </summary>
-        [DataMember(Name = "maximumAttendeeCapacity", Order = 234)]
+        [DataMember(Name = "maximumAttendeeCapacity", Order = 235)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
@@ -238,63 +245,63 @@
         /// &lt;li&gt;If a business is open 7 days a week, then it can be specified as &lt;code&gt;&amp;lt;time itemprop=&amp;quot;openingHours&amp;quot; datetime=&amp;quot;Mo-Su&amp;quot;&amp;gt;Monday through Sunday, all day&amp;lt;/time&amp;gt;&lt;/code&gt;.&lt;/li&gt;
         /// &lt;/ul&gt;
         /// </summary>
-        [DataMember(Name = "openingHours", Order = 235)]
+        [DataMember(Name = "openingHours", Order = 236)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> OpeningHours { get; set; }
 
         /// <summary>
         /// The opening hours of a certain place.
         /// </summary>
-        [DataMember(Name = "openingHoursSpecification", Order = 236)]
+        [DataMember(Name = "openingHoursSpecification", Order = 237)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOpeningHoursSpecification> OpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc.
         /// </summary>
-        [DataMember(Name = "paymentAccepted", Order = 237)]
+        [DataMember(Name = "paymentAccepted", Order = 238)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PaymentAccepted { get; set; }
 
         /// <summary>
         /// A photograph of this place.
         /// </summary>
-        [DataMember(Name = "photo", Order = 238)]
+        [DataMember(Name = "photo", Order = 239)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// The price range of the business, for example &lt;code&gt;$$$&lt;/code&gt;.
         /// </summary>
-        [DataMember(Name = "priceRange", Order = 239)]
+        [DataMember(Name = "priceRange", Order = 240)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public OneOrMany<string> PriceRange { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
         /// </summary>
-        [DataMember(Name = "publicAccess", Order = 240)]
+        [DataMember(Name = "publicAccess", Order = 241)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> PublicAccess { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 241)]
+        [DataMember(Name = "review", Order = 242)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 242)]
+        [DataMember(Name = "slogan", Order = 243)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room.
         /// </summary>
-        [DataMember(Name = "smokingAllowed", Order = 243)]
+        [DataMember(Name = "smokingAllowed", Order = 244)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<bool?> SmokingAllowed { get; set; }
 
@@ -302,16 +309,23 @@
         /// The special opening hours of a certain place.&lt;br/&gt;&lt;br/&gt;
         /// Use this to explicitly override general opening hours brought in scope by &lt;a class="localLink" href="http://schema.org/openingHoursSpecification"&gt;openingHoursSpecification&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/openingHours"&gt;openingHours&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "specialOpeningHoursSpecification", Order = 244)]
+        [DataMember(Name = "specialOpeningHoursSpecification", Order = 245)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<IOpeningHoursSpecification> SpecialOpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 245)]
+        [DataMember(Name = "telephone", Order = 246)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public override OneOrMany<string> Telephone { get; set; }
+
+        /// <summary>
+        /// A page providing information on how to book a tour of some &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt;, such as an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; in a real estate setting, as well as other kinds of tours as appropriate.
+        /// </summary>
+        [DataMember(Name = "tourBookingPage", Order = 247)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public override OneOrMany<Uri> TourBookingPage { get; set; }
 
         /// <inheritdoc/>
         public bool Equals(LocalBusinessAndPlace other)
@@ -349,6 +363,7 @@
                 this.GeoTouches == other.GeoTouches &&
                 this.GeoWithin == other.GeoWithin &&
                 this.GlobalLocationNumber == other.GlobalLocationNumber &&
+                this.HasDriveThroughService == other.HasDriveThroughService &&
                 this.HasMap == other.HasMap &&
                 this.IsAccessibleForFree == other.IsAccessibleForFree &&
                 this.IsicV4 == other.IsicV4 &&
@@ -367,6 +382,7 @@
                 this.SmokingAllowed == other.SmokingAllowed &&
                 this.SpecialOpeningHoursSpecification == other.SpecialOpeningHoursSpecification &&
                 this.Telephone == other.Telephone &&
+                this.TourBookingPage == other.TourBookingPage &&
                 base.Equals(other);
         }
 
@@ -397,6 +413,7 @@
             .And(this.GeoTouches)
             .And(this.GeoWithin)
             .And(this.GlobalLocationNumber)
+            .And(this.HasDriveThroughService)
             .And(this.HasMap)
             .And(this.IsAccessibleForFree)
             .And(this.IsicV4)
@@ -415,6 +432,7 @@
             .And(this.SmokingAllowed)
             .And(this.SpecialOpeningHoursSpecification)
             .And(this.Telephone)
+            .And(this.TourBookingPage)
             .And(base.GetHashCode());
     }
 }

--- a/Source/Schema.NET/core/combined/LocalBusinessAndPlace.cs
+++ b/Source/Schema.NET/core/combined/LocalBusinessAndPlace.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// See LocalBusiness, Place for more information.
     /// </summary>
-    public partial interface ILocalBusinessAndPlace : IPlace, ILocalBusiness
+    public partial interface ILocalBusinessAndPlace : ILocalBusiness, IPlace
     {
     }
 

--- a/Source/Schema.NET/core/combined/OrganizationAndPlace.cs
+++ b/Source/Schema.NET/core/combined/OrganizationAndPlace.cs
@@ -327,156 +327,163 @@
         public virtual OneOrMany<IPlace> HasPOS { get; set; }
 
         /// <summary>
+        /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
+        /// </summary>
+        [DataMember(Name = "interactionStatistic", Order = 149)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public virtual OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
+
+        /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 149)]
+        [DataMember(Name = "isAccessibleForFree", Order = 150)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 150)]
+        [DataMember(Name = "isicV4", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        [DataMember(Name = "knowsAbout", Order = 151)]
+        [DataMember(Name = "knowsAbout", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "knowsLanguage", Order = 152)]
+        [DataMember(Name = "knowsLanguage", Order = 153)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "latitude", Order = 153)]
+        [DataMember(Name = "latitude", Order = 154)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
         /// </summary>
-        [DataMember(Name = "legalName", Order = 154)]
+        [DataMember(Name = "legalName", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> LegalName { get; set; }
 
         /// <summary>
         /// An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.
         /// </summary>
-        [DataMember(Name = "leiCode", Order = 155)]
+        [DataMember(Name = "leiCode", Order = 156)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> LeiCode { get; set; }
 
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        [DataMember(Name = "location", Order = 156)]
+        [DataMember(Name = "location", Order = 157)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 157)]
+        [DataMember(Name = "logo", Order = 158)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "longitude", Order = 158)]
+        [DataMember(Name = "longitude", Order = 159)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
         /// </summary>
-        [DataMember(Name = "makesOffer", Order = 159)]
+        [DataMember(Name = "makesOffer", Order = 160)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOffer> MakesOffer { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
         /// </summary>
-        [DataMember(Name = "maximumAttendeeCapacity", Order = 160)]
+        [DataMember(Name = "maximumAttendeeCapacity", Order = 161)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        [DataMember(Name = "member", Order = 161)]
+        [DataMember(Name = "member", Order = 162)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        [DataMember(Name = "memberOf", Order = 162)]
+        [DataMember(Name = "memberOf", Order = 163)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
         /// </summary>
-        [DataMember(Name = "naics", Order = 163)]
+        [DataMember(Name = "naics", Order = 164)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> Naics { get; set; }
 
         /// <summary>
         /// The number of employees in an organization e.g. business.
         /// </summary>
-        [DataMember(Name = "numberOfEmployees", Order = 164)]
+        [DataMember(Name = "numberOfEmployees", Order = 165)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IQuantitativeValue> NumberOfEmployees { get; set; }
 
         /// <summary>
         /// The opening hours of a certain place.
         /// </summary>
-        [DataMember(Name = "openingHoursSpecification", Order = 165)]
+        [DataMember(Name = "openingHoursSpecification", Order = 166)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOpeningHoursSpecification> OpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt; is also available and can be used to make basic funder information machine-readable.
         /// </summary>
-        [DataMember(Name = "ownershipFundingInfo", Order = 166)]
+        [DataMember(Name = "ownershipFundingInfo", Order = 167)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        [DataMember(Name = "owns", Order = 167)]
+        [DataMember(Name = "owns", Order = 168)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
         /// </summary>
-        [DataMember(Name = "parentOrganization", Order = 168)]
+        [DataMember(Name = "parentOrganization", Order = 169)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOrganization> ParentOrganization { get; set; }
 
         /// <summary>
         /// A photograph of this place.
         /// </summary>
-        [DataMember(Name = "photo", Order = 169)]
+        [DataMember(Name = "photo", Order = 170)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
         /// </summary>
-        [DataMember(Name = "publicAccess", Order = 170)]
+        [DataMember(Name = "publicAccess", Order = 171)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<bool?> PublicAccess { get; set; }
 
@@ -484,35 +491,35 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 171)]
+        [DataMember(Name = "publishingPrinciples", Order = 172)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 172)]
+        [DataMember(Name = "review", Order = 173)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A pointer to products or services sought by the organization or person (demand).
         /// </summary>
-        [DataMember(Name = "seeks", Order = 173)]
+        [DataMember(Name = "seeks", Order = 174)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IDemand> Seeks { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 174)]
+        [DataMember(Name = "slogan", Order = 175)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room.
         /// </summary>
-        [DataMember(Name = "smokingAllowed", Order = 175)]
+        [DataMember(Name = "smokingAllowed", Order = 176)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<bool?> SmokingAllowed { get; set; }
 
@@ -520,49 +527,49 @@
         /// The special opening hours of a certain place.&lt;br/&gt;&lt;br/&gt;
         /// Use this to explicitly override general opening hours brought in scope by &lt;a class="localLink" href="http://schema.org/openingHoursSpecification"&gt;openingHoursSpecification&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/openingHours"&gt;openingHours&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "specialOpeningHoursSpecification", Order = 176)]
+        [DataMember(Name = "specialOpeningHoursSpecification", Order = 177)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOpeningHoursSpecification> SpecialOpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 177)]
+        [DataMember(Name = "sponsor", Order = 178)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
         /// </summary>
-        [DataMember(Name = "subOrganization", Order = 178)]
+        [DataMember(Name = "subOrganization", Order = 179)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOrganization> SubOrganization { get; set; }
 
         /// <summary>
         /// The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain.
         /// </summary>
-        [DataMember(Name = "taxID", Order = 179)]
+        [DataMember(Name = "taxID", Order = 180)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> TaxID { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 180)]
+        [DataMember(Name = "telephone", Order = 181)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> Telephone { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (typically a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement about policy on use of unnamed sources and the decision process required.
         /// </summary>
-        [DataMember(Name = "unnamedSourcesPolicy", Order = 181)]
+        [DataMember(Name = "unnamedSourcesPolicy", Order = 182)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
         /// </summary>
-        [DataMember(Name = "vatID", Order = 182)]
+        [DataMember(Name = "vatID", Order = 183)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> VatID { get; set; }
 
@@ -623,6 +630,7 @@
                 this.HasMap == other.HasMap &&
                 this.HasOfferCatalog == other.HasOfferCatalog &&
                 this.HasPOS == other.HasPOS &&
+                this.InteractionStatistic == other.InteractionStatistic &&
                 this.IsAccessibleForFree == other.IsAccessibleForFree &&
                 this.IsicV4 == other.IsicV4 &&
                 this.KnowsAbout == other.KnowsAbout &&
@@ -708,6 +716,7 @@
             .And(this.HasMap)
             .And(this.HasOfferCatalog)
             .And(this.HasPOS)
+            .And(this.InteractionStatistic)
             .And(this.IsAccessibleForFree)
             .And(this.IsicV4)
             .And(this.KnowsAbout)

--- a/Source/Schema.NET/core/combined/OrganizationAndPlace.cs
+++ b/Source/Schema.NET/core/combined/OrganizationAndPlace.cs
@@ -306,184 +306,191 @@
         public virtual OneOrMany<string> GlobalLocationNumber { get; set; }
 
         /// <summary>
+        /// Indicates whether some facility (e.g. &lt;a class="localLink" href="http://schema.org/FoodEstablishment"&gt;FoodEstablishment&lt;/a&gt;, &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt;) offers a service that can be used by driving through in a car. In the case of &lt;a class="localLink" href="http://schema.org/CovidTestingFacility"&gt;CovidTestingFacility&lt;/a&gt; such facilities could potentially help with social distancing from other potentially-infected users.
+        /// </summary>
+        [DataMember(Name = "hasDriveThroughService", Order = 146)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public virtual OneOrMany<bool?> HasDriveThroughService { get; set; }
+
+        /// <summary>
         /// A URL to a map of the place.
         /// </summary>
-        [DataMember(Name = "hasMap", Order = 146)]
+        [DataMember(Name = "hasMap", Order = 147)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IMap, Uri> HasMap { get; set; }
 
         /// <summary>
         /// Indicates an OfferCatalog listing for this Organization, Person, or Service.
         /// </summary>
-        [DataMember(Name = "hasOfferCatalog", Order = 147)]
+        [DataMember(Name = "hasOfferCatalog", Order = 148)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOfferCatalog> HasOfferCatalog { get; set; }
 
         /// <summary>
         /// Points-of-Sales operated by the organization or person.
         /// </summary>
-        [DataMember(Name = "hasPOS", Order = 148)]
+        [DataMember(Name = "hasPOS", Order = 149)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IPlace> HasPOS { get; set; }
 
         /// <summary>
         /// The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used.
         /// </summary>
-        [DataMember(Name = "interactionStatistic", Order = 149)]
+        [DataMember(Name = "interactionStatistic", Order = 150)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IInteractionCounter> InteractionStatistic { get; set; }
 
         /// <summary>
         /// A flag to signal that the item, event, or place is accessible for free.
         /// </summary>
-        [DataMember(Name = "isAccessibleForFree", Order = 150)]
+        [DataMember(Name = "isAccessibleForFree", Order = 151)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<bool?> IsAccessibleForFree { get; set; }
 
         /// <summary>
         /// The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.
         /// </summary>
-        [DataMember(Name = "isicV4", Order = 151)]
+        [DataMember(Name = "isicV4", Order = 152)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> IsicV4 { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or &lt;a class="localLink" href="http://schema.org/JobPosting"&gt;JobPosting&lt;/a&gt; descriptions.
         /// </summary>
-        [DataMember(Name = "knowsAbout", Order = 152)]
+        [DataMember(Name = "knowsAbout", Order = 153)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<string, IThing, Uri> KnowsAbout { get; set; }
 
         /// <summary>
         /// Of a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt;, and less typically of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt;, to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the &lt;a href="http://tools.ietf.org/html/bcp47"&gt;IETF BCP 47 standard&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "knowsLanguage", Order = 153)]
+        [DataMember(Name = "knowsLanguage", Order = 154)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<ILanguage, string> KnowsLanguage { get; set; }
 
         /// <summary>
         /// The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "latitude", Order = 154)]
+        [DataMember(Name = "latitude", Order = 155)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<double?, string> Latitude { get; set; }
 
         /// <summary>
         /// The official name of the organization, e.g. the registered company name.
         /// </summary>
-        [DataMember(Name = "legalName", Order = 155)]
+        [DataMember(Name = "legalName", Order = 156)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> LegalName { get; set; }
 
         /// <summary>
         /// An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.
         /// </summary>
-        [DataMember(Name = "leiCode", Order = 156)]
+        [DataMember(Name = "leiCode", Order = 157)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> LeiCode { get; set; }
 
         /// <summary>
         /// The location of for example where the event is happening, an organization is located, or where an action takes place.
         /// </summary>
-        [DataMember(Name = "location", Order = 157)]
+        [DataMember(Name = "location", Order = 158)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IPlace, IPostalAddress, string> Location { get; set; }
 
         /// <summary>
         /// An associated logo.
         /// </summary>
-        [DataMember(Name = "logo", Order = 158)]
+        [DataMember(Name = "logo", Order = 159)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IImageObject, Uri> Logo { get; set; }
 
         /// <summary>
         /// The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).
         /// </summary>
-        [DataMember(Name = "longitude", Order = 159)]
+        [DataMember(Name = "longitude", Order = 160)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<double?, string> Longitude { get; set; }
 
         /// <summary>
         /// A pointer to products or services offered by the organization or person.
         /// </summary>
-        [DataMember(Name = "makesOffer", Order = 160)]
+        [DataMember(Name = "makesOffer", Order = 161)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOffer> MakesOffer { get; set; }
 
         /// <summary>
         /// The total number of individuals that may attend an event or venue.
         /// </summary>
-        [DataMember(Name = "maximumAttendeeCapacity", Order = 161)]
+        [DataMember(Name = "maximumAttendeeCapacity", Order = 162)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<int?> MaximumAttendeeCapacity { get; set; }
 
         /// <summary>
         /// A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals.
         /// </summary>
-        [DataMember(Name = "member", Order = 162)]
+        [DataMember(Name = "member", Order = 163)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOrganization, IPerson> Member { get; set; }
 
         /// <summary>
         /// An Organization (or ProgramMembership) to which this Person or Organization belongs.
         /// </summary>
-        [DataMember(Name = "memberOf", Order = 163)]
+        [DataMember(Name = "memberOf", Order = 164)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOrganization, IProgramMembership> MemberOf { get; set; }
 
         /// <summary>
         /// The North American Industry Classification System (NAICS) code for a particular organization or business person.
         /// </summary>
-        [DataMember(Name = "naics", Order = 164)]
+        [DataMember(Name = "naics", Order = 165)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> Naics { get; set; }
 
         /// <summary>
         /// The number of employees in an organization e.g. business.
         /// </summary>
-        [DataMember(Name = "numberOfEmployees", Order = 165)]
+        [DataMember(Name = "numberOfEmployees", Order = 166)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IQuantitativeValue> NumberOfEmployees { get; set; }
 
         /// <summary>
         /// The opening hours of a certain place.
         /// </summary>
-        [DataMember(Name = "openingHoursSpecification", Order = 166)]
+        [DataMember(Name = "openingHoursSpecification", Order = 167)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOpeningHoursSpecification> OpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (often but not necessarily a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt; is also available and can be used to make basic funder information machine-readable.
         /// </summary>
-        [DataMember(Name = "ownershipFundingInfo", Order = 167)]
+        [DataMember(Name = "ownershipFundingInfo", Order = 168)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IAboutPage, ICreativeWork, string, Uri> OwnershipFundingInfo { get; set; }
 
         /// <summary>
         /// Products owned by the organization or person.
         /// </summary>
-        [DataMember(Name = "owns", Order = 168)]
+        [DataMember(Name = "owns", Order = 169)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOwnershipInfo, IProduct> Owns { get; set; }
 
         /// <summary>
         /// The larger organization that this organization is a &lt;a class="localLink" href="http://schema.org/subOrganization"&gt;subOrganization&lt;/a&gt; of, if any.
         /// </summary>
-        [DataMember(Name = "parentOrganization", Order = 169)]
+        [DataMember(Name = "parentOrganization", Order = 170)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOrganization> ParentOrganization { get; set; }
 
         /// <summary>
         /// A photograph of this place.
         /// </summary>
-        [DataMember(Name = "photo", Order = 170)]
+        [DataMember(Name = "photo", Order = 171)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IImageObject, IPhotograph> Photo { get; set; }
 
         /// <summary>
         /// A flag to signal that the &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt; is open to public visitors.  If this property is omitted there is no assumed default boolean value
         /// </summary>
-        [DataMember(Name = "publicAccess", Order = 171)]
+        [DataMember(Name = "publicAccess", Order = 172)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<bool?> PublicAccess { get; set; }
 
@@ -491,35 +498,35 @@
         /// The publishingPrinciples property indicates (typically via &lt;a class="localLink" href="http://schema.org/URL"&gt;URL&lt;/a&gt;) a document describing the editorial principles of an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (or individual e.g. a &lt;a class="localLink" href="http://schema.org/Person"&gt;Person&lt;/a&gt; writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt; (e.g. &lt;a class="localLink" href="http://schema.org/NewsArticle"&gt;NewsArticle&lt;/a&gt;) the principles are those of the party primarily responsible for the creation of the &lt;a class="localLink" href="http://schema.org/CreativeWork"&gt;CreativeWork&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;
         /// While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a &lt;a class="localLink" href="http://schema.org/funder"&gt;funder&lt;/a&gt;) can be expressed using schema.org terminology.
         /// </summary>
-        [DataMember(Name = "publishingPrinciples", Order = 172)]
+        [DataMember(Name = "publishingPrinciples", Order = 173)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<ICreativeWork, Uri> PublishingPrinciples { get; set; }
 
         /// <summary>
         /// A review of the item.
         /// </summary>
-        [DataMember(Name = "review", Order = 173)]
+        [DataMember(Name = "review", Order = 174)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IReview> Review { get; set; }
 
         /// <summary>
         /// A pointer to products or services sought by the organization or person (demand).
         /// </summary>
-        [DataMember(Name = "seeks", Order = 174)]
+        [DataMember(Name = "seeks", Order = 175)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IDemand> Seeks { get; set; }
 
         /// <summary>
         /// A slogan or motto associated with the item.
         /// </summary>
-        [DataMember(Name = "slogan", Order = 175)]
+        [DataMember(Name = "slogan", Order = 176)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> Slogan { get; set; }
 
         /// <summary>
         /// Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room.
         /// </summary>
-        [DataMember(Name = "smokingAllowed", Order = 176)]
+        [DataMember(Name = "smokingAllowed", Order = 177)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<bool?> SmokingAllowed { get; set; }
 
@@ -527,49 +534,56 @@
         /// The special opening hours of a certain place.&lt;br/&gt;&lt;br/&gt;
         /// Use this to explicitly override general opening hours brought in scope by &lt;a class="localLink" href="http://schema.org/openingHoursSpecification"&gt;openingHoursSpecification&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/openingHours"&gt;openingHours&lt;/a&gt;.
         /// </summary>
-        [DataMember(Name = "specialOpeningHoursSpecification", Order = 177)]
+        [DataMember(Name = "specialOpeningHoursSpecification", Order = 178)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOpeningHoursSpecification> SpecialOpeningHoursSpecification { get; set; }
 
         /// <summary>
         /// A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
         /// </summary>
-        [DataMember(Name = "sponsor", Order = 178)]
+        [DataMember(Name = "sponsor", Order = 179)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<IOrganization, IPerson> Sponsor { get; set; }
 
         /// <summary>
         /// A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.
         /// </summary>
-        [DataMember(Name = "subOrganization", Order = 179)]
+        [DataMember(Name = "subOrganization", Order = 180)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<IOrganization> SubOrganization { get; set; }
 
         /// <summary>
         /// The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain.
         /// </summary>
-        [DataMember(Name = "taxID", Order = 180)]
+        [DataMember(Name = "taxID", Order = 181)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> TaxID { get; set; }
 
         /// <summary>
         /// The telephone number.
         /// </summary>
-        [DataMember(Name = "telephone", Order = 181)]
+        [DataMember(Name = "telephone", Order = 182)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> Telephone { get; set; }
 
         /// <summary>
+        /// A page providing information on how to book a tour of some &lt;a class="localLink" href="http://schema.org/Place"&gt;Place&lt;/a&gt;, such as an &lt;a class="localLink" href="http://schema.org/Accommodation"&gt;Accommodation&lt;/a&gt; or &lt;a class="localLink" href="http://schema.org/ApartmentComplex"&gt;ApartmentComplex&lt;/a&gt; in a real estate setting, as well as other kinds of tours as appropriate.
+        /// </summary>
+        [DataMember(Name = "tourBookingPage", Order = 183)]
+        [JsonConverter(typeof(ValuesJsonConverter))]
+        public virtual OneOrMany<Uri> TourBookingPage { get; set; }
+
+        /// <summary>
         /// For an &lt;a class="localLink" href="http://schema.org/Organization"&gt;Organization&lt;/a&gt; (typically a &lt;a class="localLink" href="http://schema.org/NewsMediaOrganization"&gt;NewsMediaOrganization&lt;/a&gt;), a statement about policy on use of unnamed sources and the decision process required.
         /// </summary>
-        [DataMember(Name = "unnamedSourcesPolicy", Order = 182)]
+        [DataMember(Name = "unnamedSourcesPolicy", Order = 184)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual Values<ICreativeWork, Uri> UnnamedSourcesPolicy { get; set; }
 
         /// <summary>
         /// The Value-added Tax ID of the organization or person.
         /// </summary>
-        [DataMember(Name = "vatID", Order = 183)]
+        [DataMember(Name = "vatID", Order = 185)]
         [JsonConverter(typeof(ValuesJsonConverter))]
         public virtual OneOrMany<string> VatID { get; set; }
 
@@ -627,6 +641,7 @@
                 this.GeoTouches == other.GeoTouches &&
                 this.GeoWithin == other.GeoWithin &&
                 this.GlobalLocationNumber == other.GlobalLocationNumber &&
+                this.HasDriveThroughService == other.HasDriveThroughService &&
                 this.HasMap == other.HasMap &&
                 this.HasOfferCatalog == other.HasOfferCatalog &&
                 this.HasPOS == other.HasPOS &&
@@ -663,6 +678,7 @@
                 this.SubOrganization == other.SubOrganization &&
                 this.TaxID == other.TaxID &&
                 this.Telephone == other.Telephone &&
+                this.TourBookingPage == other.TourBookingPage &&
                 this.UnnamedSourcesPolicy == other.UnnamedSourcesPolicy &&
                 this.VatID == other.VatID &&
                 base.Equals(other);
@@ -713,6 +729,7 @@
             .And(this.GeoTouches)
             .And(this.GeoWithin)
             .And(this.GlobalLocationNumber)
+            .And(this.HasDriveThroughService)
             .And(this.HasMap)
             .And(this.HasOfferCatalog)
             .And(this.HasPOS)
@@ -749,6 +766,7 @@
             .And(this.SubOrganization)
             .And(this.TaxID)
             .And(this.Telephone)
+            .And(this.TourBookingPage)
             .And(this.UnnamedSourcesPolicy)
             .And(this.VatID)
             .And(base.GetHashCode());

--- a/Source/Schema.NET/core/enumerations/EventStatusType.cs
+++ b/Source/Schema.NET/core/enumerations/EventStatusType.cs
@@ -17,6 +17,12 @@
         EventCancelled,
 
         /// <summary>
+        /// Indicates that the event was changed to allow online participation. See &lt;a class="localLink" href="http://schema.org/eventAttendanceMode"&gt;eventAttendanceMode&lt;/a&gt; for specifics of whether it is now fully or partially online.
+        /// </summary>
+        [EnumMember(Value = "https://schema.org/EventMovedOnline")]
+        EventMovedOnline,
+
+        /// <summary>
         /// The event has been postponed and no new date has been set. The event's previousStartDate should be set.
         /// </summary>
         [EnumMember(Value = "https://schema.org/EventPostponed")]

--- a/Source/Schema.NET/core/enumerations/ItemAvailability.cs
+++ b/Source/Schema.NET/core/enumerations/ItemAvailability.cs
@@ -47,7 +47,7 @@
         OutOfStock,
 
         /// <summary>
-        /// Indicates that the item is available for pre-order, but will be delivered when generally available.
+        /// Indicates that the item is available for pre-order.
         /// </summary>
         [EnumMember(Value = "https://schema.org/PreOrder")]
         PreOrder,

--- a/Tests/Schema.NET.Test/Values7Test.cs
+++ b/Tests/Schema.NET.Test/Values7Test.cs
@@ -1,0 +1,966 @@
+namespace Schema.NET.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class Values7Test
+    {
+        [Fact]
+        public void Constructor_Value1Passed_OnlyValue1HasValue()
+        {
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1);
+
+            Assert.True(values.HasValue1);
+            Assert.Single(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { 1 }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void Constructor_Value2Passed_OnlyValue2HasValue()
+        {
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo");
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.True(values.HasValue2);
+            Assert.Single(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void Constructor_Value3Passed_OnlyValue3HasValue()
+        {
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday);
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.True(values.HasValue3);
+            Assert.Single(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { DayOfWeek.Friday }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void Constructor_Value4Passed_OnlyValue4HasValue()
+        {
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person());
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.True(values.HasValue4);
+            Assert.Single(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<Person>(item);
+        }
+
+        [Fact]
+        public void Constructor_Value5Passed_OnlyValue5HasValue()
+        {
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue);
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.True(values.HasValue5);
+            Assert.Single(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<DateTime>(item);
+        }
+
+        [Fact]
+        public void Constructor_Value6Passed_OnlyValue6HasValue()
+        {
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true);
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.True(values.HasValue6);
+            Assert.Single(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<bool>(item);
+        }
+
+        [Fact]
+        public void Constructor_Value7Passed_OnlyValue7HasValue()
+        {
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue);
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.True(values.HasValue7);
+            Assert.Single(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<TimeSpan>(item);
+        }
+
+        [Fact]
+        public void Constructor_Items_HasAllItems()
+        {
+            var person = new Person();
+            var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1, "Foo", DayOfWeek.Friday, person, DateTime.MinValue, true, TimeSpan.MinValue);
+
+            Assert.True(values.HasValue1);
+            Assert.Single(values.Value1);
+            Assert.True(values.HasValue2);
+            Assert.Single(values.Value2);
+            Assert.True(values.HasValue3);
+            Assert.Single(values.Value3);
+            Assert.True(values.HasValue4);
+            Assert.Single(values.Value4);
+            Assert.True(values.HasValue5);
+            Assert.Single(values.Value5);
+            Assert.True(values.HasValue6);
+            Assert.Single(values.Value6);
+            Assert.True(values.HasValue7);
+            Assert.Single(values.Value7);
+            Assert.Equal(new List<object>() { 1, "Foo", DayOfWeek.Friday, person, DateTime.MinValue, true, TimeSpan.MinValue }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void Constructor_NullList_ThrowsArgumentNullException() =>
+            Assert.Throws<ArgumentNullException>(() => new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>((List<object>)null));
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1, 1)]
+        [InlineData(2, 1, 2)]
+        [InlineData(1, "Foo")]
+        [InlineData(2, "Foo", "Bar")]
+        [InlineData(1, DayOfWeek.Friday)]
+        [InlineData(2, DayOfWeek.Friday, DayOfWeek.Monday)]
+        [InlineData(3, 1, "Foo", DayOfWeek.Friday)]
+        [InlineData(6, 1, 2, "Foo", "Bar", DayOfWeek.Friday, DayOfWeek.Monday)]
+        public void Count_Items_ReturnsExpectedCount(int expectedCount, params object[] items) =>
+            Assert.Equal(expectedCount, new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(items).Count);
+
+        [Fact]
+        public void HasValue_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(default(Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>).HasValue);
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData("Foo")]
+        [InlineData(DayOfWeek.Friday)]
+        public void HasValue_HasValue_ReturnsTrue(params object[] parameters) =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(parameters).HasValue);
+
+        [Fact]
+        public void HasValue1_HasValue_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).HasValue1);
+
+        [Fact]
+        public void HasValue1_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo").HasValue1);
+
+        [Fact]
+        public void HasValue2_HasValue_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo").HasValue2);
+
+        [Fact]
+        public void HasValue2_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).HasValue2);
+
+        [Fact]
+        public void HasValue3_HasValue_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday).HasValue3);
+
+        [Fact]
+        public void HasValue3_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).HasValue3);
+
+        [Fact]
+        public void HasValue4_HasValue_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person()).HasValue4);
+
+        [Fact]
+        public void HasValue4_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).HasValue4);
+
+        [Fact]
+        public void HasValue5_HasValue_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue).HasValue5);
+
+        [Fact]
+        public void HasValue5_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).HasValue5);
+
+        [Fact]
+        public void HasValue6_HasValue_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true).HasValue6);
+
+        [Fact]
+        public void HasValue6_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).HasValue6);
+
+        [Fact]
+        public void HasValue7_HasValue_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue).HasValue7);
+
+        [Fact]
+        public void HasValue7_DoesntHaveValue_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).HasValue7);
+
+        [Fact]
+        public void ImplicitConversionOperator_Value1Passed_OnlyValue1HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = 1;
+
+            Assert.True(values.HasValue1);
+            Assert.Single(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { 1 }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value2Passed_OnlyValue2HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = "Foo";
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.True(values.HasValue2);
+            Assert.Single(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { "Foo" }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value3Passed_OnlyValue3HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = DayOfWeek.Friday;
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.True(values.HasValue3);
+            Assert.Single(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { DayOfWeek.Friday }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value4Passed_OnlyValue4HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new Person();
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.True(values.HasValue4);
+            Assert.Single(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<Person>(item);
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value5Passed_OnlyValue5HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = DateTime.MinValue;
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.True(values.HasValue5);
+            Assert.Single(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<DateTime>(item);
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value6Passed_OnlyValue6HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = true;
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.True(values.HasValue6);
+            Assert.Single(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<bool>(item);
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value7Passed_OnlyValue7HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = TimeSpan.MinValue;
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.True(values.HasValue7);
+            Assert.Single(values.Value7);
+            var item = Assert.Single(((IValues)values).Cast<object>().ToList());
+            Assert.IsType<TimeSpan>(item);
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value1CollectionPassed_OnlyValue1HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new List<int>() { 1, 2 };
+
+            Assert.True(values.HasValue1);
+            Assert.Equal(2, values.Value1.Count);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { 1, 2 }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value2CollectionPassed_OnlyValue2HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new List<string>() { "Foo", "Bar" };
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.True(values.HasValue2);
+            Assert.Equal(2, values.Value2.Count);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { "Foo", "Bar" }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value3CollectionPassed_OnlyValue3HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new List<DayOfWeek>() { DayOfWeek.Friday, DayOfWeek.Monday };
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.True(values.HasValue3);
+            Assert.Equal(2, values.Value3.Count);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(new List<object>() { DayOfWeek.Friday, DayOfWeek.Monday }, ((IValues)values).Cast<object>().ToList());
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value4CollectionPassed_OnlyValue4HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new List<Person>() { new Person(), new Person() };
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.True(values.HasValue4);
+            Assert.Equal(2, values.Value4.Count);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(2, ((IValues)values).Cast<object>().ToList().Count);
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value5CollectionPassed_OnlyValue5HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new List<DateTime>() { DateTime.MinValue, DateTime.MinValue };
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.True(values.HasValue5);
+            Assert.Equal(2, values.Value5.Count);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(2, ((IValues)values).Cast<object>().ToList().Count);
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value6CollectionPassed_OnlyValue6HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new List<bool>() { true, true };
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.True(values.HasValue6);
+            Assert.Equal(2, values.Value6.Count);
+            Assert.False(values.HasValue7);
+            Assert.Empty(values.Value7);
+            Assert.Equal(2, ((IValues)values).Cast<object>().ToList().Count);
+        }
+
+        [Fact]
+        public void ImplicitConversionOperator_Value7CollectionPassed_OnlyValue7HasValue()
+        {
+            Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan> values = new List<TimeSpan>() { TimeSpan.MinValue, TimeSpan.MinValue };
+
+            Assert.False(values.HasValue1);
+            Assert.Empty(values.Value1);
+            Assert.False(values.HasValue2);
+            Assert.Empty(values.Value2);
+            Assert.False(values.HasValue3);
+            Assert.Empty(values.Value3);
+            Assert.False(values.HasValue4);
+            Assert.Empty(values.Value4);
+            Assert.False(values.HasValue5);
+            Assert.Empty(values.Value5);
+            Assert.False(values.HasValue6);
+            Assert.Empty(values.Value6);
+            Assert.True(values.HasValue7);
+            Assert.Equal(2, values.Value7.Count);
+            Assert.Equal(2, ((IValues)values).Cast<object>().ToList().Count);
+        }
+
+        [Fact]
+        public void ImplicitConversionToList_Value1Passed_ReturnsMatchingList()
+        {
+            List<int> values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1);
+
+            Assert.Equal(new List<int>() { 1 }, values);
+        }
+
+        [Fact]
+        public void ImplicitConversionToList_Value2Passed_ReturnsMatchingList()
+        {
+            List<string> values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo");
+
+            Assert.Equal(new List<string>() { "Foo" }, values);
+        }
+
+        [Fact]
+        public void ImplicitConversionToList_Value3Passed_ReturnsMatchingList()
+        {
+            List<DayOfWeek> values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday);
+
+            Assert.Equal(new List<DayOfWeek>() { DayOfWeek.Friday }, values);
+        }
+
+        [Fact]
+        public void ImplicitConversionToList_Value4Passed_ReturnsMatchingList()
+        {
+            var person = new Person();
+            List<Person> values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person);
+
+            Assert.Equal(new List<Person>() { person }, values);
+        }
+
+        [Fact]
+        public void ImplicitConversionToList_Value5Passed_ReturnsMatchingList()
+        {
+            List<DateTime> values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue);
+
+            Assert.Equal(new List<DateTime>() { DateTime.MinValue }, values);
+        }
+
+        [Fact]
+        public void ImplicitConversionToList_Value6Passed_ReturnsMatchingList()
+        {
+            List<bool> values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true);
+
+            Assert.Equal(new List<bool>() { true }, values);
+        }
+
+        [Fact]
+        public void ImplicitConversionToList_Value7Passed_ReturnsMatchingList()
+        {
+            List<TimeSpan> values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue);
+
+            Assert.Equal(new List<TimeSpan>() { TimeSpan.MinValue }, values);
+        }
+
+        [Fact]
+        public void Deconstruct_Values_ReturnsAllEnumerables()
+        {
+            var person = new Person();
+            var (integers, strings, daysOfWeek, people, dates, bools, times) = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1, "Foo", DayOfWeek.Friday, person, DateTime.MinValue, true, TimeSpan.MinValue);
+            Assert.Equal(new List<int>() { 1 }, integers);
+            Assert.Equal(new List<string>() { "Foo" }, strings);
+            Assert.Equal(new List<DayOfWeek>() { DayOfWeek.Friday }, daysOfWeek);
+            Assert.Equal(new List<Person>() { person }, people);
+            Assert.Equal(new List<DateTime>() { DateTime.MinValue }, dates);
+            Assert.Equal(new List<bool>() { true }, bools);
+            Assert.Equal(new List<TimeSpan>() { TimeSpan.MinValue }, times);
+        }
+
+        [Fact]
+        public void EqualsOperator_EqualValue1Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1));
+
+        [Fact]
+        public void EqualsOperator_NotEqualValue1Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(2));
+
+        [Fact]
+        public void EqualsOperator_EqualValue2Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo") == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo"));
+
+        [Fact]
+        public void EqualsOperator_NotEqualValue2Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo") == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Bar"));
+
+        [Fact]
+        public void EqualsOperator_EqualValue3Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday));
+
+        [Fact]
+        public void EqualsOperator_NotEqualValue3Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Monday));
+
+        [Fact]
+        public void EqualsOperator_EqualValue4Passed_ReturnsTrue()
+        {
+            var person = new Person();
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person));
+        }
+
+        [Fact]
+        public void EqualsOperator_NotEqualValue4Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person { Name = "A" }) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person { Name = "B" }));
+
+        [Fact]
+        public void EqualsOperator_EqualValue5Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue));
+
+        [Fact]
+        public void EqualsOperator_NotEqualValue5Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MaxValue));
+
+        [Fact]
+        public void EqualsOperator_EqualValue6Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true));
+
+        [Fact]
+        public void EqualsOperator_NotEqualValue6Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(false));
+
+        [Fact]
+        public void EqualsOperator_EqualValue7Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue));
+
+        [Fact]
+        public void EqualsOperator_NotEqualValue7Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue) == new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MaxValue));
+
+        [Fact]
+        public void NotEqualsOperator_EqualValue1Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1));
+
+        [Fact]
+        public void NotEqualsOperator_NotEqualValue1Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(2));
+
+        [Fact]
+        public void NotEqualsOperator_EqualValue2Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo") != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo"));
+
+        [Fact]
+        public void NotEqualsOperator_NotEqualValue2Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo") != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Bar"));
+
+        [Fact]
+        public void NotEqualsOperator_EqualValue3Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday));
+
+        [Fact]
+        public void NotEqualsOperator_NotEqualValue3Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Monday));
+
+        [Fact]
+        public void NotEqualsOperator_EqualValue4Passed_ReturnsFalse()
+        {
+            var person = new Person();
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person));
+        }
+
+        [Fact]
+        public void NotEqualsOperator_NotEqualValue4Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person { Name = "A" }) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person { Name = "B" }));
+
+        [Fact]
+        public void NotEqualsOperator_EqualValue5Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue));
+
+        [Fact]
+        public void NotEqualsOperator_NotEqualValue5Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MaxValue));
+
+        [Fact]
+        public void NotEqualsOperator_EqualValue6Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true));
+
+        [Fact]
+        public void NotEqualsOperator_NotEqualValue6Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(false));
+
+        [Fact]
+        public void NotEqualsOperator_EqualValue7Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue));
+
+        [Fact]
+        public void NotEqualsOperator_NotEqualValue7Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue) != new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MaxValue));
+
+        [Fact]
+        public void Equals_EqualValue1Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1)));
+
+        [Fact]
+        public void Equals_NotEqualValue1Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(2)));
+
+        [Fact]
+        public void Equals_EqualValue2Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo").Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo")));
+
+        [Fact]
+        public void Equals_NotEqualValue2Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo").Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Bar")));
+
+        [Fact]
+        public void Equals_EqualValue3Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday)));
+
+        [Fact]
+        public void Equals_NotEqualValue3Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Monday)));
+
+        [Fact]
+        public void Equals_EqualValue4Passed_ReturnsTrue()
+        {
+            var person = new Person();
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person)));
+        }
+
+        [Fact]
+        public void Equals_NotEqualValue4Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person { Name = "A" }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new Person { Name = "B" })));
+
+        [Fact]
+        public void Equals_EqualValue5Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue)));
+
+        [Fact]
+        public void Equals_NotEqualValue5Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MaxValue)));
+
+        [Fact]
+        public void Equals_EqualValue6Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true)));
+
+        [Fact]
+        public void Equals_NotEqualValue6Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(false)));
+
+        [Fact]
+        public void Equals_EqualValue7Passed_ReturnsTrue() =>
+            Assert.True(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue)));
+
+        [Fact]
+        public void Equals_NotEqualValue7Passed_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MaxValue)));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3EqualValue4EqualValue5EqualValue6EqualValue7NotEqual_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MaxValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3EqualValue4EqualValue5EqualValue6NotEqualValue7Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, false, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3EqualValue4EqualValue5NotEqualValue6EqualValue7Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MaxValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3EqualValue4NotEqualValue5EqualValue6EqualValue7Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person { Name = "Schema" }, DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2EqualValue3NotEqualValue4EqualValue5EqualValue6EqualValue7Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Wednesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1EqualValue2NotEqualValue3EqualValue4EqualValue5EqualValue6EqualValue7Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Bar", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_Value1NotEqualValue2EqualValue3EqualValue4EqualValue5EqualValue6EqualValue7Equal_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 1, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue7_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue6_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue5_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue4_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue3_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_ThisMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue7_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue6_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue5_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue4_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue3_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue2_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void Equals_MixedTypes_OtherMissingValue1_ReturnsFalse() =>
+            Assert.False(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { 0, "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue }).Equals(new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(new object[] { "Foo", DayOfWeek.Tuesday, new Person(), DateTime.MinValue, true, TimeSpan.MinValue })));
+
+        [Fact]
+        public void GetHashCode_Value1Passed_ReturnsMatchingHashCode() =>
+            Assert.Equal(
+                CombineHashCodes(CombineHashCodes(CombineHashCodes(CombineHashCodes(CombineHashCodes(CombineHashCodes(1.GetHashCode(), 0), 0), 0), 0), 0), 0),
+                new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(1).GetHashCode());
+
+        [Fact]
+        public void GetHashCode_Value2Passed_ReturnsMatchingHashCode() =>
+            Assert.Equal(
+                CombineHashCodes(CombineHashCodes(CombineHashCodes(CombineHashCodes(CombineHashCodes("Foo".GetHashCode(StringComparison.Ordinal), 0), 0), 0), 0), 0),
+                new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>("Foo").GetHashCode());
+
+        [Fact]
+        public void GetHashCode_Value3Passed_ReturnsMatchingHashCode() =>
+            Assert.Equal(
+                CombineHashCodes(CombineHashCodes(CombineHashCodes(CombineHashCodes(DayOfWeek.Friday.GetHashCode(), 0), 0), 0), 0),
+                new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DayOfWeek.Friday).GetHashCode());
+
+        [Fact]
+        public void GetHashCode_Value4Passed_ReturnsMatchingHashCode()
+        {
+            var person = new Person();
+            Assert.Equal(
+                CombineHashCodes(CombineHashCodes(CombineHashCodes(person.GetHashCode(), 0), 0), 0),
+                new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(person).GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_Value5Passed_ReturnsMatchingHashCode() =>
+            Assert.Equal(
+                CombineHashCodes(CombineHashCodes(DateTime.MinValue.GetHashCode(), 0), 0),
+                new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(DateTime.MinValue).GetHashCode());
+
+        [Fact]
+        public void GetHashCode_Value6Passed_ReturnsMatchingHashCode() =>
+            Assert.Equal(
+                CombineHashCodes(true.GetHashCode(), 0),
+                new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(true).GetHashCode());
+
+        [Fact]
+        public void GetHashCode_Value7Passed_ReturnsMatchingHashCode() =>
+            Assert.Equal(
+                TimeSpan.MinValue.GetHashCode(),
+                new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(TimeSpan.MinValue).GetHashCode());
+
+        private static int CombineHashCodes(int h1, int h2) => ((h1 << 5) + h1) ^ h2;
+    }
+}

--- a/Tools/Schema.NET.Tool/Models/SchemaClass.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaClass.cs
@@ -7,23 +7,7 @@ namespace Schema.NET.Tool.Models
 
     public class SchemaClass : SchemaObject
     {
-        public bool IsEnum => EnumerableExtensions
-            .Traverse(this, x => x.SubClassOf)
-            .Any(x => x.Id == new Uri("http://schema.org/Enumeration"));
-
-        public bool IsArchived => EnumerableExtensions
-            .Traverse(this, x => x.SubClassOf)
-            .Any(x => string.Equals(x.Layer, LayerName.Archived, StringComparison.OrdinalIgnoreCase));
-
-        public bool IsMeta => EnumerableExtensions
-            .Traverse(this, x => x.SubClassOf)
-            .Any(x => string.Equals(x.Layer, LayerName.Meta, StringComparison.OrdinalIgnoreCase));
-
-        public bool IsPending => EnumerableExtensions
-            .Traverse(this, x => x.SubClassOf)
-            .Any(x => string.Equals(x.Layer, LayerName.Pending, StringComparison.OrdinalIgnoreCase));
-
-        public bool IsPrimitive => new string[]
+        private static readonly string[] PrimitiveTypes = new string[]
         {
             "QualitativeValue",
             "Enumeration",
@@ -44,7 +28,26 @@ namespace Schema.NET.Tool.Models
             "Time",
             "URL",
             "DataType",
-        }.Contains(this.Label);
+            "PronounceableText",
+        };
+
+        public bool IsEnum => EnumerableExtensions
+            .Traverse(this, x => x.SubClassOf)
+            .Any(x => x.Id == new Uri("http://schema.org/Enumeration"));
+
+        public bool IsArchived => EnumerableExtensions
+            .Traverse(this, x => x.SubClassOf)
+            .Any(x => string.Equals(x.Layer, LayerName.Archived, StringComparison.OrdinalIgnoreCase));
+
+        public bool IsMeta => EnumerableExtensions
+            .Traverse(this, x => x.SubClassOf)
+            .Any(x => string.Equals(x.Layer, LayerName.Meta, StringComparison.OrdinalIgnoreCase));
+
+        public bool IsPending => EnumerableExtensions
+            .Traverse(this, x => x.SubClassOf)
+            .Any(x => string.Equals(x.Layer, LayerName.Pending, StringComparison.OrdinalIgnoreCase));
+
+        public bool IsPrimitive => PrimitiveTypes.Contains(this.Label);
 
         public List<SchemaClass> SubClassOf { get; } = new List<SchemaClass>();
 

--- a/Tools/Schema.NET.Tool/Services/SchemaService.cs
+++ b/Tools/Schema.NET.Tool/Services/SchemaService.cs
@@ -331,6 +331,7 @@ namespace Schema.NET.Tool.Services
                 case "Mass":
                 case "XPathType":
                 case "CssSelectorType":
+                case "PronounceableText":
                     return new List<string> { "string" };
                 case "Time":
                 case "Duration":


### PR DESCRIPTION
- Adds support for `PronounceableText`-to-string
- Adds all other Schema.org v7 changes
- Minor allocation cleanup for `SchemaClass` - no longer allocates an array per call to `IsPrimitive`

Closes #126 