### PR TITLE
Add TrySetValue and TryGetValue

### DIFF
--- a/Source/Common/JsonLdObject.cs
+++ b/Source/Common/JsonLdObject.cs
@@ -55,6 +55,18 @@ namespace Schema.NET
         public virtual bool TrySetValue(string property, IEnumerable<object> value) => false;
 
         /// <summary>
+        /// Attempts to retrieve the value for <paramref name="property"/>.
+        /// </summary>
+        /// <param name="property">The property to get the value from.</param>
+        /// <param name="result">The value on the property.</param>
+        /// <returns><see langword="true"/> when the value has successfully been retrieved; otherwise, <see langword="false"/>.</returns>
+        public virtual bool TryGetValue(string property, out IValues? result)
+        {
+            result = default;
+            return false;
+        }
+
+        /// <summary>
         /// Attempts to retrieve the <typeparamref name="TValue"/> from <paramref name="property"/>.
         /// </summary>
         /// <typeparam name="TValue">The type of value you want to retrieve.</typeparam>

--- a/Source/Common/JsonLdObject.cs
+++ b/Source/Common/JsonLdObject.cs
@@ -1,6 +1,7 @@
 namespace Schema.NET
 {
     using System;
+    using System.Collections.Generic;
     using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
@@ -44,6 +45,27 @@ namespace Schema.NET
         /// </summary>
         [DataMember(Name = "@id", Order = 2)]
         public virtual Uri? Id { get; set; }
+
+        /// <summary>
+        /// Attempts to set the Schema.org <paramref name="property"/> on the current object with the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="property">The property to set the value on.</param>
+        /// <param name="value">The value to set on the property</param>
+        /// <returns><see langword="true"/> when the value has successfully been set; otherwise, <see langword="false"/>.</returns>
+        public virtual bool TrySetValue(string property, IEnumerable<object> value) => false;
+
+        /// <summary>
+        /// Attempts to retrieve the <typeparamref name="TValue"/> from <paramref name="property"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The type of value you want to retrieve.</typeparam>
+        /// <param name="property">The property to get the value from.</param>
+        /// <param name="result">The value on the property.</param>
+        /// <returns><see langword="true"/> when the value has successfully been retrieved; otherwise, <see langword="false"/>.</returns>
+        public virtual bool TryGetValue<TValue>(string property, out OneOrMany<TValue> result)
+        {
+            result = default;
+            return false;
+        }
 
         /// <inheritdoc/>
         public bool Equals(JsonLdObject? other)

--- a/Tests/Schema.NET.Test/ThingTest.cs
+++ b/Tests/Schema.NET.Test/ThingTest.cs
@@ -233,12 +233,59 @@ namespace Schema.NET.Test
                 Name = "TestName",
             };
 
+            Assert.True(thing.TryGetValue("Name", out var result));
+            var name = Assert.Single(result);
+            Assert.Equal("TestName", name);
+        }
+
+        [Fact]
+        public void TryGetValue_ValidProperty_Values()
+        {
+            var thing = new Thing
+            {
+                Identifier = new Uri("https://example.org/test-identifier"),
+            };
+
+            Assert.True(thing.TryGetValue("Identifier", out var result));
+            var identifier = Assert.Single(result);
+            Assert.Equal(new Uri("https://example.org/test-identifier"), identifier);
+        }
+
+        [Fact]
+        public void TryGetValue_InvalidProperty_InvalidName()
+        {
+            var thing = new Thing();
+
+            Assert.False(thing.TryGetValue("InvalidName", out _));
+        }
+
+        [Fact]
+        public void TryGetValue_CaseInsensitive()
+        {
+            var thing = new Thing
+            {
+                Name = "TestName",
+            };
+
+            Assert.True(thing.TryGetValue("name", out var result));
+            var name = Assert.Single(result);
+            Assert.Equal("TestName", name);
+        }
+
+        [Fact]
+        public void TryGetValue_Generic_ValidProperty_OneOrMany()
+        {
+            var thing = new Thing
+            {
+                Name = "TestName",
+            };
+
             Assert.True(thing.TryGetValue<string>("Name", out var result));
             Assert.Equal("TestName", result);
         }
 
         [Fact]
