### PR TITLE
Add Microsoft Cross-Platform Code Coverage

### DIFF
--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -6,6 +6,7 @@
     <PackageReference Include="coverlet.collector" PrivateAssets="All" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/build.cake
+++ b/build.cake
@@ -62,7 +62,7 @@ Task("Test")
             new DotNetCoreTestSettings()
             {
                 Blame = true,
-                Collectors = new string[] { "XPlat Code Coverage" },
+                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
                 Configuration = configuration,
                 Loggers = new string[]
                 {


### PR DESCRIPTION
Leave coverlet in there as the Microsoft format is binary and only readable by Visual Studio.