### PR TITLE
Update .editorconfig from 2.1.0 to 3.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 2.1.0 (Using https://semver.org/)
-# Updated: 2021-03-03
+# Version: 3.0.0 (Using https://semver.org/)
+# Updated: 2021-08-09
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.
@@ -48,7 +48,7 @@ indent_size = 2
 trim_trailing_whitespace = false
 
 # Web Files
-[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,svg,vue}]
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,pcss,svg,vue}]
 indent_size = 2
 
 # Batch Files
@@ -97,7 +97,7 @@ dotnet_style_readonly_field = true:warning
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_other_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 # Expression-level preferences
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
@@ -121,7 +121,10 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 # If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
 # dotnet_diagnostic.SA1636.severity = none
 # Undocumented
-dotnet_style_operator_placement_when_wrapping = end_of_line
+dotnet_style_operator_placement_when_wrapping = end_of_line:warning
+csharp_style_prefer_null_check_over_type_check = true:warning
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_diagnostic.IDE0130.severity = suggestion
 
 # C# Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules

--- a/Benchmarks/Schema.NET.Benchmarks/Properties/AssemblyInfo.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(true)]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Build">
     <LangVersion>latest</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisMode>Default</AnalysisMode>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
     <NeutralLanguage>en-GB</NeutralLanguage>
     <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Build">
     <LangVersion>latest</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisMode>Default</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
     <NeutralLanguage>en-GB</NeutralLanguage>
     <Nullable>enable</Nullable>

--- a/Source/Common/ContextJsonConverter.cs
+++ b/Source/Common/ContextJsonConverter.cs
@@ -23,6 +23,11 @@ namespace Schema.NET
                 throw new ArgumentNullException(nameof(objectType));
             }
 
+            if (hasExistingValue && existingValue is null)
+            {
+                throw new ArgumentNullException(nameof(existingValue));
+            }
+
             if (serializer is null)
             {
                 throw new ArgumentNullException(nameof(serializer));
@@ -48,8 +53,10 @@ namespace Schema.NET
                 language = languageProperty?.Value?.ToString();
             }
 
+#pragma warning disable CA1062 // Validate arguments of public methods
             context.Name = name;
             context.Language = language;
+#pragma warning restore CA1062 // Validate arguments of public methods
             return context;
         }
 

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -30,7 +30,9 @@ namespace Schema.NET
                 result = Enum.Parse(enumType, value);
                 return true;
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 result = null;
                 return false;

--- a/Source/Common/HashCode.cs
+++ b/Source/Common/HashCode.cs
@@ -114,9 +114,7 @@ namespace Schema.NET
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() =>
 #pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
-#pragma warning disable CA1303 // Do not pass literals as localized parameters
             throw new NotSupportedException("Implicitly convert this struct to an int to get the hash code.");
-#pragma warning restore CA1303 // Do not pass literals as localized parameters
 #pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
 
         private static int CombineHashCodes(int h1, int h2)

