### PR TITLE
Tweak release drafter template and categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,7 +6,6 @@ categories:
   - title: '🚀 New Features'
     labels:
       - 'enhancement'
-      - 'dependencies'
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
@@ -25,10 +24,8 @@ version-resolver:
       - 'patch'
   default: patch
 template: |
-  ## Changes
-
   $CHANGES
 
-  ## Contributors
+  ## 👨🏼‍💻 Contributors
 
   $CONTRIBUTORS


### PR DESCRIPTION
@dependabot-bot marks it's PR's with the `dependencies` label. I marked these as 'New Features' in release drafter. However, unit test NuGet package updates should show up in 'Maintenance' instead. This PR will make it so that each and ever PR will require manual labelling, so they appear in the correct section.