### PR TITLE
Stop Duplicate Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: master
   pull_request:
   release:
     types:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,6 @@ image:
 - Ubuntu
 - Visual Studio 2019
 
-pull_requests:
-  # Do not increment build number for pull requests
-  do_not_increment_build_number: true
-
 environment:
   # Disable the .NET logo in the console output.
   DOTNET_NOLOGO: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,12 @@
 trigger:
   branches:
     include:
-    - '*'
+    - 'master'
   tags:
+    include:
+    - '*'
+pr:
+  branches:
     include:
     - '*'
 


### PR DESCRIPTION
- Always increment build numbers in AppVeyor, since we no longer use the build number and use MinVer for versioning.
- Stop duplicate builds from Branch and PR triggers in GitHub Actions and Azure Pipelines.