--- a/Source/Common/OneOrMany{T}.cs
+++ b/Source/Common/OneOrMany{T}.cs
@@ -23,7 +23,9 @@ namespace Schema.NET
         /// <param name="item">The single item value.</param>
         public OneOrMany(T item)
         {
+#pragma warning disable CA1508 // TODO: Remove this suppression in .NET 6 where the warning is fixed.
             if (item is null || (item is string itemAsString && string.IsNullOrWhiteSpace(itemAsString)))
+#pragma warning restore CA1508 // TODO: Remove this suppression in .NET 6 where the warning is fixed.
             {
                 this.collection = null;
                 this.HasOne = false;
@@ -51,7 +53,9 @@ namespace Schema.NET
                     for (var i = 0; i < span.Length; i++)
                     {
                         var item = span[i];
+#pragma warning disable CA1508 // TODO: Remove this suppression in .NET 6 where the warning is fixed.
                         if (!string.IsNullOrWhiteSpace(item as string))
+#pragma warning restore CA1508 // TODO: Remove this suppression in .NET 6 where the warning is fixed.
                         {
                             items[index] = item;
                             index++;
@@ -63,7 +67,9 @@ namespace Schema.NET
                     for (var i = 0; i < span.Length; i++)
                     {
                         var item = span[i];
+#pragma warning disable CA1508 // TODO: Remove this suppression in .NET 6 where the warning is fixed.
                         if (item is not null)
+#pragma warning restore CA1508 // TODO: Remove this suppression in .NET 6 where the warning is fixed.
                         {
                             items[index] = item;
                             index++;

--- a/Source/Common/OneOrMany{T}.cs
+++ b/Source/Common/OneOrMany{T}.cs
@@ -10,10 +10,8 @@ namespace Schema.NET
     /// </summary>
     /// <typeparam name="T">The type of the values.</typeparam>
     /// <seealso cref="ICollection{T}" />
-#pragma warning disable CA1710 // Identifiers should have correct suffix
     public readonly struct OneOrMany<T>
         : IReadOnlyCollection<T>, IEnumerable<T>, IValues, IEquatable<OneOrMany<T>>
-#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         private readonly T[]? collection;
 

--- a/Source/Common/OneOrMany{T}.cs
+++ b/Source/Common/OneOrMany{T}.cs
@@ -160,7 +160,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator OneOrMany<T>(List<T> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -193,7 +195,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T>(OneOrMany<T> oneOrMany) => oneOrMany.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Common/Thing.Partial.cs
+++ b/Source/Common/Thing.Partial.cs
@@ -5,9 +5,7 @@ namespace Schema.NET
     /// <summary>
     /// The most generic type of item.
     /// </summary>
-#pragma warning disable CA1040 // Avoid empty interfaces
     public partial interface IThing
-#pragma warning restore CA1040 // Avoid empty interfaces
     {
     }
 

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -415,7 +415,7 @@ namespace Schema.NET
                     if (localType is not null && ThingInterfaceTypeInfo.IsAssignableFrom(localType.GetTypeInfo()))
                     {
                         type = localType;
-                        return type is not null;
+                        return true;
                     }
                     else
                     {

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -15,10 +15,8 @@ namespace Schema.NET
     /// <typeparam name="T5">The fifth type the values can take.</typeparam>
     /// <typeparam name="T6">The sixth type the values can take.</typeparam>
     /// <typeparam name="T7">The seventh type the values can take.</typeparam>
-#pragma warning disable CA1710 // Identifiers should have correct suffix
     public readonly struct Values<T1, T2, T3, T4, T5, T6, T7>
         : IReadOnlyCollection<object?>, IEnumerable<object?>, IValues, IEquatable<Values<T1, T2, T3, T4, T5, T6, T7>>
-#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> struct.
@@ -366,21 +364,20 @@ namespace Schema.NET
         /// </summary>
         public OneOrMany<T7> Value7 { get; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
+#pragma warning disable CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2 item) => new(item);
 
         /// <summary>
@@ -388,24 +385,20 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T4"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
+
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T5"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5 item) => new(item);
 
         /// <summary>
@@ -413,177 +406,126 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T7"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T1[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T2[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T3[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T4[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T4[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
+
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T5[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T5[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T6[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T6[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T7[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(T7[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T1> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T2> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T3}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T3> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T4}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T4> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T5}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T5> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T6}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T6> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T7}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T7> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="object"/> array to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(object[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{Object}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<object> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T1"/>.
@@ -592,9 +534,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1?(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value1.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T2"/>.
@@ -603,9 +543,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2?(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value2.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T3"/>.
@@ -614,9 +552,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3?(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value3.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T4"/>.
@@ -625,9 +561,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T4?(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value4.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T5"/>.
@@ -636,9 +570,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T5?(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value5.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T6"/>.
@@ -647,9 +579,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T6?(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value6.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to the first item of type <typeparamref name="T7"/>.
@@ -658,9 +588,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T7?(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value7.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T1"/>.
@@ -669,9 +597,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value1.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T1}"/>.
@@ -680,11 +606,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value1.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T2"/>.
@@ -693,9 +615,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value2.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T2}"/>.
@@ -704,11 +624,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value2.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T3"/>.
@@ -717,9 +633,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value3.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T3}"/>.
@@ -728,11 +642,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value3.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T4"/>.
@@ -741,9 +651,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T4[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value4.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T4}"/>.
@@ -752,11 +660,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T4>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value4.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T5"/>.
@@ -765,9 +669,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T5[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value5.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T5}"/>.
@@ -776,11 +678,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T5>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value5.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T6"/>.
@@ -789,9 +687,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T6[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value6.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T6}"/>.
@@ -800,11 +696,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T6>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value6.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to an array of <typeparamref name="T7"/>.
@@ -813,9 +705,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T7[](Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value7.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6,T7}"/> to <see cref="List{T7}"/>.
@@ -824,11 +714,9 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T7>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value7.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Implements the operator ==.

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -494,7 +494,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T1> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -503,7 +505,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T2> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -512,7 +516,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T3> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -521,7 +527,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T4> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -530,7 +538,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T5> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -539,7 +549,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T6> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -548,7 +560,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<T7> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -566,7 +580,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6, T7>(List<object> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -665,7 +681,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value1.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -687,7 +705,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value2.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -709,7 +729,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value3.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -731,7 +753,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T4>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value4.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -753,7 +777,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T5>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value5.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -775,7 +801,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T6>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value6.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -797,7 +825,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T7>(Values<T1, T2, T3, T4, T5, T6, T7> values) => values.Value7.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
@@ -14,10 +14,8 @@ namespace Schema.NET
     /// <typeparam name="T4">The fourth type the values can take.</typeparam>
     /// <typeparam name="T5">The fifth type the values can take.</typeparam>
     /// <typeparam name="T6">The sixth type the values can take.</typeparam>
-#pragma warning disable CA1710 // Identifiers should have correct suffix
     public readonly struct Values<T1, T2, T3, T4, T5, T6>
         : IReadOnlyCollection<object?>, IEnumerable<object?>, IValues, IEquatable<Values<T1, T2, T3, T4, T5, T6>>
-#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4,T5,T6}"/> struct.
@@ -309,21 +307,20 @@ namespace Schema.NET
         /// </summary>
         public OneOrMany<T6> Value6 { get; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
+#pragma warning disable CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T1 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T2 item) => new(item);
 
         /// <summary>
@@ -331,24 +328,20 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T3 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T4"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T4 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
+
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T5"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T5 item) => new(item);
 
         /// <summary>
@@ -356,147 +349,105 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T6 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T1[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T2[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T3[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T4[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T4[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
+
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T5[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T5[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T6[]"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(T6[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
+
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T1> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T2> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T3}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T3> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T4}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T4> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T5}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T5> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T6}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T6> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="object"/> array to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(object[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{Object}"/> to <see cref="Values{T1,T2,T3,T4,T5,T6}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<object> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to the first item of type <typeparamref name="T1"/>.
@@ -505,9 +456,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1?(Values<T1, T2, T3, T4, T5, T6> values) => values.Value1.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to the first item of type <typeparamref name="T2"/>.
@@ -516,9 +465,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2?(Values<T1, T2, T3, T4, T5, T6> values) => values.Value2.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to the first item of type <typeparamref name="T3"/>.
@@ -527,9 +474,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3?(Values<T1, T2, T3, T4, T5, T6> values) => values.Value3.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to the first item of type <typeparamref name="T4"/>.
@@ -538,9 +483,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T4?(Values<T1, T2, T3, T4, T5, T6> values) => values.Value4.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to the first item of type <typeparamref name="T5"/>.
@@ -549,9 +492,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T5?(Values<T1, T2, T3, T4, T5, T6> values) => values.Value5.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to the first item of type <typeparamref name="T6"/>.
@@ -560,9 +501,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T6?(Values<T1, T2, T3, T4, T5, T6> values) => values.Value6.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to an array of <typeparamref name="T1"/>.
@@ -571,9 +510,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1[](Values<T1, T2, T3, T4, T5, T6> values) => values.Value1.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to <see cref="List{T1}"/>.
@@ -582,11 +519,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value1.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to an array of <typeparamref name="T2"/>.
@@ -595,9 +528,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2[](Values<T1, T2, T3, T4, T5, T6> values) => values.Value2.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to <see cref="List{T2}"/>.
@@ -606,11 +537,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value2.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to an array of <typeparamref name="T3"/>.
@@ -619,9 +546,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3[](Values<T1, T2, T3, T4, T5, T6> values) => values.Value3.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to <see cref="List{T3}"/>.
@@ -630,11 +555,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value3.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to an array of <typeparamref name="T4"/>.
@@ -643,9 +564,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T4[](Values<T1, T2, T3, T4, T5, T6> values) => values.Value4.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to <see cref="List{T4}"/>.
@@ -654,11 +573,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T4>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value4.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to an array of <typeparamref name="T5"/>.
@@ -667,9 +582,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T5[](Values<T1, T2, T3, T4, T5, T6> values) => values.Value5.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to <see cref="List{T5}"/>.
@@ -678,11 +591,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T5>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value5.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to an array of <typeparamref name="T6"/>.
@@ -691,9 +600,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T6[](Values<T1, T2, T3, T4, T5, T6> values) => values.Value6.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1,T2,T3,T4,T5,T6}"/> to <see cref="List{T6}"/>.
@@ -702,11 +609,9 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T6>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value6.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Implements the operator ==.

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
@@ -418,7 +418,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T1> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -427,7 +429,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T2> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -436,7 +440,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T3> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -445,7 +451,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T4> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -454,7 +462,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T5> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -463,7 +473,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<T6> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -481,7 +493,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4, T5, T6>(List<object> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -569,7 +583,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value1.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -591,7 +607,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value2.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -613,7 +631,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value3.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -635,7 +655,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T4>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value4.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -657,7 +679,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T5>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value5.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -679,7 +703,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T6>(Values<T1, T2, T3, T4, T5, T6> values) => values.Value6.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Common/Values{T1,T2,T3,T4}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4}.cs
@@ -284,7 +284,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T1> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -293,7 +295,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T2> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -302,7 +306,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T3> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -311,7 +317,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T4> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -329,7 +337,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<object> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -395,7 +405,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3, T4> values) => values.Value1.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -417,7 +429,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3, T4> values) => values.Value2.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -439,7 +453,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3, T4> values) => values.Value3.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -461,7 +477,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T4>(Values<T1, T2, T3, T4> values) => values.Value4.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Common/Values{T1,T2,T3,T4}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4}.cs
@@ -12,10 +12,8 @@ namespace Schema.NET
     /// <typeparam name="T2">The second type the values can take.</typeparam>
     /// <typeparam name="T3">The third type the values can take.</typeparam>
     /// <typeparam name="T4">The fourth type the values can take.</typeparam>
-#pragma warning disable CA1710 // Identifiers should have correct suffix
     public readonly struct Values<T1, T2, T3, T4>
         : IReadOnlyCollection<object?>, IEnumerable<object?>, IValues, IEquatable<Values<T1, T2, T3, T4>>
-#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Values{T1,T2,T3,T4}"/> struct.
@@ -207,21 +205,20 @@ namespace Schema.NET
         /// </summary>
         public OneOrMany<T4> Value4 { get; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
+#pragma warning disable CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T1 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T2 item) => new(item);
 
         /// <summary>
@@ -229,118 +226,84 @@ namespace Schema.NET
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T3 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T4"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T4 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1[]"/> to <see cref="Values{T1,T2,T,T43}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T1[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2[]"/> to <see cref="Values{T1,T2,T3,T4}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T2[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3[]"/> to <see cref="Values{T1,T2,T3,T4}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T3[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T4[]"/> to <see cref="Values{T1,T2,T3,T4}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(T4[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T1> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T2> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T3}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T3> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T4}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<T4> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="object"/> array to <see cref="Values{T1,T2,T3,T4}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3, T4>(object[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{Object}"/> to <see cref="Values{T1,T2,T3,T4}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3, T4>(List<object> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to the first item of type <typeparamref name="T1"/>.
@@ -349,9 +312,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1?(Values<T1, T2, T3, T4> values) => values.Value1.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to the first item of type <typeparamref name="T2"/>.
@@ -360,9 +321,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2?(Values<T1, T2, T3, T4> values) => values.Value2.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to the first item of type <typeparamref name="T3"/>.
@@ -371,9 +330,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3?(Values<T1, T2, T3, T4> values) => values.Value3.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to the first item of type <typeparamref name="T4"/>.
@@ -382,9 +339,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T4?(Values<T1, T2, T3, T4> values) => values.Value4.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to an array of <typeparamref name="T1"/>.
@@ -393,9 +348,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1[](Values<T1, T2, T3, T4> values) => values.Value1.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to <see cref="List{T1}"/>.
@@ -404,11 +357,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3, T4> values) => values.Value1.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to an array of <typeparamref name="T2"/>.
@@ -417,9 +366,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2[](Values<T1, T2, T3, T4> values) => values.Value2.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to <see cref="List{T2}"/>.
@@ -428,11 +375,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3, T4> values) => values.Value2.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to an array of <typeparamref name="T3"/>.
@@ -441,9 +384,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3[](Values<T1, T2, T3, T4> values) => values.Value3.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to <see cref="List{T3}"/>.
@@ -452,11 +393,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3, T4> values) => values.Value3.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to an array of <typeparamref name="T4"/>.
@@ -465,9 +402,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T4[](Values<T1, T2, T3, T4> values) => values.Value4.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3, T4}"/> to <see cref="List{T4}"/>.
@@ -476,11 +411,9 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T4>(Values<T1, T2, T3, T4> values) => values.Value4.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Implements the operator ==.

--- a/Source/Common/Values{T1,T2,T3}.cs
+++ b/Source/Common/Values{T1,T2,T3}.cs
@@ -222,7 +222,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<T1> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -231,7 +233,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<T2> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -240,7 +244,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<T3> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -258,7 +264,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<object> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -313,7 +321,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3> values) => values.Value1.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -335,7 +345,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3> values) => values.Value2.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -357,7 +369,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3> values) => values.Value3.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Common/Values{T1,T2,T3}.cs
+++ b/Source/Common/Values{T1,T2,T3}.cs
@@ -11,10 +11,8 @@ namespace Schema.NET
     /// <typeparam name="T1">The first type the values can take.</typeparam>
     /// <typeparam name="T2">The second type the values can take.</typeparam>
     /// <typeparam name="T3">The third type the values can take.</typeparam>
-#pragma warning disable CA1710 // Identifiers should have correct suffix
     public readonly struct Values<T1, T2, T3>
         : IReadOnlyCollection<object?>, IEnumerable<object?>, IValues, IEquatable<Values<T1, T2, T3>>
-#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Values{T1,T2,T3}"/> struct.
@@ -162,112 +160,84 @@ namespace Schema.NET
         /// </summary>
         public OneOrMany<T3> Value3 { get; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
+#pragma warning disable CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3>(T1 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3>(T2 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3>(T3 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1[]"/> to <see cref="Values{T1,T2,T3}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3>(T1[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2[]"/> to <see cref="Values{T1,T2,T3}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3>(T2[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T3[]"/> to <see cref="Values{T1,T2,T3}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3>(T3[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<T1> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<T2> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T3}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<T3> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="object"/> array to <see cref="Values{T1,T2,T3}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2, T3>(object[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{Object}"/> to <see cref="Values{T1,T2,T3}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2, T3>(List<object> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to the first item of type <typeparamref name="T1"/>.
@@ -276,9 +246,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1?(Values<T1, T2, T3> values) => values.Value1.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to the first item of type <typeparamref name="T2"/>.
@@ -287,9 +255,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2?(Values<T1, T2, T3> values) => values.Value2.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to the first item of type <typeparamref name="T3"/>.
@@ -298,9 +264,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3?(Values<T1, T2, T3> values) => values.Value3.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to an array of <typeparamref name="T1"/>.
@@ -309,9 +273,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1[](Values<T1, T2, T3> values) => values.Value1.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to <see cref="List{T1}"/>.
@@ -320,11 +282,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2, T3> values) => values.Value1.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to an array of <typeparamref name="T2"/>.
@@ -333,9 +291,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2[](Values<T1, T2, T3> values) => values.Value2.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to <see cref="List{T2}"/>.
@@ -344,11 +300,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2, T3> values) => values.Value2.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to an array of <typeparamref name="T3"/>.
@@ -357,9 +309,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T3[](Values<T1, T2, T3> values) => values.Value3.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2, T3}"/> to <see cref="List{T3}"/>.
@@ -368,11 +318,9 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T3>(Values<T1, T2, T3> values) => values.Value3.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Implements the operator ==.

--- a/Source/Common/Values{T1,T2}.cs
+++ b/Source/Common/Values{T1,T2}.cs
@@ -10,10 +10,8 @@ namespace Schema.NET
     /// </summary>
     /// <typeparam name="T1">The first type the values can take.</typeparam>
     /// <typeparam name="T2">The second type the values can take.</typeparam>
-#pragma warning disable CA1710 // Identifiers should have correct suffix
     public readonly struct Values<T1, T2>
         : IReadOnlyCollection<object?>, IEnumerable<object?>, IValues, IEquatable<Values<T1, T2>>
-#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Values{T1,T2}"/> struct.
@@ -121,83 +119,63 @@ namespace Schema.NET
         /// </summary>
         public OneOrMany<T2> Value2 { get; }
 
+#pragma warning disable CA1002 // Do not expose generic lists
+#pragma warning disable CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2>(T1 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="item">The single item value.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2>(T2 item) => new(item);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T1[]"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2>(T1[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <typeparamref name="T2[]"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2>(T2[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T1}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2>(List<T1> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{T2}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2>(List<T2> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="object"/> array to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="array">The array of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator Values<T1, T2>(object[] array) => new(array);
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="List{Object}"/> to <see cref="Values{T1,T2}"/>.
         /// </summary>
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2>(List<object> list) => new(list);
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2}"/> to the first item of type <typeparamref name="T1"/>.
@@ -206,9 +184,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1?(Values<T1, T2> values) => values.Value1.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2}"/> to the first item of type <typeparamref name="T2"/>.
@@ -217,9 +193,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2?(Values<T1, T2> values) => values.Value2.FirstOrDefault();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2}"/> to an array of <typeparamref name="T1"/>.
@@ -228,9 +202,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T1[](Values<T1, T2> values) => values.Value1.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2}"/> to <see cref="List{T1}"/>.
@@ -239,11 +211,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2> values) => values.Value1.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2}"/> to an array of <typeparamref name="T2"/>.
@@ -252,9 +220,7 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
         public static implicit operator T2[](Values<T1, T2> values) => values.Value2.ToArray();
-#pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="Values{T1, T2}"/> to <see cref="List{T2}"/>.
@@ -263,11 +229,9 @@ namespace Schema.NET
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-#pragma warning disable CA2225 // Operator overloads have named alternates
-#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2> values) => values.Value2.ToList();
-#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Implements the operator ==.

--- a/Source/Common/Values{T1,T2}.cs
+++ b/Source/Common/Values{T1,T2}.cs
@@ -163,7 +163,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2>(List<T1> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -172,7 +174,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2>(List<T2> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -190,7 +194,9 @@ namespace Schema.NET
         /// <param name="list">The list of values.</param>
         /// <returns>The result of the conversion.</returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator Values<T1, T2>(List<object> list) => new(list);
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -234,7 +240,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T1>(Values<T1, T2> values) => values.Value1.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>
@@ -256,7 +264,9 @@ namespace Schema.NET
         /// The result of the conversion.
         /// </returns>
 #pragma warning disable CA2225 // Operator overloads have named alternates
+#pragma warning disable CA1002 // Do not expose generic lists
         public static implicit operator List<T2>(Values<T1, T2> values) => values.Value2.ToList();
+#pragma warning restore CA1002 // Do not expose generic lists
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
         /// <summary>

--- a/Source/Schema.NET.Pending/Properties/AssemblyInfo.cs
+++ b/Source/Schema.NET.Pending/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(true)]

--- a/Source/Schema.NET/Properties/AssemblyInfo.cs
+++ b/Source/Schema.NET/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(true)]

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -34,6 +34,11 @@ dotnet_diagnostic.SA1633.severity = none
 ##########################################
 
 [*.cs]
+# CA1014: Mark assemblies with CLSCompliant.
+# Justification: Not needed here
+# https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
 # CA1062: Validate arguments of public methods
 # Justification: xUnit Theory method parameters don't need to be validated
 # https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1062

--- a/Tools/.editorconfig
+++ b/Tools/.editorconfig
@@ -28,3 +28,13 @@ dotnet_diagnostic.SA1602.severity = none
 # Justification: Comments turned off
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 dotnet_diagnostic.SA1633.severity = none
+
+##########################################
+# StyleCop
+##########################################
+
+[*.cs]
+# CA1014: Mark assemblies with CLSCompliant.
+# Justification: Not needed here
+# https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1014
+dotnet_diagnostic.CA1014.severity = none

--- a/Tools/Schema.NET.Tool/CollectionExtensions.cs
+++ b/Tools/Schema.NET.Tool/CollectionExtensions.cs
@@ -1,0 +1,26 @@
+namespace Schema.NET.Tool
+{
+    using System;
+    using System.Collections.Generic;
+
+    public static class CollectionExtensions
+    {
+        public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> items)
+        {
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            foreach (var item in items)
+            {
+                collection.Add(item);
+            }
+        }
+    }
+}

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaClass.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaClass.cs
@@ -25,9 +25,9 @@ namespace Schema.NET.Tool.GeneratorModels
             .Traverse(this, x => x.Parents)
             .Where(x => x != this);
 
-        public List<GeneratorSchemaClass> Children { get; } = new List<GeneratorSchemaClass>();
+        public ICollection<GeneratorSchemaClass> Children { get; } = new List<GeneratorSchemaClass>();
 
-        public List<GeneratorSchemaClass> CombinationOf { get; } = new List<GeneratorSchemaClass>();
+        public ICollection<GeneratorSchemaClass> CombinationOf { get; } = new List<GeneratorSchemaClass>();
 
         public IEnumerable<GeneratorSchemaClass> Descendants => EnumerableExtensions
             .Traverse(this, x => x.Children)
@@ -64,8 +64,8 @@ namespace Schema.NET.Tool.GeneratorModels
 
         public bool IsThingType => string.Equals(this.Name, "Thing", StringComparison.Ordinal);
 
-        public List<GeneratorSchemaClass> Parents { get; } = new List<GeneratorSchemaClass>();
+        public ICollection<GeneratorSchemaClass> Parents { get; } = new List<GeneratorSchemaClass>();
 
-        public List<GeneratorSchemaProperty> Properties { get; } = new List<GeneratorSchemaProperty>();
+        public ICollection<GeneratorSchemaProperty> Properties { get; } = new List<GeneratorSchemaProperty>();
     }
 }

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaEnumeration.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaEnumeration.cs
@@ -11,6 +11,6 @@ namespace Schema.NET.Tool.GeneratorModels
         {
         }
 
-        public List<GeneratorSchemaEnumerationValue> Values { get; } = new List<GeneratorSchemaEnumerationValue>();
+        public ICollection<GeneratorSchemaEnumerationValue> Values { get; } = new List<GeneratorSchemaEnumerationValue>();
     }
 }

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaProperty.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaProperty.cs
@@ -26,7 +26,7 @@ namespace Schema.NET.Tool.GeneratorModels
 
         public int Order { get; set; }
 
-        public List<GeneratorSchemaPropertyType> Types { get; } = new List<GeneratorSchemaPropertyType>();
+        public ICollection<GeneratorSchemaPropertyType> Types { get; } = new List<GeneratorSchemaPropertyType>();
 
         public string PropertyTypeString
         {

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaPropertyType.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaPropertyType.cs
@@ -18,7 +18,7 @@ namespace Schema.NET.Tool.GeneratorModels
             this.CSharpTypeStrings = new List<string>(csharpTypeStrings);
         }
 
-        public List<string> CSharpTypeStrings { get; }
+        public ICollection<string> CSharpTypeStrings { get; }
 
         public string Name { get; }
 

--- a/Tools/Schema.NET.Tool/Models/SchemaClass.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaClass.cs
@@ -26,8 +26,8 @@ namespace Schema.NET.Tool.Models
             .Traverse(this, x => x.SubClassOf)
             .Any(x => string.Equals(x.Layer, LayerName.Meta, StringComparison.OrdinalIgnoreCase));
 
-        public List<SchemaClass> SubClassOf { get; } = new List<SchemaClass>();
+        public ICollection<SchemaClass> SubClassOf { get; } = new List<SchemaClass>();
 
-        public List<Uri> SubClassOfIds { get; } = new List<Uri>();
+        public ICollection<Uri> SubClassOfIds { get; } = new List<Uri>();
     }
 }

--- a/Tools/Schema.NET.Tool/Models/SchemaObject.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaObject.cs
@@ -30,7 +30,7 @@ namespace Schema.NET.Tool.Models
             "PronounceableText",
         };
 