-        public void TryGetValue_ValidProperty_Values()
+        public void TryGetValue_Generic_ValidProperty_Values()
         {
             var thing = new Thing
             {
@@ -251,7 +298,7 @@ namespace Schema.NET.Test
         }
 
         [Fact]
-        public void TryGetValue_InvalidProperty_InvalidName()
+        public void TryGetValue_Generic_InvalidProperty_InvalidName()
         {
             var thing = new Thing();
 
@@ -259,7 +306,7 @@ namespace Schema.NET.Test
         }
 
         [Fact]
-        public void TryGetValue_InvalidProperty_InvalidType()
+        public void TryGetValue_Generic_InvalidProperty_InvalidType()
         {
             var thing = new Thing
             {
@@ -270,7 +317,7 @@ namespace Schema.NET.Test
         }
 
         [Fact]
-        public void TryGetValue_CaseInsensitive()
+        public void TryGetValue_Generic_CaseInsensitive()
         {
             var thing = new Thing
             {

--- a/Tests/Schema.NET.Test/ThingTest.cs
+++ b/Tests/Schema.NET.Test/ThingTest.cs
@@ -199,6 +199,88 @@ namespace Schema.NET.Test
             Assert.Equal(expectedJson, thing.ToString());
         }
 
+        [Fact]
+        public void TrySetValue_ValidProperty()
+        {
+            var thing = new Thing();
+
+            Assert.True(thing.TrySetValue("Name", new[] { "TestName" }));
+            Assert.Equal("TestName", thing.Name);
+        }
+
+        [Fact]
+        public void TrySetValue_InvalidProperty()
+        {
+            var thing = new Thing();
+
+            Assert.False(thing.TrySetValue("InvalidName", new[] { "TestName" }));
+        }
+
+        [Fact]
+        public void TrySetValue_CaseInsensitive()
+        {
+            var thing = new Thing();
+
+            Assert.True(thing.TrySetValue("name", new[] { "TestName" }));
+            Assert.Equal("TestName", thing.Name);
+        }
+
+        [Fact]
+        public void TryGetValue_ValidProperty_OneOrMany()
+        {
+            var thing = new Thing
+            {
+                Name = "TestName",
+            };
+
+            Assert.True(thing.TryGetValue<string>("Name", out var result));
+            Assert.Equal("TestName", result);
+        }
+
+        [Fact]
+        public void TryGetValue_ValidProperty_Values()
+        {
+            var thing = new Thing
+            {
+                Identifier = new Uri("https://example.org/test-identifier"),
+            };
+
+            Assert.True(thing.TryGetValue<Uri>("Identifier", out var result));
+            var identifier = Assert.Single(result);
+            Assert.Equal(new Uri("https://example.org/test-identifier"), identifier);
+        }
+
+        [Fact]
+        public void TryGetValue_InvalidProperty_InvalidName()
+        {
+            var thing = new Thing();
+
+            Assert.False(thing.TryGetValue<string>("InvalidName", out _));
+        }
+
+        [Fact]
+        public void TryGetValue_InvalidProperty_InvalidType()
+        {
+            var thing = new Thing
+            {
+                Name = "TestName",
+            };
+
+            Assert.False(thing.TryGetValue<Uri>("Name", out _));
+        }
+
+        [Fact]
+        public void TryGetValue_CaseInsensitive()
+        {
+            var thing = new Thing
+            {
+                Name = "TestName",
+            };
+
+            Assert.True(thing.TryGetValue<string>("name", out var result));
+            Assert.Equal("TestName", result);
+        }
+
         private static void CompareEqual<T>(T a, T? b)
         {
             Assert.NotNull(a);

--- a/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaProperty.cs
+++ b/Tools/Schema.NET.Tool/GeneratorModels/GeneratorSchemaProperty.cs
@@ -28,11 +28,13 @@ namespace Schema.NET.Tool.GeneratorModels
 
         public ICollection<GeneratorSchemaPropertyType> Types { get; } = new List<GeneratorSchemaPropertyType>();
 
+        public IEnumerable<string> CSharpTypes => this.Types.SelectMany(x => x.CSharpTypeStrings);
+
         public string PropertyTypeString
         {
             get
             {
-                var propertyTypes = this.Types.SelectMany(x => x.CSharpTypeStrings).ToArray();
+                var propertyTypes = this.CSharpTypes.ToArray();
                 var propertyTypesString = string.Join(", ", propertyTypes);
                 if (propertyTypes.Length == 1)
                 {

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -93,6 +93,7 @@ namespace Schema.NET.Tool
 $@"namespace Schema.NET
 {{
     using System;
+    using System.Collections.Generic;
     using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
@@ -125,6 +126,58 @@ $@"namespace Schema.NET
         [DataMember(Name = ""{property.JsonName}"", Order = {property.Order})]
         [JsonConverter(typeof({property.JsonConverterType}))]
         public{GetAccessModifier(property)} {property.PropertyTypeString} {property.Name} {{ get; set; }}")}
+
+        /// <inheritdoc/>
+        public override bool TrySetValue(string property, IEnumerable<object> value)
+        {{
+            if (string.IsNullOrWhiteSpace(property))
+            {{
+                return false;
+            }}
+
+            var success = false;
+            {SourceUtility.RenderItems(allProperties, property => $@"if (""{property.Name}"".Equals(property, StringComparison.OrdinalIgnoreCase))
+            {{
+                this.{property.Name} = new(value);
+                success = true;
+            }}
+            else ")}
+            {{
+                success = base.TrySetValue(property, value);
+            }}
+
+            return success;
+        }}
+
+        /// <inheritdoc/>
+        public override bool TryGetValue<TValue>(string property, out OneOrMany<TValue> result)
+        {{
+            if (string.IsNullOrWhiteSpace(property))
+            {{
+                result = default;
+                return false;
+            }}
+
+            var success = false;
+            {SourceUtility.RenderItems(allProperties, property => $@"if (""{property.Name}"".Equals(property, StringComparison.OrdinalIgnoreCase))
+            {{
+                {SourceUtility.RenderItems(property.CSharpTypes, (propertyType, index) => $@"if (typeof({propertyType}) == typeof(TValue))
+                {{
+                    result = (OneOrMany<TValue>)(IValues)this.{property.Name}{(property.CSharpTypes.Count() > 1 ? $".Value{index + 1}" : string.Empty)};
+                    success = true;
+                }}
+                else ")}
+                {{
+                    result = default;
+                }}
+            }}
+            else ")}
+            {{
+                success = base.TryGetValue(property, out result);
+            }}
+
+            return success;
+        }}
 
         /// <inheritdoc/>
         public bool Equals({schemaClass.Name} other)

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -180,6 +180,29 @@ $@"namespace Schema.NET
         }}
 
         /// <inheritdoc/>
+        public override bool TryGetValue(string property, out IValues result)
+        {{
+            if (string.IsNullOrWhiteSpace(property))
+            {{
+                result = default;
+                return false;
+            }}
+
+            var success = false;
+            {SourceUtility.RenderItems(allProperties, property => $@"if (""{property.Name}"".Equals(property, StringComparison.OrdinalIgnoreCase))
+            {{
+                result = (IValues)this.{property.Name};
+                success = true;
+            }}
+            else ")}
+            {{
+                success = base.TryGetValue(property, out result);
+            }}
+
+            return success;
+        }}
+
+        /// <inheritdoc/>
         public bool Equals({schemaClass.Name} other)
         {{
             if (other is null)

--- a/Tools/Schema.NET.Tool/SourceUtility.cs
+++ b/Tools/Schema.NET.Tool/SourceUtility.cs
@@ -42,6 +42,29 @@ namespace Schema.NET.Tool
             return stringBuilder.ToString();
         }
 
+        public static string RenderItems<T>(IEnumerable<T> items, Func<T, int, string> action)
+        {
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var stringBuilder = new StringBuilder();
+            var i = 0;
+            foreach (var item in items)
+            {
+                stringBuilder.Append(action(item, i));
+                i++;
+            }
+
+            return stringBuilder.ToString();
+        }
+
         public static string RenderDoc(int indent, string? text)
         {
             if (text == null)


### PR DESCRIPTION
Introduces two new methods `TrySetValue` and `TryGetValue` which allow dynamic access to get and set values on a schema object. Both methods are generated via our source generator rather than doing something weird with reflection.

While `TrySetValue` is straight forward, `TryGetValue` requires a generic parameter to identify which piece of data you want. This is required to have a typed-value be the result of the call. If you specify a type that is invalid for the property, the method fails gracefully.

The methods are also case insensitive.

Open to any feedback or suggestions you have @RehanSaeed 🙂