### PR TITLE
Fix VS 16.9 Warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 2.0.1 (Using https://semver.org/)
-# Updated: 2020-12-11
+# Version: 2.1.0 (Using https://semver.org/)
+# Updated: 2021-03-03
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.
@@ -73,84 +73,64 @@ indent_style = tab
 dotnet_analyzer_diagnostic.severity = warning
 
 ##########################################
-# File Header (Uncomment to support file headers)
-# https://docs.microsoft.com/visualstudio/ide/reference/add-file-header
+# Language Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
 ##########################################
 
-# [*.{cs,csx,cake,vb,vbx}]
-# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
-
-# SA1636: File header copyright text should match
-# Justification: .editorconfig supports file headers. If this is changed to a value other than "none", a stylecop.json file will need to added to the project.
-# dotnet_diagnostic.SA1636.severity = none
-
-##########################################
-# .NET Language Conventions
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions
-##########################################
-
-# .NET Code Style Settings
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#net-code-style-settings
+# .NET Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.{cs,csx,cake,vb,vbx}]
 # "this." and "Me." qualifiers
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#this-and-me
 dotnet_style_qualification_for_field = true:warning
 dotnet_style_qualification_for_property = true:warning
 dotnet_style_qualification_for_method = true:warning
 dotnet_style_qualification_for_event = true:warning
 # Language keywords instead of framework type names for type references
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#language-keywords
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning
 # Modifier preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#normalize-modifiers
 dotnet_style_require_accessibility_modifiers = always:warning
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
 dotnet_style_readonly_field = true:warning
 # Parentheses preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parentheses-preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_operators = always_for_clarity:suggestion
 # Expression-level preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
 dotnet_style_explicit_tuple_names = true:warning
 dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 dotnet_style_prefer_auto_properties = true:warning
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
 dotnet_diagnostic.IDE0045.severity = suggestion
 dotnet_style_prefer_conditional_expression_over_return = false:suggestion
 dotnet_diagnostic.IDE0046.severity = suggestion
 dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
 # Null-checking preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#null-checking-preferences
 dotnet_style_coalesce_expression = true:warning
 dotnet_style_null_propagation = true:warning
-# Parameter preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parameter-preferences
-dotnet_code_quality_unused_parameters = all:warning
-# More style options (Undocumented)
-# https://github.com/MicrosoftDocs/visualstudio-docs/issues/3641
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+# File header preferences
+# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
+# If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
+# dotnet_diagnostic.SA1636.severity = none
+# Undocumented
 dotnet_style_operator_placement_when_wrapping = end_of_line
-# https://github.com/dotnet/roslyn/pull/40070
-dotnet_style_prefer_simplified_interpolation = true:warning
 
-# C# Code Style Settings
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings
+# C# Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
 [*.{cs,csx,cake}]
-# Implicit and explicit types
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#implicit-and-explicit-types
+# 'var' preferences
 csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = true:warning
 # Expression-bodied members
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-bodied-members
 csharp_style_expression_bodied_methods = true:warning
 csharp_style_expression_bodied_constructors = true:warning
 csharp_style_expression_bodied_operators = true:warning
@@ -159,50 +139,64 @@ csharp_style_expression_bodied_indexers = true:warning
 csharp_style_expression_bodied_accessors = true:warning
 csharp_style_expression_bodied_lambdas = true:warning
 csharp_style_expression_bodied_local_functions = true:warning
-# Pattern matching
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#pattern-matching
+# Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_pattern_matching_over_as_with_null_check = true:warning
-# Inlined variable declarations
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#inlined-variable-declarations
-csharp_style_inlined_variable_declaration = true:warning
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_not_pattern = true:warning
 # Expression-level preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
+csharp_style_inlined_variable_declaration = true:warning
 csharp_prefer_simple_default_expression = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
 # "Null" checking preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-null-checking-preferences
 csharp_style_throw_expression = true:warning
 csharp_style_conditional_delegate_call = true:warning
 # Code block preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#code-block-preferences
 csharp_prefer_braces = true:warning
-# Unused value preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#unused-value-preferences
+csharp_prefer_simple_using_statement = true:suggestion
+dotnet_diagnostic.IDE0063.severity = suggestion
+# 'using' directive preferences
+csharp_using_directive_placement = inside_namespace:warning
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+
+##########################################
+# Unnecessary Code Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
+##########################################
+
+# .NET Unnecessary code rules
+[*.{cs,csx,cake,vb,vbx}]
+dotnet_code_quality_unused_parameters = all:warning
+dotnet_remove_unnecessary_suppression_exclusions = none:warning
+
+# C# Unnecessary code rules
+[*.{cs,csx,cake}]
 csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
 dotnet_diagnostic.IDE0058.severity = suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 dotnet_diagnostic.IDE0059.severity = suggestion
-# Index and range preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#index-and-range-preferences
-csharp_style_prefer_index_operator = true:warning
-csharp_style_prefer_range_operator = true:warning
-# Miscellaneous preferences
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#miscellaneous-preferences
-csharp_style_deconstructed_variable_declaration = true:warning
-csharp_style_pattern_local_over_anonymous_function = true:warning
-csharp_using_directive_placement = inside_namespace:warning
-csharp_prefer_static_local_function = true:warning
-csharp_prefer_simple_using_statement = true:suggestion
-dotnet_diagnostic.IDE0063.severity = suggestion
 
 ##########################################
-# .NET Formatting Conventions
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference#formatting-conventions
+# Formatting Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules
 ##########################################
 
-# Organize usings
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#organize-using-directives
+# .NET formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
+[*.{cs,csx,cake,vb,vbx}]
+# Organize using directives
 dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# C# formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#c-formatting-rules
+[*.{cs,csx,cake}]
 # Newline options
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#new-line-options
 csharp_new_line_before_open_brace = all
@@ -244,14 +238,14 @@ csharp_space_around_declaration_statements = false
 csharp_space_before_open_square_brackets = false
 csharp_space_between_empty_square_brackets = false
 csharp_space_between_square_brackets = false
-# Wrapping options
+# Wrap options
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#wrap-options
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
 ##########################################
-# .NET Naming Conventions
-# https://docs.microsoft.com/visualstudio/ide/editorconfig-naming-conventions
+# .NET Naming Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/naming-rules
 ##########################################
 
 [*.{cs,csx,cake,vb,vbx}]

--- a/Source/Schema.NET/DateTimeHelper.cs
+++ b/Source/Schema.NET/DateTimeHelper.cs
@@ -10,7 +10,7 @@ namespace Schema.NET
         private const string MSDateStringStart = "/Date(";
         private const string MSDateStringEnd = ")/";
         private const string NegativeOffset = "-";
-        private static readonly DateTime EpochDate = new DateTime(1970, 1, 1);
+        private static readonly DateTime EpochDate = new(1970, 1, 1);
         private static readonly char[] OffsetChars = new[] { '+', '-' };
 
         /// <summary>

--- a/Source/Schema.NET/FastActivator.cs
+++ b/Source/Schema.NET/FastActivator.cs
@@ -10,7 +10,7 @@ namespace Schema.NET
     /// </summary>
     internal static class FastActivator
     {
-        private static readonly ConcurrentDictionary<(Type, Type), Delegate> ConstructorDelegateLookup = new ConcurrentDictionary<(Type, Type), Delegate>();
+        private static readonly ConcurrentDictionary<(Type, Type), Delegate> ConstructorDelegateLookup = new();
 
         /// <summary>
         /// Creates a constructor delegate for the specified type.

--- a/Source/Schema.NET/HashCode.cs
+++ b/Source/Schema.NET/HashCode.cs
@@ -55,7 +55,7 @@ namespace Schema.NET
         /// <typeparam name="T">The type of the item.</typeparam>
         /// <param name="item">The item.</param>
         /// <returns>The new hash code.</returns>
-        public static HashCode Of<T>(T item) => new HashCode(GetHashCode(item));
+        public static HashCode Of<T>(T item) => new(GetHashCode(item));
 
         /// <summary>
         /// Takes the hash code of the specified items.
@@ -72,7 +72,7 @@ namespace Schema.NET
         /// <typeparam name="T">The type of the item.</typeparam>
         /// <param name="item">The item.</param>
         /// <returns>The new hash code.</returns>
-        public HashCode And<T>(T item) => new HashCode(CombineHashCodes(this.value, GetHashCode(item)));
+        public HashCode And<T>(T item) => new(CombineHashCodes(this.value, GetHashCode(item)));
 
         /// <summary>
         /// Adds the hash code of the specified items in the collection.

--- a/Source/Schema.NET/OneOrMany{T}.cs
+++ b/Source/Schema.NET/OneOrMany{T}.cs
@@ -142,7 +142,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(T item) => new OneOrMany<T>(item);
+        public static implicit operator OneOrMany<T>(T item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(T[] array) => new OneOrMany<T>(array);
+        public static implicit operator OneOrMany<T>(T[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator OneOrMany<T>(List<T> list) => new OneOrMany<T>(list);
+        public static implicit operator OneOrMany<T>(List<T> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Schema.NET/SchemaSerializer.cs
+++ b/Source/Schema.NET/SchemaSerializer.cs
@@ -16,7 +16,7 @@ namespace Schema.NET
         /// <summary>
         /// Default serializer settings used when deserializing
         /// </summary>
-        private static readonly JsonSerializerSettings DeserializeSettings = new JsonSerializerSettings
+        private static readonly JsonSerializerSettings DeserializeSettings = new()
         {
             DateParseHandling = DateParseHandling.None,
         };
@@ -24,7 +24,7 @@ namespace Schema.NET
         /// <summary>
         /// Default serializer settings used when HTML escaping is not required.
         /// </summary>
-        private static readonly JsonSerializerSettings DefaultSerializationSettings = new JsonSerializerSettings()
+        private static readonly JsonSerializerSettings DefaultSerializationSettings = new()
         {
             Converters = new List<JsonConverter>()
             {
@@ -38,7 +38,7 @@ namespace Schema.NET
         /// Serializer settings used when trying to avoid XSS vulnerabilities where user-supplied data is used
         /// and the output of the serialization is embedded into a web page raw.
         /// </summary>
-        private static readonly JsonSerializerSettings HtmlEscapedSerializationSettings = new JsonSerializerSettings()
+        private static readonly JsonSerializerSettings HtmlEscapedSerializationSettings = new()
         {
             Converters = new List<JsonConverter>()
             {

--- a/Source/Schema.NET/ValuesJsonConverter.cs
+++ b/Source/Schema.NET/ValuesJsonConverter.cs
@@ -21,7 +21,7 @@ namespace Schema.NET
         private const int HttpsSchemaOrgLength = 19; // equivalent to "https://schema.org/".Length
 
         private static readonly TypeInfo ThingInterfaceTypeInfo = typeof(IThing).GetTypeInfo();
-        private static readonly Dictionary<string, Type> BuiltInThingTypeLookup = new Dictionary<string, Type>(StringComparer.Ordinal);
+        private static readonly Dictionary<string, Type> BuiltInThingTypeLookup = new(StringComparer.Ordinal);
 
         static ValuesJsonConverter()
         {

--- a/Source/Schema.NET/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -372,7 +372,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -381,7 +381,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2 item) => new(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
@@ -389,7 +389,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -398,7 +398,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T5"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
@@ -406,7 +406,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5 item) => new(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T6"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
@@ -414,7 +414,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -423,7 +423,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7 item) => new Values<T1, T2, T3, T4, T5, T6, T7>(item);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -432,7 +432,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -441,7 +441,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -459,7 +459,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T5[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
@@ -467,7 +467,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -476,7 +476,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -485,7 +485,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -494,7 +494,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T1> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T1> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -503,7 +503,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T2> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T2> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -512,7 +512,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T3> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T3> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -521,7 +521,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T4> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T4> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -530,7 +530,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T5> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T5> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -539,7 +539,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T6> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T6> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -548,7 +548,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T7> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T7> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -557,7 +557,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(object[] array) => new Values<T1, T2, T3, T4, T5, T6, T7>(array);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(object[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -566,7 +566,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<object> list) => new Values<T1, T2, T3, T4, T5, T6, T7>(list);
+        public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<object> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3,T4}.cs
@@ -213,7 +213,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T1 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T1 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T2 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T2 item) => new(item);
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3"/> to <see cref="Values{T1,T2}"/>.
@@ -230,7 +230,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T3 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T3 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T4 item) => new Values<T1, T2, T3, T4>(item);
+        public static implicit operator Values<T1, T2, T3, T4>(T4 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T1[] array) => new Values<T1, T2, T3, T4>(array);
+        public static implicit operator Values<T1, T2, T3, T4>(T1[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T2[] array) => new Values<T1, T2, T3, T4>(array);
+        public static implicit operator Values<T1, T2, T3, T4>(T2[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T3[] array) => new Values<T1, T2, T3, T4>(array);
+        public static implicit operator Values<T1, T2, T3, T4>(T3[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -275,7 +275,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(T4[] array) => new Values<T1, T2, T3, T4>(array);
+        public static implicit operator Values<T1, T2, T3, T4>(T4[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(List<T1> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T1> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -293,7 +293,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(List<T2> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T2> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(List<T3> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T3> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(List<T4> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<T4> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(object[] array) => new Values<T1, T2, T3, T4>(array);
+        public static implicit operator Values<T1, T2, T3, T4>(object[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -329,7 +329,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3, T4>(List<object> list) => new Values<T1, T2, T3, T4>(list);
+        public static implicit operator Values<T1, T2, T3, T4>(List<object> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Schema.NET/Values{T1,T2,T3}.cs
+++ b/Source/Schema.NET/Values{T1,T2,T3}.cs
@@ -168,7 +168,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(T1 item) => new Values<T1, T2, T3>(item);
+        public static implicit operator Values<T1, T2, T3>(T1 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(T2 item) => new Values<T1, T2, T3>(item);
+        public static implicit operator Values<T1, T2, T3>(T2 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(T3 item) => new Values<T1, T2, T3>(item);
+        public static implicit operator Values<T1, T2, T3>(T3 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(T1[] array) => new Values<T1, T2, T3>(array);
+        public static implicit operator Values<T1, T2, T3>(T1[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(T2[] array) => new Values<T1, T2, T3>(array);
+        public static implicit operator Values<T1, T2, T3>(T2[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(T3[] array) => new Values<T1, T2, T3>(array);
+        public static implicit operator Values<T1, T2, T3>(T3[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(List<T1> list) => new Values<T1, T2, T3>(list);
+        public static implicit operator Values<T1, T2, T3>(List<T1> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(List<T2> list) => new Values<T1, T2, T3>(list);
+        public static implicit operator Values<T1, T2, T3>(List<T2> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(List<T3> list) => new Values<T1, T2, T3>(list);
+        public static implicit operator Values<T1, T2, T3>(List<T3> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(object[] array) => new Values<T1, T2, T3>(array);
+        public static implicit operator Values<T1, T2, T3>(object[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2, T3>(List<object> list) => new Values<T1, T2, T3>(list);
+        public static implicit operator Values<T1, T2, T3>(List<object> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Schema.NET/Values{T1,T2}.cs
+++ b/Source/Schema.NET/Values{T1,T2}.cs
@@ -127,7 +127,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(T1 item) => new Values<T1, T2>(item);
+        public static implicit operator Values<T1, T2>(T1 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(T2 item) => new Values<T1, T2>(item);
+        public static implicit operator Values<T1, T2>(T2 item) => new(item);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(T1[] array) => new Values<T1, T2>(array);
+        public static implicit operator Values<T1, T2>(T1[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(T2[] array) => new Values<T1, T2>(array);
+        public static implicit operator Values<T1, T2>(T2[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(List<T1> list) => new Values<T1, T2>(list);
+        public static implicit operator Values<T1, T2>(List<T1> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(List<T2> list) => new Values<T1, T2>(list);
+        public static implicit operator Values<T1, T2>(List<T2> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Schema.NET
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(object[] array) => new Values<T1, T2>(array);
+        public static implicit operator Values<T1, T2>(object[] array) => new(array);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
-        public static implicit operator Values<T1, T2>(List<object> list) => new Values<T1, T2>(list);
+        public static implicit operator Values<T1, T2>(List<object> list) => new(list);
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Tests/Schema.NET.Test/MixedTypesTest.cs
+++ b/Tests/Schema.NET.Test/MixedTypesTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
     public class MixedTypesTest
     {
         private readonly Book book =
-            new Book()
+            new()
             {
                 Id = new Uri("https://example.com/book/1"),
                 Author = new List<object>()

--- a/Tests/Schema.NET.Test/SerializationTest.cs
+++ b/Tests/Schema.NET.Test/SerializationTest.cs
@@ -40,20 +40,20 @@ namespace Schema.NET.Test
                 "  \"name\": \"J.D. Salinger\\u003c/script\\u003e\\u003cscript\\u003ealert(\\u0027gotcha\\u0027);\\u003c/script\\u003e\"\r\n" +
             "}";
 
-        private static readonly Person Person = new Person()
+        private static readonly Person Person = new()
         {
             Name = "J.D. Salinger</script><script>alert('gotcha');</script>",
             Description = (string)null,
         };
 
-        private readonly Book book = new Book()
+        private readonly Book book = new()
         {
             Id = new Uri("https://example.com/book/1"),
             Name = "The Catcher in the Rye</script><script>alert('gotcha');</script>",
             Author = Person,
         };
 
-        private readonly JsonSerializerSettings customSerializerSettings = new JsonSerializerSettings()
+        private readonly JsonSerializerSettings customSerializerSettings = new()
         {
             Converters = new List<JsonConverter>()
             {

--- a/Tests/Schema.NET.Test/ThingTest.cs
+++ b/Tests/Schema.NET.Test/ThingTest.cs
@@ -6,7 +6,7 @@ namespace Schema.NET.Test
 
     public class ThingTest
     {
-        private readonly Thing thing = new Thing()
+        private readonly Thing thing = new()
         {
             Name = "New Object",
             Description = "This is the description of a new object we can't deserialize",

--- a/Tests/Schema.NET.Test/core/BookTest.cs
+++ b/Tests/Schema.NET.Test/core/BookTest.cs
@@ -9,7 +9,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/books
     public class BookTest
     {
-        private readonly Book book = new Book()
+        private readonly Book book = new()
         {
             Id = new Uri("https://example.com/book/1"),
             Name = "The Catcher in the Rye",

--- a/Tests/Schema.NET.Test/core/BreadcrumbListTest.cs
+++ b/Tests/Schema.NET.Test/core/BreadcrumbListTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
 
     public class BreadcrumbListTest
     {
-        private readonly BreadcrumbList breadcrumbList = new BreadcrumbList()
+        private readonly BreadcrumbList breadcrumbList = new()
         {
             ItemListElement = new List<IListItem>()
             {

--- a/Tests/Schema.NET.Test/core/CarTest.cs
+++ b/Tests/Schema.NET.Test/core/CarTest.cs
@@ -6,7 +6,7 @@ namespace Schema.NET.Test
 
     public class CarTest
     {
-        private readonly Car car = new Car
+        private readonly Car car = new()
         {
             Name = "Volvo XC90", // Required
             Description = "The XC90 is pure reflection of luxury that embodies Swedish design heritage. See everything this luxury SUV has to offer.", // Recommended

--- a/Tests/Schema.NET.Test/core/ClaimReviewTest.cs
+++ b/Tests/Schema.NET.Test/core/ClaimReviewTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/factcheck
     public class ClaimReviewTest
     {
-        private readonly ClaimReview claimReview = new ClaimReview()
+        private readonly ClaimReview claimReview = new()
         {
             DatePublished = new DateTime(2016, 6, 22), // Required
             Url = new Uri("https://example.com/news/science/worldisflat.html"), // Required

--- a/Tests/Schema.NET.Test/core/CourseTest.cs
+++ b/Tests/Schema.NET.Test/core/CourseTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/courses
     public class CourseTest
     {
-        private readonly Course course = new Course()
+        private readonly Course course = new()
         {
             Name = "Introduction to Computer Science and Programming", // Required
             Description = "Introductory CS course laying out the basics.", // Required

--- a/Tests/Schema.NET.Test/core/EventTest.cs
+++ b/Tests/Schema.NET.Test/core/EventTest.cs
@@ -13,7 +13,7 @@ namespace Schema.NET.Test
         private static readonly ItemAvailability? NullItemAvailability;
 #pragma warning restore CS0649 // Field is never assigned to and will always have its default value.
 
-        private readonly Event @event = new Event()
+        private readonly Event @event = new()
         {
             Name = "Jan Lieberman Concert Series: Journey in Jazz", // Required
             Description = "Join us for an afternoon of Jazz with Santa Clara resident and pianist Andy Lagunoff. Complimentary food and beverages will be served.", // Recommended

--- a/Tests/Schema.NET.Test/core/ItemListTest.cs
+++ b/Tests/Schema.NET.Test/core/ItemListTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
 
     public class ItemListTest
     {
-        private readonly ItemList itemlist = new ItemList()
+        private readonly ItemList itemlist = new()
         {
             ItemListElement = new List<IListItem>() // Required
                 {

--- a/Tests/Schema.NET.Test/core/JobPostingTest.cs
+++ b/Tests/Schema.NET.Test/core/JobPostingTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/job-postings
     public class JobPostingTest
     {
-        private readonly JobPosting jobPosting = new JobPosting()
+        private readonly JobPosting jobPosting = new()
         {
             Title = "Fitter and Turner", // Required
             Description = "<p>Widget assembly role for pressing wheel assemblies.</p><p><strong>Educational Requirements:</strong> Completed level 2 ISTA Machinist Apprenticeship.</p><p><strong>Required Experience:</strong> At least 3 years in a machinist role.</p>", // Required

--- a/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicAlbumTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
 
     public class MusicAlbumTest
     {
-        private readonly MusicAlbum musicAlbum = new MusicAlbum()
+        private readonly MusicAlbum musicAlbum = new()
         {
             Name = "Hail to the Thief", // Required
             Identifier = "1oW3v5Har9mvXnGk0x4fHm", // Recommended

--- a/Tests/Schema.NET.Test/core/MusicEventTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicEventTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
 
     public class MusicEventTest
     {
-        private readonly MusicEvent musicEvent = new MusicEvent()
+        private readonly MusicEvent musicEvent = new()
         {
             Name = "Arash & Tohi", // Required
             Identifier = "vv1AaZAQ8Gkds-P77",

--- a/Tests/Schema.NET.Test/core/MusicGroupTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicGroupTest.cs
@@ -6,7 +6,7 @@ namespace Schema.NET.Test
 
     public class MusicGroupTest
     {
-        private readonly MusicGroup musicGroup = new MusicGroup()
+        private readonly MusicGroup musicGroup = new()
         {
             Name = "Radiohead", // Required
             Identifier = "4Z8W4fKeB5YxbusRsdQVPb", // Recommended

--- a/Tests/Schema.NET.Test/core/MusicRecordingTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicRecordingTest.cs
@@ -6,7 +6,7 @@ namespace Schema.NET.Test
 
     public class MusicRecordingTest
     {
-        private readonly MusicRecording musicRecording = new MusicRecording()
+        private readonly MusicRecording musicRecording = new()
         {
             Name = "2 + 2 = 5", // Required
             Identifier = "37kUGdEJJ7NaMl5LFW4EA4", // Recommended

--- a/Tests/Schema.NET.Test/core/MusicVenueTest.cs
+++ b/Tests/Schema.NET.Test/core/MusicVenueTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
 
     public class MusicVenueTest
     {
-        private readonly MusicVenue musicVenue = new MusicVenue()
+        private readonly MusicVenue musicVenue = new()
         {
             Name = "Dolby Theatre", // Required
             Description = "Host to a range of prestigious events including movie premieres, concerts & the Oscars https://www.dolbytheatre.com", // Recommended

--- a/Tests/Schema.NET.Test/core/NewsArticleTest.cs
+++ b/Tests/Schema.NET.Test/core/NewsArticleTest.cs
@@ -6,7 +6,7 @@ namespace Schema.NET.Test
 
     public class NewsArticleTest
     {
-        private readonly NewsArticle article = new NewsArticle()
+        private readonly NewsArticle article = new()
         {
             MainEntityOfPage = new Uri("https://google.com/article"), // Ignored
             Headline = "Article headline", // Recommended

--- a/Tests/Schema.NET.Test/core/OrganizationTest.cs
+++ b/Tests/Schema.NET.Test/core/OrganizationTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/logo
     public class OrganizationTest
     {
-        private readonly Organization organization = new Organization()
+        private readonly Organization organization = new()
         {
             AreaServed = "GB", // Recommended. Omit for global.
             ContactPoint = new ContactPoint() // Required

--- a/Tests/Schema.NET.Test/core/PersonTest.cs
+++ b/Tests/Schema.NET.Test/core/PersonTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/social-profile-links
     public class PersonTest
     {
-        private readonly Person person = new Person()
+        private readonly Person person = new()
         {
             Name = "Name", // Required
             SameAs = new List<Uri>() // Required

--- a/Tests/Schema.NET.Test/core/ProductTest.cs
+++ b/Tests/Schema.NET.Test/core/ProductTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/products
     public class ProductTest
     {
-        private readonly Product product = new Product()
+        private readonly Product product = new()
         {
             Name = "Executive Anvil", // Required
             Description = "Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveller looking for something to drop from a height.", // Recommended

--- a/Tests/Schema.NET.Test/core/RecipeTest.cs
+++ b/Tests/Schema.NET.Test/core/RecipeTest.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/guides/mark-up-listings
     public class RecipeTest
     {
-        private readonly Recipe recipe = new Recipe()
+        private readonly Recipe recipe = new()
         {
             Name = "Grandma's Holiday Apple Pie",
             Image = new Uri("https://example.com/image.jpg"),

--- a/Tests/Schema.NET.Test/core/RestaurantTest.cs
+++ b/Tests/Schema.NET.Test/core/RestaurantTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/local-businesses
     public class RestaurantTest
     {
-        private readonly Restaurant restaurant = new Restaurant()
+        private readonly Restaurant restaurant = new()
         {
             Id = new Uri("https://davessteakhouse.example.com"),
             Name = "Dave's Steak House",

--- a/Tests/Schema.NET.Test/core/TestDefaults.cs
+++ b/Tests/Schema.NET.Test/core/TestDefaults.cs
@@ -5,7 +5,7 @@ namespace Schema.NET.Test
 
     public static class TestDefaults
     {
-        public static readonly JsonSerializerSettings DefaultJsonSerializerSettings = new JsonSerializerSettings()
+        public static readonly JsonSerializerSettings DefaultJsonSerializerSettings = new()
         {
             Formatting = Formatting.None,
             DateParseHandling = DateParseHandling.DateTimeOffset,

--- a/Tests/Schema.NET.Test/core/VideoObjectTest.cs
+++ b/Tests/Schema.NET.Test/core/VideoObjectTest.cs
@@ -7,7 +7,7 @@ namespace Schema.NET.Test
     // https://developers.google.com/search/docs/data-types/articles
     public class VideoObjectTest
     {
-        private readonly VideoObject videoObject = new VideoObject()
+        private readonly VideoObject videoObject = new()
         {
             Name = "Title", // Required
             Description = "Video description", // Required

--- a/Tools/Schema.NET.Tool/Services/EnumerationValueComparer.cs
+++ b/Tools/Schema.NET.Tool/Services/EnumerationValueComparer.cs
@@ -5,7 +5,7 @@ namespace Schema.NET.Tool.Services
 
     public class EnumerationValueComparer : IComparer<string>
     {
-        private static readonly Dictionary<string, int> KnownEnumerationValueOrders = new Dictionary<string, int>
+        private static readonly Dictionary<string, int> KnownEnumerationValueOrders = new()
         {
             { "SUNDAY", 0 },
             { "MONDAY", 1 },

--- a/Tools/Schema.NET.Tool/Services/PropertyNameComparer.cs
+++ b/Tools/Schema.NET.Tool/Services/PropertyNameComparer.cs
@@ -5,7 +5,7 @@ namespace Schema.NET.Tool.Services
 
     public class PropertyNameComparer : IComparer<string>
     {
-        public static readonly Dictionary<string, int> KnownPropertyNameOrders = new Dictionary<string, int>
+        public static readonly Dictionary<string, int> KnownPropertyNameOrders = new()
         {
             { "CONTEXT", 0 },
             { "TYPE", 1 },

--- a/Tools/Schema.NET.Tool/ViewModels/PropertyType.cs
+++ b/Tools/Schema.NET.Tool/ViewModels/PropertyType.cs
@@ -22,6 +22,6 @@ namespace Schema.NET.Tool.ViewModels
 
         public string Name { get; }
 
-        public PropertyType Clone() => new PropertyType(this.Name, this.CSharpTypeStrings);
+        public PropertyType Clone() => new(this.Name, this.CSharpTypeStrings);
     }
 }


### PR DESCRIPTION
cc @Turnerj 

I think VS 16.9 switched on some new warnings from the `.editorconfig` file.