-        public SchemaObject(string layer, Uri id, string label, string comment)
+        protected SchemaObject(string layer, Uri id, string label, string comment)
         {
             this.Layer = layer;
             this.Id = id;
@@ -46,7 +46,7 @@ namespace Schema.NET.Tool.Models
 
         public string Layer { get; }
 
-        public List<string> Types { get; } = new List<string>();
+        public ICollection<string> Types { get; } = new List<string>();
 
         public virtual bool IsArchived => string.Equals(this.Layer, LayerName.Archived, StringComparison.OrdinalIgnoreCase);
 

--- a/Tools/Schema.NET.Tool/Models/SchemaProperty.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaProperty.cs
@@ -10,8 +10,8 @@ namespace Schema.NET.Tool.Models
         {
         }
 
-        public List<Uri> DomainIncludes { get; } = new List<Uri>();
+        public ICollection<Uri> DomainIncludes { get; } = new List<Uri>();
 
-        public List<Uri> RangeIncludes { get; } = new List<Uri>();
+        public ICollection<Uri> RangeIncludes { get; } = new List<Uri>();
     }
 }

--- a/Tools/Schema.NET.Tool/Models/SchemaTreeClass.cs
+++ b/Tools/Schema.NET.Tool/Models/SchemaTreeClass.cs
@@ -8,7 +8,7 @@ namespace Schema.NET.Tool.Models
     public class SchemaTreeClass
     {
         [DataMember]
-        public List<SchemaTreeClass> Children { get; set; } = new List<SchemaTreeClass>();
+        public ICollection<SchemaTreeClass> Children { get; set; } = new List<SchemaTreeClass>();
 
         [DataMember]
         public string? Description { get; set; }

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -1,7 +1,6 @@
 namespace Schema.NET.Tool
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
     using Microsoft.CodeAnalysis;

--- a/Tools/Schema.NET.Tool/Services/SchemaService.cs
+++ b/Tools/Schema.NET.Tool/Services/SchemaService.cs
@@ -220,7 +220,7 @@ namespace Schema.NET.Tool.Services
             HashSet<Uri> knownSchemaClasses,
             bool includePending)
         {
-            var className = StartsWithNumber.IsMatch(schemaClass.Label) ? $"_{schemaClass.Label}" : schemaClass.Label;
+            var className = StartsWithNumber.IsMatch(schemaClass.Label) ? $"Type{schemaClass.Label}" : schemaClass.Label;
             var @class = new GeneratorSchemaClass(schemaClass.Layer, schemaClass.Id, className, schemaClass.Comment);
 
             @class.Parents.AddRange(schemaClass.SubClassOfIds

--- a/Tools/Schema.NET.Tool/SourceUtility.cs
+++ b/Tools/Schema.NET.Tool/SourceUtility.cs
@@ -23,6 +23,16 @@ namespace Schema.NET.Tool
 
         public static string RenderItems<T>(IEnumerable<T> items, Func<T, string> action)
         {
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
             var stringBuilder = new StringBuilder();
             foreach (var item in items)
             {

--- a/Tools/Schema.NET.Updater/Program.cs
+++ b/Tools/Schema.NET.Updater/Program.cs
@@ -15,6 +15,7 @@ namespace Schema.NET.Updater
 
         private static async Task Main()
         {
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
             Console.WriteLine("Downloading '{0}'...", SchemaJsonSourceUrl);
             using var httpClient = new HttpClient();
             using var stream = await httpClient.GetStreamAsync(new Uri(SchemaJsonSourceUrl)).ConfigureAwait(true);
@@ -22,6 +23,7 @@ namespace Schema.NET.Updater
             using var fileStream = File.Open(SchemaJsonDestinationFilePath, FileMode.Create);
             await stream.CopyToAsync(fileStream).ConfigureAwait(true);
             Console.WriteLine("Update complete!");
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
         }
     }
 }

--- a/Tools/Schema.NET.Updater/Program.cs
+++ b/Tools/Schema.NET.Updater/Program.cs
@@ -17,7 +17,7 @@ namespace Schema.NET.Updater
         {
             Console.WriteLine("Downloading '{0}'...", SchemaJsonSourceUrl);
             using var httpClient = new HttpClient();
-            using var stream = await httpClient.GetStreamAsync(SchemaJsonSourceUrl).ConfigureAwait(true);
+            using var stream = await httpClient.GetStreamAsync(new Uri(SchemaJsonSourceUrl)).ConfigureAwait(true);
             Console.WriteLine("Saving to '{0}'...", SchemaJsonDestinationFilePath);
             using var fileStream = File.Open(SchemaJsonDestinationFilePath, FileMode.Create);
             await stream.CopyToAsync(fileStream).ConfigureAwait(true);

--- a/Tools/Schema.NET.Updater/Properties/AssemblyInfo.cs
+++ b/Tools/Schema.NET.Updater/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(true)]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ stages:
           vmImageName: windows-latest
     pool:
       vmImage: $(vmImageName)
-    timeoutInMinutes: 10
+    timeoutInMinutes: 15
     steps:
     - checkout: self
       lfs: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ stages:
           vmImageName: windows-latest
     pool:
       vmImage: $(vmImageName)
-    timeoutInMinutes: 15
+    timeoutInMinutes: 20
     steps:
     - checkout: self
       lfs: true


### PR DESCRIPTION
- See https://github.com/RehanSaeed/EditorConfig/releases/tag/3.0.0
- Set `<AnalysisMode>AllEnabledByDefault</AnalysisMode>`. This actually picked up a couple of small things that I've fixed. Added a bunch of warning suppressions too though. Also added `CLSCompliant(true)` so our F# folks can also play.
- In `SchemaService.cs` if we found a schema type that started with a number e.g. the `pending` type `3DModel` we prefixed it with an underscore. This is not CLSCompliant, so I changed the prefix to the word `Type`. Happy to pick something better.