### PR TITLE
Source generator tweaks

### DIFF
--- a/Tools/Schema.NET.Tool/CustomOverrides/AddQueryInputPropertyToSearchAction.cs
+++ b/Tools/Schema.NET.Tool/CustomOverrides/AddQueryInputPropertyToSearchAction.cs
@@ -23,10 +23,7 @@ namespace Schema.NET.Tool.CustomOverrides
                 throw new ArgumentNullException(nameof(c));
             }
 
-            var property = new GeneratorSchemaProperty(c, "query-input", "QueryInput")
-            {
-                Description = "Gets or sets the query input search parameter.",
-            };
+            var property = new GeneratorSchemaProperty(c, "query-input", "QueryInput", "Gets or sets the query input search parameter.");
             property.Types.AddRange(
                 new List<GeneratorSchemaPropertyType>()
                 {

--- a/Tools/Schema.NET.Tool/CustomOverrides/RenameEventProperty.cs
+++ b/Tools/Schema.NET.Tool/CustomOverrides/RenameEventProperty.cs
@@ -28,9 +28,8 @@ namespace Schema.NET.Tool.CustomOverrides
                 .First(x => string.Equals(x.Name, "Event", StringComparison.OrdinalIgnoreCase));
             c.Properties.Remove(eventProperty);
 
-            var updatedProperty = new GeneratorSchemaProperty(c, eventProperty.JsonName, "Events")
+            var updatedProperty = new GeneratorSchemaProperty(c, eventProperty.JsonName, "Events", eventProperty.Description)
             {
-                Description = eventProperty.Description,
                 Order = eventProperty.Order,
             };
             updatedProperty.Types.AddRange(eventProperty.Types);

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaClass.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaClass.cs
@@ -7,15 +7,19 @@ namespace Schema.NET.Tool.GeneratorModels
     using Schema.NET.Tool.Constants;
 
     [DebuggerDisplay("{Name}")]
-#pragma warning disable CA1716 // Identifiers should not match keywords
     public class GeneratorSchemaClass : GeneratorSchemaObject
-#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public GeneratorSchemaClass(Uri id)
-            : base(string.Empty, string.Empty) => this.Id = id;
+            : this(layer: string.Empty, id, name: string.Empty, description: string.Empty)
+        {
+        }
 
-        public GeneratorSchemaClass(Uri id, string layer, string name)
-            : base(layer, name) => this.Id = id;
+        public GeneratorSchemaClass(string layer, Uri id, string name, string description, bool isCombined = false)
+            : base(layer, name, description)
+        {
+            this.Id = id;
+            this.IsCombined = isCombined;
+        }
 
         public IEnumerable<GeneratorSchemaClass> Ancestors => EnumerableExtensions
             .Traverse(this, x => x.Parents)
@@ -29,15 +33,13 @@ namespace Schema.NET.Tool.GeneratorModels
             .Traverse(this, x => x.Children)
             .Where(x => x != this);
 
-        public string? Description { get; set; }
-
         public Uri Id { get; }
 
         public bool IsArchived => EnumerableExtensions
             .Traverse(this, x => x.Parents)
             .Any(x => string.Equals(x.Layer, LayerName.Archived, StringComparison.Ordinal));
 
-        public bool IsCombined { get; set; }
+        public bool IsCombined { get; }
 
         public IEnumerable<GeneratorSchemaProperty> DeclaredProperties
         {

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaEnumeration.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaEnumeration.cs
@@ -4,16 +4,12 @@ namespace Schema.NET.Tool.GeneratorModels
     using System.Diagnostics;
 
     [DebuggerDisplay("{Name}")]
-#pragma warning disable CA1724 // Identifiers should conflict with namespaces
     public class GeneratorSchemaEnumeration : GeneratorSchemaObject
-#pragma warning restore CA1724 // Identifiers should conflict with namespaces
     {
-        public GeneratorSchemaEnumeration(string layer, string name)
-            : base(layer, name)
+        public GeneratorSchemaEnumeration(string layer, string name, string description)
+            : base(layer, name, description)
         {
         }
-
-        public string? Description { get; set; }
 
         public List<GeneratorSchemaEnumerationValue> Values { get; } = new List<GeneratorSchemaEnumerationValue>();
     }

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaEnumerationValue.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaEnumerationValue.cs
@@ -6,13 +6,14 @@ namespace Schema.NET.Tool.GeneratorModels
     [DebuggerDisplay("{Name}")]
     public class GeneratorSchemaEnumerationValue
     {
-        public GeneratorSchemaEnumerationValue(string name, Uri uri)
+        public GeneratorSchemaEnumerationValue(string name, Uri uri, string description)
         {
             this.Name = name;
             this.Uri = uri;
+            this.Description = description;
         }
 
-        public string? Description { get; set; }
+        public string Description { get; }
 
         public string Name { get; }
 

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaObject.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaObject.cs
@@ -2,11 +2,14 @@ namespace Schema.NET.Tool.GeneratorModels
 {
     public class GeneratorSchemaObject
     {
-        public GeneratorSchemaObject(string layer, string name)
+        public GeneratorSchemaObject(string layer, string name, string description)
         {
             this.Layer = layer;
             this.Name = name;
+            this.Description = description;
         }
+
+        public string Description { get; }
 
         public string Layer { get; }
 

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaProperty.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaProperty.cs
@@ -6,20 +6,19 @@ namespace Schema.NET.Tool.GeneratorModels
     using System.Linq;
 
     [DebuggerDisplay("{Name}")]
-#pragma warning disable CA1716 // Identifiers should not match keywords
     public class GeneratorSchemaProperty
-#pragma warning restore CA1716 // Identifiers should not match keywords
     {
-        public GeneratorSchemaProperty(GeneratorSchemaClass @class, string jsonName, string name)
+        public GeneratorSchemaProperty(GeneratorSchemaClass @class, string jsonName, string name, string description)
         {
             this.Class = @class;
             this.JsonName = jsonName;
             this.Name = name;
+            this.Description = description;
         }
 
         public GeneratorSchemaClass Class { get; }
 
-        public string? Description { get; set; }
+        public string Description { get; }
 
         public string JsonName { get; }
 
@@ -66,9 +65,8 @@ namespace Schema.NET.Tool.GeneratorModels
 
         public GeneratorSchemaProperty Clone(GeneratorSchemaClass context)
         {
-            var property = new GeneratorSchemaProperty(context, this.JsonName, this.Name)
+            var property = new GeneratorSchemaProperty(context, this.JsonName, this.Name, this.Description)
             {
-                Description = this.Description,
                 Order = this.Order,
             };
             property.Types.AddRange(this.Types.Select(x => x.Clone()));

--- a/Tools/Schema.NET.Tool/Models/SchemaClass.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaClass.cs
@@ -9,8 +9,8 @@ namespace Schema.NET.Tool.Models
     {
         private static readonly Uri EnumerationId = new("https://schema.org/Enumeration");
 
-        public SchemaClass(Uri id, string label, string layer)
-            : base(id, label, layer)
+        public SchemaClass(string comment, Uri id, string label, string layer)
+            : base(comment, id, label, layer)
         {
         }
 

--- a/Tools/Schema.NET.Tool/Models/SchemaClass.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaClass.cs
@@ -9,8 +9,8 @@ namespace Schema.NET.Tool.Models
     {
         private static readonly Uri EnumerationId = new("https://schema.org/Enumeration");
 
-        public SchemaClass(string comment, Uri id, string label, string layer)
-            : base(comment, id, label, layer)
+        public SchemaClass(string layer, Uri id, string label, string comment)
+            : base(layer, id, label, comment)
         {
         }
 

--- a/Tools/Schema.NET.Tool/Models/SchemaEnumerationValue.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaEnumerationValue.cs
@@ -4,8 +4,8 @@ namespace Schema.NET.Tool.Models
 
     public class SchemaEnumerationValue : SchemaObject
     {
-        public SchemaEnumerationValue(string comment, Uri id, string label, string layer)
-            : base(comment, id, label, layer)
+        public SchemaEnumerationValue(string layer, Uri id, string label, string comment)
+            : base(layer, id, label, comment)
         {
         }
     }

--- a/Tools/Schema.NET.Tool/Models/SchemaEnumerationValue.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaEnumerationValue.cs
@@ -4,8 +4,8 @@ namespace Schema.NET.Tool.Models
 
     public class SchemaEnumerationValue : SchemaObject
     {
-        public SchemaEnumerationValue(Uri id, string label, string layer)
-            : base(id, label, layer)
+        public SchemaEnumerationValue(string comment, Uri id, string label, string layer)
+            : base(comment, id, label, layer)
         {
         }
     }

--- a/Tools/Schema.NET.Tool/Models/SchemaObject.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaObject.cs
@@ -30,20 +30,21 @@ namespace Schema.NET.Tool.Models
             "PronounceableText",
         };
 
-        public SchemaObject(Uri id, string label, string layer)
+        public SchemaObject(string comment, Uri id, string label, string layer)
         {
+            this.Comment = comment;
             this.Id = id;
             this.Label = label;
             this.Layer = layer;
         }
+
+        public string Comment { get; }
 
         public Uri Id { get; }
 
         public string Label { get; }
 
         public string Layer { get; }
-
-        public string? Comment { get; set; }
 
         public List<string> Types { get; } = new List<string>();
 

--- a/Tools/Schema.NET.Tool/Models/SchemaObject.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaObject.cs
@@ -30,12 +30,12 @@ namespace Schema.NET.Tool.Models
             "PronounceableText",
         };
 
-        public SchemaObject(string comment, Uri id, string label, string layer)
+        public SchemaObject(string layer, Uri id, string label, string comment)
         {
-            this.Comment = comment;
+            this.Layer = layer;
             this.Id = id;
             this.Label = label;
-            this.Layer = layer;
+            this.Comment = comment;
         }
 
         public string Comment { get; }

--- a/Tools/Schema.NET.Tool/Models/SchemaProperty.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaProperty.cs
@@ -5,8 +5,8 @@ namespace Schema.NET.Tool.Models
 
     public class SchemaProperty : SchemaObject
     {
-        public SchemaProperty(Uri id, string label, string layer)
-            : base(id, label, layer)
+        public SchemaProperty(string comment, Uri id, string label, string layer)
+            : base(comment, id, label, layer)
         {
         }
 

--- a/Tools/Schema.NET.Tool/Models/SchemaProperty.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaProperty.cs
@@ -5,8 +5,8 @@ namespace Schema.NET.Tool.Models
 
     public class SchemaProperty : SchemaObject
     {
-        public SchemaProperty(string comment, Uri id, string label, string layer)
-            : base(comment, id, label, layer)
+        public SchemaProperty(string layer, Uri id, string label, string comment)
+            : base(layer, id, label, comment)
         {
         }
 

--- a/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
+++ b/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
@@ -51,20 +51,17 @@ namespace Schema.NET.Tool.Repositories
             var id = SchemaOrgUrl(idToken.GetString()!);
             var types = GetTokenValues(token, "@type").ToArray();
 
-            string? comment;
+            string comment;
             if (commentToken.ValueKind == JsonValueKind.Object && commentToken.TryGetProperty("@value", out var commentValueToken))
             {
-                comment = commentValueToken.GetString();
+                comment = commentValueToken.GetString()!;
             }
             else
             {
-                comment = commentToken.GetString();
+                comment = commentToken.GetString()!;
             }
 
             var label = GetLabel(token);
-            var domainIncludes = GetTokenValues(token, "schema:domainIncludes", "@id").Select(SchemaOrgUrl).ToArray();
-            var rangeIncludes = GetTokenValues(token, "schema:rangeIncludes", "@id").Select(SchemaOrgUrl).ToArray();
-            var subClassOf = GetTokenValues(token, "rdfs:subClassOf", "@id").Select(SchemaOrgUrl).ToArray();
             var isPartOf = GetTokenValues(token, "schema:isPartOf", "@id").Select(s => new Uri(s)).FirstOrDefault();
 
             var layer = LayerName.Core;
@@ -75,32 +72,31 @@ namespace Schema.NET.Tool.Repositories
 
             if (types.Any(type => string.Equals(type, "rdfs:Class", StringComparison.Ordinal)))
             {
-                var schemaClass = new SchemaClass(id, label, layer)
-                {
-                    Comment = comment,
-                };
+                var schemaClass = new SchemaClass(comment, id, label, layer);
+
+                var subClassOf = GetTokenValues(token, "rdfs:subClassOf", "@id").Select(SchemaOrgUrl);
                 schemaClass.SubClassOfIds.AddRange(subClassOf);
+
                 schemaClass.Types.AddRange(types);
                 return schemaClass;
             }
             else if (types.Any(type => string.Equals(type, "rdf:Property", StringComparison.Ordinal)))
             {
-                var schemaProperty = new SchemaProperty(id, label, layer)
-                {
-                    Comment = comment,
-                };
+                var schemaProperty = new SchemaProperty(comment, id, label, layer);
+
+                var domainIncludes = GetTokenValues(token, "schema:domainIncludes", "@id").Select(SchemaOrgUrl);
                 schemaProperty.DomainIncludes.AddRange(domainIncludes);
+
+                var rangeIncludes = GetTokenValues(token, "schema:rangeIncludes", "@id").Select(SchemaOrgUrl);
                 schemaProperty.RangeIncludes.AddRange(rangeIncludes);
+
                 schemaProperty.Types.AddRange(types);
                 return schemaProperty;
             }
             else
             {
-                var schemaEnumerationValue = new SchemaEnumerationValue(id, label, layer)
-                {
-                    Comment = comment,
-                };
-                schemaEnumerationValue.Types.AddRange(types.Select(SchemaOrgUrl).Select(u => u.ToString()).ToArray());
+                var schemaEnumerationValue = new SchemaEnumerationValue(comment, id, label, layer);
+                schemaEnumerationValue.Types.AddRange(types.Select(SchemaOrgUrl).Select(u => u.ToString()));
                 return schemaEnumerationValue;
             }
         }

--- a/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
+++ b/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
@@ -72,7 +72,7 @@ namespace Schema.NET.Tool.Repositories
 
             if (types.Any(type => string.Equals(type, "rdfs:Class", StringComparison.Ordinal)))
             {
-                var schemaClass = new SchemaClass(comment, id, label, layer);
+                var schemaClass = new SchemaClass(layer, id, label, comment);
 
                 var subClassOf = GetTokenValues(token, "rdfs:subClassOf", "@id").Select(SchemaOrgUrl);
                 schemaClass.SubClassOfIds.AddRange(subClassOf);
@@ -82,7 +82,7 @@ namespace Schema.NET.Tool.Repositories
             }
             else if (types.Any(type => string.Equals(type, "rdf:Property", StringComparison.Ordinal)))
             {
-                var schemaProperty = new SchemaProperty(comment, id, label, layer);
+                var schemaProperty = new SchemaProperty(layer, id, label, comment);
 
                 var domainIncludes = GetTokenValues(token, "schema:domainIncludes", "@id").Select(SchemaOrgUrl);
                 schemaProperty.DomainIncludes.AddRange(domainIncludes);
@@ -95,7 +95,7 @@ namespace Schema.NET.Tool.Repositories
             }
             else
             {
-                var schemaEnumerationValue = new SchemaEnumerationValue(comment, id, label, layer);
+                var schemaEnumerationValue = new SchemaEnumerationValue(layer, id, label, comment);
                 schemaEnumerationValue.Types.AddRange(types.Select(SchemaOrgUrl).Select(u => u.ToString()));
                 return schemaEnumerationValue;
             }

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -26,10 +26,10 @@ namespace Schema.NET.Tool
             var schemaService = new SchemaService(
                 new IClassOverride[]
                 {
-                        new AddQueryInputPropertyToSearchAction(),
-                        new AddTextTypeToActionTarget(),
-                        new AddNumberTypeToMediaObjectHeightAndWidth(),
-                        new RenameEventProperty(),
+                    new AddQueryInputPropertyToSearchAction(),
+                    new AddTextTypeToActionTarget(),
+                    new AddNumberTypeToMediaObjectHeightAndWidth(),
+                    new RenameEventProperty(),
                 },
                 Array.Empty<IEnumerationOverride>(),
                 schemaRepository,

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -4,7 +4,6 @@ namespace Schema.NET.Tool
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
-    using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Schema.NET.Tool.CustomOverrides;
     using Schema.NET.Tool.GeneratorModels;
@@ -14,7 +13,9 @@ namespace Schema.NET.Tool
     [Generator]
     public class SchemaSourceGenerator : ISourceGenerator
     {
-        private IEnumerable<GeneratorSchemaObject>? SchemaObjects { get; set; }
+        private static readonly object SchemaLock = new();
+
+        private static IEnumerable<GeneratorSchemaObject>? SchemaObjects { get; set; }
 
         public void Initialize(GeneratorInitializationContext context)
         {
@@ -34,16 +35,25 @@ namespace Schema.NET.Tool
                 schemaRepository,
                 false);
 
+            if (SchemaObjects is null)
+            {
+                lock (SchemaLock)
+                {
+                    if (SchemaObjects is null)
+                    {
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            this.SchemaObjects = schemaService.GetObjectsAsync().GetAwaiter().GetResult();
+                        SchemaObjects = schemaService.GetObjectsAsync().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+                    }
+                }
+            }
         }
 
         public void Execute(GeneratorExecutionContext context)
         {
-            if (this.SchemaObjects is not null)
+            if (SchemaObjects is not null)
             {
-                foreach (var schemaObject in this.SchemaObjects)
+                foreach (var schemaObject in SchemaObjects)
                 {
                     var source = string.Empty;
                     if (schemaObject is GeneratorSchemaClass schemaClass)

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -18,29 +18,24 @@ namespace Schema.NET.Tool
 
         public void Initialize(GeneratorInitializationContext context)
         {
-#pragma warning disable IDE0022 // Use expression body for methods
-            Task.Run(async () =>
+            var schemaRepository = new SchemaRepository(new HttpClient()
             {
-                var schemaRepository = new SchemaRepository(new HttpClient()
+                BaseAddress = new Uri("https://schema.org"),
+            });
+            var schemaService = new SchemaService(
+                new IClassOverride[]
                 {
-                    BaseAddress = new Uri("https://schema.org"),
-                });
-                var schemaService = new SchemaService(
-                    new IClassOverride[]
-                    {
                         new AddQueryInputPropertyToSearchAction(),
                         new AddTextTypeToActionTarget(),
                         new AddNumberTypeToMediaObjectHeightAndWidth(),
                         new RenameEventProperty(),
-                    },
-                    Array.Empty<IEnumerationOverride>(),
-                    schemaRepository,
-                    false);
+                },
+                Array.Empty<IEnumerationOverride>(),
+                schemaRepository,
+                false);
 
-                this.SchemaObjects = await schemaService.GetObjectsAsync().ConfigureAwait(false);
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            }).GetAwaiter().GetResult();
-#pragma warning restore IDE0022 // Use expression body for methods
+            this.SchemaObjects = schemaService.GetObjectsAsync().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 

--- a/Tools/Schema.NET.Tool/Services/SchemaService.cs
+++ b/Tools/Schema.NET.Tool/Services/SchemaService.cs
@@ -124,11 +124,7 @@ namespace Schema.NET.Tool.Services
                         var classDescription = "See " + string.Join(", ", @class.Parents.Select(x => x.Name).OrderBy(x => x)) + " for more information.";
                         var parents = @class.Parents.SelectMany(x => x.Parents).GroupBy(x => x.Name).Select(x => x.First()).ToArray();
                         var layerName = @class.IsCombined ? @class.Layer : $"{@class.Layer}.combined";
-                        combinedClass = new GeneratorSchemaClass(new Uri($"https://CombinedClass/{className}"), layerName, className)
-                        {
-                            Description = classDescription,
-                            IsCombined = true,
-                        };
+                        combinedClass = new GeneratorSchemaClass(layerName, new Uri($"https://CombinedClass/{className}"), className, classDescription, isCombined: true);
                         combinedClass.CombinationOf.AddRange(@class.Parents);
                         combinedClass.Properties.AddRange(@class
                             .Parents
@@ -208,17 +204,10 @@ namespace Schema.NET.Tool.Services
             Models.SchemaClass schemaClass,
             IEnumerable<Models.SchemaEnumerationValue> schemaValues)
         {
-            var enumeration = new GeneratorSchemaEnumeration($"{schemaClass.Layer}.enumerations", schemaClass.Label)
-            {
-                Description = schemaClass.Comment,
-            };
+            var enumeration = new GeneratorSchemaEnumeration($"{schemaClass.Layer}.enumerations", schemaClass.Label, schemaClass.Comment);
             enumeration.Values.AddRange(schemaValues
                 .Where(x => x.Types.Contains(schemaClass.Id.ToString()))
-                .Select(
-                    x => new GeneratorSchemaEnumerationValue(x.Label, x.Id)
-                    {
-                        Description = x.Comment,
-                    })
+                .Select(x => new GeneratorSchemaEnumerationValue(x.Label, x.Id, x.Comment))
                 .OrderBy(x => x.Name, new EnumerationValueComparer()));
             return enumeration;
         }
@@ -232,10 +221,7 @@ namespace Schema.NET.Tool.Services
             bool includePending)
         {
             var className = StartsWithNumber.IsMatch(schemaClass.Label) ? $"_{schemaClass.Label}" : schemaClass.Label;
-            var @class = new GeneratorSchemaClass(schemaClass.Id, schemaClass.Layer, className)
-            {
-                Description = schemaClass.Comment,
-            };
+            var @class = new GeneratorSchemaClass(schemaClass.Layer, schemaClass.Id, className, schemaClass.Comment);
 
             @class.Parents.AddRange(schemaClass.SubClassOfIds
                 .Where(id => knownSchemaClasses.Contains(id))
@@ -245,10 +231,7 @@ namespace Schema.NET.Tool.Services
                 .Select(x =>
                 {
                     var propertyName = GetPropertyName(x.Label);
-                    var property = new GeneratorSchemaProperty(@class, CamelCase(propertyName), propertyName)
-                    {
-                        Description = x.Comment,
-                    };
+                    var property = new GeneratorSchemaProperty(@class, CamelCase(propertyName), propertyName, x.Comment);
                     property.Types.AddRange(x.RangeIncludes
                         .Where(id =>
                         {


### PR DESCRIPTION
Various source generator tweaks and improvements:

- The comment field is now immutable (we were already refusing to parse any classes/enums/properties that didn't have one so it made sense to do)
- Optimizing the parsing of various properties depending on the type (eg. only parsing `schema:domainIncludes` for properties only)
- Deserializing the HTTP stream for the JSON rather than a string buffer (note the `HttpCompletionOption` which helps this) which can improve performance and allocations
- Removes the additional `Task.Run` in the generator's initializer
- Caches schema object data between different runs of the source generator for the different targets

Other plans:
- ~Investigate whether the source generator is triggered for every target (if so, see if we can cache the JSON)~
- Any other performance improvements in processing the JSON

Other notes:
- Found a weird quirk with #261 that it compiles with `dotnet build` but not `msbuild` or via Visual Studio. See dotnet/roslyn#52017 - the CI isn't affected as far as I can tell.