### PR TITLE
Bump StyleCop.Analyzers from 1.1.118 to 1.2.0-beta.321

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="All" Version="2.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.2.0-beta.321" />
   </ItemGroup>
 
 </Project>

--- a/Source/Schema.NET/ContextJsonConverter.cs
+++ b/Source/Schema.NET/ContextJsonConverter.cs
@@ -7,7 +7,7 @@ namespace Schema.NET
     /// <summary>
     /// Converts a <see cref="JsonLdContext"/> object to and from JSON.
     /// </summary>
-    /// <seealso cref="Newtonsoft.Json.JsonConverter" />
+    /// <seealso cref="JsonConverter" />
     public class ContextJsonConverter : JsonConverter<JsonLdContext>
     {
         /// <inheritdoc />
@@ -48,9 +48,7 @@ namespace Schema.NET
                 language = languageProperty?.Value?.ToString();
             }
 
-#pragma warning disable CA1062 // Validate arguments of public methods
             context.Name = name;
-#pragma warning restore CA1062 // Validate arguments of public methods
             context.Language = language;
             return context;
         }

--- a/Source/Schema.NET/JsonLdContext.cs
+++ b/Source/Schema.NET/JsonLdContext.cs
@@ -60,7 +60,7 @@ namespace Schema.NET
                 return false;
             }
 
-            if (object.ReferenceEquals(this, other))
+            if (ReferenceEquals(this, other))
             {
                 return true;
             }

--- a/Tools/Schema.NET.Tool/Repositories/ISchemaRepository.cs
+++ b/Tools/Schema.NET.Tool/Repositories/ISchemaRepository.cs
@@ -6,6 +6,6 @@ namespace Schema.NET.Tool.Repositories
 
     public interface ISchemaRepository
     {
-        Task<(List<SchemaClass> classes, List<SchemaProperty> properties, List<SchemaEnumerationValue> enumerationValues)> GetObjectsAsync();
+        Task<(List<SchemaClass> Classes, List<SchemaProperty> Properties, List<SchemaEnumerationValue> EnumerationValues)> GetObjectsAsync();
     }
 }

--- a/Tools/Schema.NET.Tool/Repositories/SchemaRepository.cs
+++ b/Tools/Schema.NET.Tool/Repositories/SchemaRepository.cs
@@ -21,7 +21,7 @@ namespace Schema.NET.Tool.Repositories
                 BaseAddress = new Uri("https://schema.org"),
             };
 
-        public async Task<(List<SchemaClass> classes, List<SchemaProperty> properties, List<SchemaEnumerationValue> enumerationValues)> GetObjectsAsync()
+        public async Task<(List<SchemaClass> Classes, List<SchemaProperty> Properties, List<SchemaEnumerationValue> EnumerationValues)> GetObjectsAsync()
         {
             var schemaObjects = await this.GetSchemaObjectsAsync().ConfigureAwait(false);
             var schemaTreeClasses = await this.GetSchemaTreeClassesAsync().ConfigureAwait(false);

--- a/Tools/Schema.NET.Tool/Services/SchemaService.cs
+++ b/Tools/Schema.NET.Tool/Services/SchemaService.cs
@@ -27,7 +27,7 @@ namespace Schema.NET.Tool.Services
             this.schemaRepository = schemaRepository;
         }
 
-        public async Task<(List<Enumeration> enumerations, List<Class> classes)> GetObjectsAsync()
+        public async Task<(List<Enumeration> Enumerations, List<Class> Classes)> GetObjectsAsync()
         {
             var (schemaClasses, schemaProperties, schemaValues) = await this.schemaRepository
                 .GetObjectsAsync()

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0002",
+      "version": "1.0.0-rc0003",
       "commands": [
         "dotnet-cake"
       ]


### PR DESCRIPTION
- Bump StyleCop.Analyzers from 1.1.118 to 1.2.0-beta.321, this allows use of new C# features without warnings.
- Bump dotnet-cake from 1.0.0-rc0002 to 1.0.0-rc0003.