### PR TITLE
Upgrade to .NET Core SDK 5.0.100

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 1.6.2 (Using https://semver.org/)
-# Updated: 2020-11-02
+# Version: 2.0.0 (Using https://semver.org/)
+# Updated: 2020-11-15
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.
@@ -80,106 +80,115 @@ indent_style = tab
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions
 ##########################################
 
+# Default Severity for .NET Code Style
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
+dotnet_analyzer_diagnostic.severity = warning
+
 # .NET Code Style Settings
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#net-code-style-settings
 [*.{cs,csx,cake,vb,vbx}]
 # "this." and "Me." qualifiers
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#this-and-me
-dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_property = true:warning
-dotnet_style_qualification_for_method = true:warning
-dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_property = true
+dotnet_style_qualification_for_method = true
+dotnet_style_qualification_for_event = true
 # Language keywords instead of framework type names for type references
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#language-keywords
-dotnet_style_predefined_type_for_locals_parameters_members = true:warning
-dotnet_style_predefined_type_for_member_access = true:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
 # Modifier preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#normalize-modifiers
-dotnet_style_require_accessibility_modifiers = always:warning
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
-dotnet_style_readonly_field = true:warning
+dotnet_style_require_accessibility_modifiers = always
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async
+dotnet_style_readonly_field = true
 # Parentheses preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parentheses-preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = always_for_clarity
 # Expression-level preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
-dotnet_style_object_initializer = true:warning
-dotnet_style_collection_initializer = true:warning
-dotnet_style_explicit_tuple_names = true:warning
-dotnet_style_prefer_inferred_tuple_names = true:warning
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
-dotnet_style_prefer_auto_properties = true:warning
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
-dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
-dotnet_style_prefer_conditional_expression_over_return = false:suggestion
-dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_object_initializer = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_conditional_expression_over_assignment = false
+dotnet_diagnostic.IDE0045.severity = suggestion
+dotnet_style_prefer_conditional_expression_over_return = false
+dotnet_diagnostic.IDE0046.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
 # Null-checking preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#null-checking-preferences
-dotnet_style_coalesce_expression = true:warning
-dotnet_style_null_propagation = true:warning
+dotnet_style_coalesce_expression = true
+dotnet_style_null_propagation = true
 # Parameter preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parameter-preferences
-dotnet_code_quality_unused_parameters = all:warning
+dotnet_code_quality_unused_parameters = all
 # More style options (Undocumented)
 # https://github.com/MicrosoftDocs/visualstudio-docs/issues/3641
 dotnet_style_operator_placement_when_wrapping = end_of_line
 # https://github.com/dotnet/roslyn/pull/40070
-dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_interpolation = true
 
 # C# Code Style Settings
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings
 [*.{cs,csx,cake}]
 # Implicit and explicit types
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#implicit-and-explicit-types
-csharp_style_var_for_built_in_types = true:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = true
 # Expression-bodied members
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-bodied-members
-csharp_style_expression_bodied_methods = true:warning
-csharp_style_expression_bodied_constructors = true:warning
-csharp_style_expression_bodied_operators = true:warning
-csharp_style_expression_bodied_properties = true:warning
-csharp_style_expression_bodied_indexers = true:warning
-csharp_style_expression_bodied_accessors = true:warning
-csharp_style_expression_bodied_lambdas = true:warning
-csharp_style_expression_bodied_local_functions = true:warning
+csharp_style_expression_bodied_methods = true
+csharp_style_expression_bodied_constructors = true
+csharp_style_expression_bodied_operators = true
+csharp_style_expression_bodied_properties = true
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = true
 # Pattern matching
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#pattern-matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:warning
-csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_pattern_matching_over_as_with_null_check = true
 # Inlined variable declarations
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#inlined-variable-declarations
-csharp_style_inlined_variable_declaration = true:warning
+csharp_style_inlined_variable_declaration = true
 # Expression-level preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
-csharp_prefer_simple_default_expression = true:warning
+csharp_prefer_simple_default_expression = true
 # "Null" checking preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-null-checking-preferences
-csharp_style_throw_expression = true:warning
-csharp_style_conditional_delegate_call = true:warning
+csharp_style_throw_expression = true
+csharp_style_conditional_delegate_call = true
 # Code block preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#code-block-preferences
-csharp_prefer_braces = true:warning
+csharp_prefer_braces = true
 # Unused value preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#unused-value-preferences
-csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable
+dotnet_diagnostic.IDE0058.severity = suggestion
+csharp_style_unused_value_assignment_preference = discard_variable
+dotnet_diagnostic.IDE0059.severity = suggestion
 # Index and range preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#index-and-range-preferences
-csharp_style_prefer_index_operator = true:warning
-csharp_style_prefer_range_operator = true:warning
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_range_operator = true
 # Miscellaneous preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#miscellaneous-preferences
-csharp_style_deconstructed_variable_declaration = true:warning
-csharp_style_pattern_local_over_anonymous_function = true:warning
-csharp_using_directive_placement = inside_namespace:warning
-csharp_prefer_static_local_function = true:warning
-csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_pattern_local_over_anonymous_function = true
+csharp_using_directive_placement = inside_namespace
+csharp_prefer_static_local_function = true
+csharp_prefer_simple_using_statement = true
+dotnet_diagnostic.IDE0063.severity = suggestion
 
 ##########################################
 # .NET Formatting Conventions

--- a/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
+++ b/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup Label="Build">
     <LangVersion>latest</LangVersion>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <NeutralLanguage>en-GB</NeutralLanguage>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -21,7 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" Version="3.3.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.1" />

--- a/Source/Schema.NET/HashCode.cs
+++ b/Source/Schema.NET/HashCode.cs
@@ -96,9 +96,9 @@ namespace Schema.NET
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (obj is HashCode)
+            if (obj is HashCode hashCode)
             {
-                return this.Equals((HashCode)obj);
+                return this.Equals(hashCode);
             }
 
             return false;

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -64,7 +64,7 @@ namespace Schema.NET
                     for (var i = 0; i < span.Length; i++)
                     {
                         var item = span[i];
-                        if (item is object)
+                        if (item is not null)
                         {
                             items[index] = item;
                             index++;
@@ -223,7 +223,7 @@ namespace Schema.NET
         /// <returns>An enumerator for the <see cref="OneOrMany{T}"/>.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            if (this.collection is object)
+            if (this.collection is not null)
             {
                 for (var i = 0; i < this.collection.Length; i++)
                 {
@@ -309,7 +309,7 @@ namespace Schema.NET
         /// <returns>
         ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => obj is OneOrMany<T> ? this.Equals((OneOrMany<T>)obj) : false;
+        public override bool Equals(object obj) => obj is OneOrMany<T> oneOrMany && this.Equals(oneOrMany);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/Source/Schema.NET/PropertyValueSpecification.Partial.cs
+++ b/Source/Schema.NET/PropertyValueSpecification.Partial.cs
@@ -32,14 +32,14 @@ namespace Schema.NET
                 stringBuilder.Append(this.ValueMinLength.First().Value);
             }
 
-            if (this.ValueName.First() is object)
+            if (this.ValueName.First() is not null)
             {
                 AppendSpace(stringBuilder);
                 stringBuilder.Append("name=");
                 stringBuilder.Append(this.ValueName.First());
             }
 
-            if (this.ValuePattern.First() is object)
+            if (this.ValuePattern.First() is not null)
             {
                 AppendSpace(stringBuilder);
                 stringBuilder.Append("pattern=");

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -15,7 +15,7 @@
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' OR '$(TargetFramework)' == 'net461'">
+  <ItemGroup Label="Package References (.NET Framework)" Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/Source/Schema.NET/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -936,7 +936,7 @@ namespace Schema.NET
         /// <returns>
         /// <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => obj is Values<T1, T2, T3, T4, T5, T6, T7> ? this.Equals((Values<T1, T2, T3, T4, T5, T6, T7>)obj) : false;
+        public override bool Equals(object obj) => obj is Values<T1, T2, T3, T4, T5, T6, T7> values && this.Equals(values);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
@@ -567,7 +567,7 @@ namespace Schema.NET
         /// <returns>
         /// <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => obj is Values<T1, T2, T3, T4> ? this.Equals((Values<T1, T2, T3, T4>)obj) : false;
+        public override bool Equals(object obj) => obj is Values<T1, T2, T3, T4> values && this.Equals(values);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/Source/Schema.NET/Values{T1,T2,T3}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3}.cs
@@ -452,7 +452,7 @@ namespace Schema.NET
         /// <returns>
         /// <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => obj is Values<T1, T2, T3> ? this.Equals((Values<T1, T2, T3>)obj) : false;
+        public override bool Equals(object obj) => obj is Values<T1, T2, T3> values && this.Equals(values);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/Source/Schema.NET/Values{T1,T2}.cs
+++ b/Source/Schema.NET/Values{T1,T2}.cs
@@ -340,7 +340,7 @@ namespace Schema.NET
         /// <returns>
         /// <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => obj is Values<T1, T2> ? this.Equals((Values<T1, T2>)obj) : false;
+        public override bool Equals(object obj) => obj is Values<T1, T2> values && this.Equals(values);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/Tools/Schema.NET.Tool/EnumerableExtensions.cs
+++ b/Tools/Schema.NET.Tool/EnumerableExtensions.cs
@@ -13,7 +13,7 @@ namespace Schema.NET.Tool
                 throw new ArgumentNullException(nameof(parent));
             }
 
-            for (var x = node; x is object; x = parent(x))
+            for (var x = node; x is not null; x = parent(x))
             {
                 yield return x;
             }
@@ -29,7 +29,7 @@ namespace Schema.NET.Tool
             yield return node;
 
             var childNodes = children(node);
-            if (childNodes is object)
+            if (childNodes is not null)
             {
                 foreach (var childNode in childNodes.SelectMany(x => Traverse(x, children)))
                 {

--- a/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
+++ b/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
@@ -33,7 +33,7 @@ namespace Schema.NET.Tool.Repositories
             {
                 var token = JToken.Load(reader);
                 var graphArray = ((JArray)token["@graph"]).ToList();
-                return graphArray.Select(Read).Where(x => x is object).ToList();
+                return graphArray.Select(Read).Where(x => x is not null).ToList();
             }
 
             return Enumerable.Empty<SchemaObject>();
@@ -51,7 +51,7 @@ namespace Schema.NET.Tool.Repositories
             }
 
             var supercededByToken = token["https://schema.org/supersededBy"];
-            if (supercededByToken is object)
+            if (supercededByToken is not null)
             {
                 // Ignore deprecated properties.
                 return null;
@@ -124,7 +124,7 @@ namespace Schema.NET.Tool.Repositories
 
         private static IEnumerable<string> GetTokenValues(JToken token)
         {
-            if (token is object)
+            if (token is not null)
             {
                 if (token.Type == JTokenType.String)
                 {
@@ -142,7 +142,7 @@ namespace Schema.NET.Tool.Repositories
 
         private static IEnumerable<Uri> GetTokenValues(JToken token, string name)
         {
-            if (token is object)
+            if (token is not null)
             {
                 if (token.Type == JTokenType.Object)
                 {

--- a/Tools/Schema.NET.Tool/Repositories/SchemaRepository.cs
+++ b/Tools/Schema.NET.Tool/Repositories/SchemaRepository.cs
@@ -31,7 +31,7 @@ namespace Schema.NET.Tool.Repositories
             foreach (var enumeration in enumerations)
             {
                 var schemaTreeClass = schemaTreeClasses.FirstOrDefault(x => new Uri("https://schema.org/" + x.Name) == enumeration.Id);
-                if (schemaTreeClass is object)
+                if (schemaTreeClass is not null)
                 {
                     enumeration.Layer = schemaTreeClass.Layer;
                 }
@@ -40,7 +40,7 @@ namespace Schema.NET.Tool.Repositories
             foreach (var c in classes)
             {
                 var schemaTreeClass = schemaTreeClasses.FirstOrDefault(x => new Uri("https://schema.org/" + x.Name) == c.Id);
-                if (schemaTreeClass is object)
+                if (schemaTreeClass is not null)
                 {
                     c.Layer = schemaTreeClass.Layer;
                 }

--- a/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
+++ b/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 var target = Argument("Target", "Default");
 var configuration =
     HasArgument("Configuration") ? Argument<string>("Configuration") :
-    EnvironmentVariable("Configuration") is object ? EnvironmentVariable("Configuration") :
+    EnvironmentVariable("Configuration") is not null ? EnvironmentVariable("Configuration") :
     "Release";
 
 var artefactsDirectory = Directory("./Artefacts");

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "3.1.403"
+    "version": "5.0.100"
   }
 }


### PR DESCRIPTION
- Upgrade to .NET Core SDK 5.0.100.
- Dropped support for `netstandard1.1`.
- Update the `.editorconfig` file which has changed in a breaking way (https://github.com/RehanSaeed/EditorConfig/pull/42) to support VS 16.8.
- Enable `EnforceCodeStyleInBuild` (This is awesome).
- Fix all the new warnings.
- Switch from `is object` to `is not null`. This has been on my mind for a long time. There is a lot more that could be done but getting some C# 9 in early.