### PR TITLE
Enable MacOS in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 version: '{build}'
 
 image:
-# - MacOS
+- MacOS
 - Ubuntu
 - Visual Studio 2019
 


### PR DESCRIPTION
MacOS on AppVeyor doesn't work yet. Wait for it in this PR.