### PR TITLE
Further Nullable Improvements

### DIFF
--- a/Source/Schema.NET/DateTimeHelper.cs
+++ b/Source/Schema.NET/DateTimeHelper.cs
@@ -1,6 +1,7 @@
 namespace Schema.NET
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Helper for parsing strings into <see cref="DateTime"/> or <see cref="DateTimeOffset"/>
@@ -45,7 +46,12 @@ namespace Schema.NET
         /// <param name="input">The input string</param>
         /// <param name="result">The result date and time</param>
         /// <returns>True if the input string was able to be parsed into a <see cref="DateTime"/></returns>
-        public static bool TryParseMSDateTime(string? input, out DateTime result)
+        public static bool TryParseMSDateTime(
+#if NETCOREAPP3_1_OR_GREATER
+            [NotNullWhen(true)]
+#endif
+            string? input,
+            out DateTime result)
         {
             if (input is not null &&
                 input.StartsWith(MSDateStringStart, StringComparison.Ordinal) &&
@@ -54,7 +60,7 @@ namespace Schema.NET
                 var dateTimeStartIndex = MSDateStringStart.Length;
                 var dateTimeLength = input.IndexOf(MSDateStringEnd, StringComparison.Ordinal) - dateTimeStartIndex;
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 var timeValue = input.AsSpan().Slice(dateTimeStartIndex, dateTimeLength);
 #else
                 var timeValue = input.Substring(dateTimeStartIndex, dateTimeLength);
@@ -77,7 +83,12 @@ namespace Schema.NET
         /// <param name="input">The input string</param>
         /// <param name="result">The result date and time with offset</param>
         /// <returns>True if the input string was able to be parsed into a <see cref="DateTimeOffset"/></returns>
-        public static bool TryParseMSDateTimeOffset(string? input, out DateTimeOffset result)
+        public static bool TryParseMSDateTimeOffset(
+#if NETCOREAPP3_1_OR_GREATER
+            [NotNullWhen(true)]
+#endif
+            string? input,
+            out DateTimeOffset result)
         {
             if (input is not null &&
                 input.StartsWith(MSDateStringStart, StringComparison.Ordinal) &&
@@ -88,7 +99,7 @@ namespace Schema.NET
                 var dateTimeLength = offsetIndex - dateTimeStartIndex;
                 var offsetLength = input.IndexOf(MSDateStringEnd, offsetIndex, StringComparison.Ordinal) - offsetIndex;
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 var timeValue = input.AsSpan().Slice(dateTimeStartIndex, dateTimeLength);
                 var offsetType = input.AsSpan().Slice(offsetIndex, 1);
                 var offsetValue = input.AsSpan().Slice(offsetIndex + 1, offsetLength - 1);

--- a/Source/Schema.NET/EnumHelper.cs
+++ b/Source/Schema.NET/EnumHelper.cs
@@ -1,6 +1,7 @@
 namespace Schema.NET
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Helper for parsing strings into Enum values.
@@ -15,7 +16,13 @@ namespace Schema.NET
         /// <param name="value">The string representation of the name or numeric value of one or more enumerated constants.</param>
         /// <param name="result">When this method returns true, an object containing an enumeration constant representing the parsed value.</param>
         /// <returns><see langword="true"/> if the conversion succeeded; <see langword="false"/> otherwise.</returns>
-        public static bool TryParse(Type enumType, string? value, out object? result)
+        public static bool TryParse(
+            Type enumType,
+#if NETCOREAPP3_1_OR_GREATER
+            [NotNullWhen(true)]
+#endif
+            string? value,
+            out object? result)
         {
 #if NETSTANDARD2_0 || NET472 || NET461
             try

--- a/Source/Schema.NET/ValuesJsonConverter.cs
+++ b/Source/Schema.NET/ValuesJsonConverter.cs
@@ -3,6 +3,7 @@ namespace Schema.NET
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Reflection;
     using System.Xml;
@@ -395,7 +396,12 @@ namespace Schema.NET
             return success;
         }
 
-        private static bool TryGetConcreteType(string typeName, out Type? type)
+        private static bool TryGetConcreteType(
+            string typeName,
+#if NETCOREAPP3_1_OR_GREATER
+            [NotNullWhen(true)]
+#endif
+            out Type? type)
         {
             if (BuiltInThingTypeLookup.TryGetValue(typeName, out type))
             {
@@ -409,7 +415,7 @@ namespace Schema.NET
                     if (localType is not null && ThingInterfaceTypeInfo.IsAssignableFrom(localType.GetTypeInfo()))
                     {
                         type = localType;
-                        return !(type is null);
+                        return type is not null;
                     }
                     else
                     {


### PR DESCRIPTION
- Further nullable improvements.
- Also realized we were not using `Span<T>` when targeting .NET 5, so fixed that.
- Use `is not null`.