### PR TITLE
Add .NET 6 and C# 10 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - name: "Install .NET Core 3.1 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "3.1.x"
+      - name: "Install .NET Core 5.0 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "5.0.x"
       - name: "Install .NET Core SDK"
         uses: actions/setup-dotnet@v1.8.2
       - name: "Dotnet Tool Restore"

--- a/Benchmarks/Schema.NET.Benchmarks/Program.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/Program.cs
@@ -2,7 +2,7 @@ namespace Schema.NET.Benchmarks
 {
     using BenchmarkDotNet.Running;
 
-    internal class Program
+    public class Program
     {
         private static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }

--- a/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
+++ b/Benchmarks/Schema.NET.Benchmarks/Schema.NET.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
@@ -12,8 +12,10 @@ namespace Schema.NET.Benchmarks
     [HtmlExporter]
     [CsvMeasurementsExporter]
     [RPlotExporter]
-    [SimpleJob(RuntimeMoniker.Net472)]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    [SimpleJob(RuntimeMoniker.Net50)]
     [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob(RuntimeMoniker.Net472)]
     public abstract class SchemaBenchmarkBase
     {
         public Thing Thing { get; set; } = default!;

--- a/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
+++ b/Benchmarks/Schema.NET.Benchmarks/SchemaBenchmarkBase.cs
@@ -13,8 +13,6 @@ namespace Schema.NET.Benchmarks
     [CsvMeasurementsExporter]
     [RPlotExporter]
     [SimpleJob(RuntimeMoniker.Net60)]
-    [SimpleJob(RuntimeMoniker.Net50)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [SimpleJob(RuntimeMoniker.Net472)]
     public abstract class SchemaBenchmarkBase
     {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/RehanSaeed/Schema.NET</PackageProjectUrl>
     <PackageIcon>Icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/RehanSaeed/Schema.NET.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>https://github.com/RehanSaeed/Schema.NET/releases</PackageReleaseNotes>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Schema.NET Banner](Images/Banner.png)
+![Schema.NET Banner](https://media.githubusercontent.com/media/RehanSaeed/Schema.NET/main/Images/Banner.png)
 
 [![Schema.NET NuGet Package](https://img.shields.io/nuget/v/Schema.NET.svg)](https://www.nuget.org/packages/Schema.NET) [![Schema.NET Azure Artifacts Package](https://feeds.dev.azure.com/schema-net/_apis/public/Packaging/Feeds/64e69c35-cb00-46e4-9cba-6d8faf1f41d6/Packages/fa72270b-6c54-4403-9307-aa826e43530e/Badge)](https://dev.azure.com/schema-net/Schema.NET/_packaging?_a=package&feed=64e69c35-cb00-46e4-9cba-6d8faf1f41d6&package=fa72270b-6c54-4403-9307-aa826e43530e&preferRelease=true) [![Schema.NET NuGet Package Downloads](https://img.shields.io/nuget/dt/Schema.NET)](https://www.nuget.org/packages/Schema.NET) [![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/RehanSaeedUK) [![Twitter Follow](https://img.shields.io/twitter/follow/rehansaeeduk.svg?style=social&label=Follow)](https://twitter.com/RehanSaeedUK)
 
@@ -40,7 +40,7 @@ If writing the result into a `<script>` element, be sure to use the `.ToHtmlEsca
 
 Websites can define Structured Data in the `head` section of their `html` to enable search engines to show richer information in their search results. Here is an example of how [Google](https://developers.google.com/search/docs/guides/intro-structured-data) can display extended metadata about your site in it's search results.
 
-![Google Logo Structured Data Example](Images/Google%20Logo%20Structured%20Data%20Example.png)
+![Google Logo Structured Data Example](https://media.githubusercontent.com/media/RehanSaeed/Schema.NET/main/Images/Google%20Logo%20Structured%20Data%20Example.png)
 
 Using structured data in `html` requires the use of a `script` tag with a MIME type of `application/ld+json` like so:
 
@@ -167,7 +167,7 @@ There are many pending types on [schema.org](https://schema.org) which are not y
 
 ## Contributions and Thanks
 
-Please view the [contributing guide](/.github/CONTRIBUTING.md) for more information.
+Please view the [contributing guide](https://github.com/RehanSaeed/Schema.NET/blob/main/.github/CONTRIBUTING.md) for more information.
 
 - [kirkone](https://github.com/kirkone) - CI reads .NET Core version from new global.json file.
 - [Turnerj](https://github.com/Turnerj) - Added `System.Text.Json` support, Had all types implement `IEquatable<T>` `GetHashCode` and added extra unit tests and bug fixes.

--- a/Source/Common/ContextJsonConverter.cs
+++ b/Source/Common/ContextJsonConverter.cs
@@ -13,6 +13,16 @@ namespace Schema.NET
         /// <inheritdoc />
         public override JsonLdContext ReadJson(JsonReader reader, Type objectType, JsonLdContext? existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(reader);
+            ArgumentNullException.ThrowIfNull(objectType);
+            if (hasExistingValue)
+            {
+                ArgumentNullException.ThrowIfNull(existingValue);
+            }
+
+            ArgumentNullException.ThrowIfNull(serializer);
+#else
             if (reader is null)
             {
                 throw new ArgumentNullException(nameof(reader));
@@ -32,6 +42,7 @@ namespace Schema.NET
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
+#endif
 
             var context = hasExistingValue ? existingValue! : new JsonLdContext();
 
@@ -86,6 +97,11 @@ namespace Schema.NET
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, JsonLdContext? value, JsonSerializer serializer)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(value);
+            ArgumentNullException.ThrowIfNull(serializer);
+#else
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
@@ -100,6 +116,7 @@ namespace Schema.NET
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
+#endif
 
             if (string.IsNullOrWhiteSpace(value.Language))
             {

--- a/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
+++ b/Source/Common/DateTimeToIso8601DateValuesJsonConverter.cs
@@ -20,6 +20,10 @@ namespace Schema.NET
         /// <param name="serializer">The JSON serializer.</param>
         public override void WriteObject(JsonWriter writer, object? value, JsonSerializer serializer)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(serializer);
+#else
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
@@ -29,6 +33,7 @@ namespace Schema.NET
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
+#endif
 
             if (value is DateTime dateTimeType)
             {

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -24,7 +24,7 @@ namespace Schema.NET
             string? value,
             out object? result)
         {
-#if NETSTANDARD2_0 || NET472
+#if NETSTANDARD2_0 || NET472 || NET461
             try
             {
                 result = Enum.Parse(enumType, value);

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -24,7 +24,7 @@ namespace Schema.NET
             string? value,
             out object? result)
         {
-#if NETSTANDARD2_0 || NET472 || NET461
+#if NETSTANDARD2_0 || NET472
             try
             {
                 result = Enum.Parse(enumType, value);

--- a/Source/Common/OneOrMany{T}.cs
+++ b/Source/Common/OneOrMany{T}.cs
@@ -263,11 +263,7 @@ namespace Schema.NET
             }
             else
             {
-#if NETSTANDARD1_1
-                return new T[0];
-#else
                 return Array.Empty<T>();
-#endif
             }
         }
 

--- a/Source/Common/Thing.Partial.cs
+++ b/Source/Common/Thing.Partial.cs
@@ -5,7 +5,9 @@ namespace Schema.NET
     /// <summary>
     /// The most generic type of item.
     /// </summary>
+#pragma warning disable CA1040 // Avoid empty interfaces
     public partial interface IThing
+#pragma warning restore CA1040 // Avoid empty interfaces
     {
     }
 

--- a/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
+++ b/Source/Common/TimeSpanToISO8601DurationValuesJsonConverter.cs
@@ -20,6 +20,11 @@ namespace Schema.NET
         /// <param name="serializer">The JSON serializer.</param>
         public override void WriteObject(JsonWriter writer, object? value, JsonSerializer serializer)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(value);
+            ArgumentNullException.ThrowIfNull(serializer);
+#else
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
@@ -34,6 +39,7 @@ namespace Schema.NET
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
+#endif
 
             if (value is TimeSpan duration)
             {

--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -60,6 +60,11 @@ namespace Schema.NET
             object? existingValue,
             JsonSerializer serializer)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(reader);
+            ArgumentNullException.ThrowIfNull(objectType);
+            ArgumentNullException.ThrowIfNull(serializer);
+#else
             if (reader is null)
             {
                 throw new ArgumentNullException(nameof(reader));
@@ -74,6 +79,7 @@ namespace Schema.NET
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
+#endif
 
             var dynamicConstructor = FastActivator.GetDynamicConstructor<IEnumerable<object?>>(objectType);
             if (dynamicConstructor is not null)
@@ -118,6 +124,11 @@ namespace Schema.NET
         /// <param name="serializer">The JSON serializer.</param>
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(value);
+            ArgumentNullException.ThrowIfNull(serializer);
+#else
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
@@ -132,6 +143,7 @@ namespace Schema.NET
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
+#endif
 
             var values = (IValues)value;
             if (values.Count == 0)
@@ -164,6 +176,10 @@ namespace Schema.NET
         /// <param name="serializer">The JSON serializer.</param>
         public virtual void WriteObject(JsonWriter writer, object? value, JsonSerializer serializer)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(serializer);
+#else
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
@@ -173,6 +189,7 @@ namespace Schema.NET
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
+#endif
 
             serializer.Serialize(writer, value);
         }

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -187,10 +187,14 @@ namespace Schema.NET
         /// <param name="items">The items.</param>
         public Values(IEnumerable<object?> items)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+#else
             if (items is null)
             {
                 throw new ArgumentNullException(nameof(items));
             }
+#endif
 
             List<T1>? items1 = null;
             List<T2>? items2 = null;

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
@@ -152,10 +152,14 @@ namespace Schema.NET
         /// <param name="items">The items.</param>
         public Values(IEnumerable<object?> items)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+#else
             if (items is null)
             {
                 throw new ArgumentNullException(nameof(items));
             }
+#endif
 
             List<T1>? items1 = null;
             List<T2>? items2 = null;

--- a/Source/Common/Values{T1,T2,T3,T4}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4}.cs
@@ -94,10 +94,14 @@ namespace Schema.NET
         /// <param name="items">The items.</param>
         public Values(IEnumerable<object?> items)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+#else
             if (items is null)
             {
                 throw new ArgumentNullException(nameof(items));
             }
+#endif
 
             List<T1>? items1 = null;
             List<T2>? items2 = null;

--- a/Source/Common/Values{T1,T2,T3}.cs
+++ b/Source/Common/Values{T1,T2,T3}.cs
@@ -71,10 +71,14 @@ namespace Schema.NET
         /// <param name="items">The items.</param>
         public Values(IEnumerable<object> items)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+#else
             if (items is null)
             {
                 throw new ArgumentNullException(nameof(items));
             }
+#endif
 
             List<T1>? items1 = null;
             List<T2>? items2 = null;

--- a/Source/Common/Values{T1,T2}.cs
+++ b/Source/Common/Values{T1,T2}.cs
@@ -52,10 +52,14 @@ namespace Schema.NET
         /// <param name="items">The items.</param>
         public Values(IEnumerable<object?> items)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+#else
             if (items is null)
             {
                 throw new ArgumentNullException(nameof(items));
             }
+#endif
 
             List<T1>? items1 = null;
             List<T2>? items2 = null;

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -31,6 +31,7 @@
 
   <ItemGroup Label="Files">
     <None Include="..\..\Images\Icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
     <IncludePendingSchemaObjects>True</IncludePendingSchemaObjects>

--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.0;net472;net461</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
     <IncludePendingSchemaObjects>True</IncludePendingSchemaObjects>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
     <IncludePendingSchemaObjects>False</IncludePendingSchemaObjects>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.0;net472;net461</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
     <IncludePendingSchemaObjects>False</IncludePendingSchemaObjects>

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/Tests/Schema.NET.Test/Schema.NET.Test.csproj
+++ b/Tests/Schema.NET.Test/Schema.NET.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/Tests/Schema.NET.Test/StringExtensions.cs
+++ b/Tests/Schema.NET.Test/StringExtensions.cs
@@ -1,4 +1,4 @@
-#if NET472
+#if NET472 || NET461
 namespace Schema.NET.Test
 {
     using System;

--- a/Tools/Schema.NET.Tool/CollectionExtensions.cs
+++ b/Tools/Schema.NET.Tool/CollectionExtensions.cs
@@ -7,6 +7,10 @@ namespace Schema.NET.Tool
     {
         public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> items)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(collection);
+            ArgumentNullException.ThrowIfNull(items);
+#else
             if (collection is null)
             {
                 throw new ArgumentNullException(nameof(collection));
@@ -16,6 +20,7 @@ namespace Schema.NET.Tool
             {
                 throw new ArgumentNullException(nameof(items));
             }
+#endif
 
             foreach (var item in items)
             {

--- a/Tools/Schema.NET.Tool/CustomOverrides/AddNumberTypeToMediaObjectHeightAndWidth.cs
+++ b/Tools/Schema.NET.Tool/CustomOverrides/AddNumberTypeToMediaObjectHeightAndWidth.cs
@@ -9,10 +9,14 @@ namespace Schema.NET.Tool.CustomOverrides
     {
         public bool CanOverride(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             return string.Equals(c.Name, "MediaObject", StringComparison.OrdinalIgnoreCase) ||
                 c.CombinationOf.Any(co => string.Equals(co.Name, "MediaObject", StringComparison.OrdinalIgnoreCase));
@@ -20,10 +24,14 @@ namespace Schema.NET.Tool.CustomOverrides
 
         public void Override(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(c);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             c
                 .Properties

--- a/Tools/Schema.NET.Tool/CustomOverrides/AddQueryInputPropertyToSearchAction.cs
+++ b/Tools/Schema.NET.Tool/CustomOverrides/AddQueryInputPropertyToSearchAction.cs
@@ -8,20 +8,28 @@ namespace Schema.NET.Tool.CustomOverrides
     {
         public bool CanOverride(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(c);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             return string.Equals(c.Name, "SearchAction", StringComparison.Ordinal);
         }
 
         public void Override(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(c);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             var property = new GeneratorSchemaProperty(c, "query-input", "QueryInput", "Gets or sets the query input search parameter.");
             property.Types.AddRange(

--- a/Tools/Schema.NET.Tool/CustomOverrides/AddTextTypeToActionTarget.cs
+++ b/Tools/Schema.NET.Tool/CustomOverrides/AddTextTypeToActionTarget.cs
@@ -9,20 +9,28 @@ namespace Schema.NET.Tool.CustomOverrides
     {
         public bool CanOverride(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(c);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             return string.Equals(c.Name, "Action", StringComparison.OrdinalIgnoreCase);
         }
 
         public void Override(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(c);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             var property = c.Properties.First(x => string.Equals(x.Name, "target", StringComparison.OrdinalIgnoreCase));
             property.Types.Add(new GeneratorSchemaPropertyType("URL", "Uri"));

--- a/Tools/Schema.NET.Tool/CustomOverrides/RenameEventProperty.cs
+++ b/Tools/Schema.NET.Tool/CustomOverrides/RenameEventProperty.cs
@@ -8,20 +8,28 @@ namespace Schema.NET.Tool.CustomOverrides
     {
         public bool CanOverride(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(c);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             return c.Properties.Any(x => string.Equals(x.Name, "Event", StringComparison.OrdinalIgnoreCase));
         }
 
         public void Override(GeneratorSchemaClass c)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(c);
+#else
             if (c is null)
             {
                 throw new ArgumentNullException(nameof(c));
             }
+#endif
 
             var eventProperty = c
                 .Properties

--- a/Tools/Schema.NET.Tool/EnumerableExtensions.cs
+++ b/Tools/Schema.NET.Tool/EnumerableExtensions.cs
@@ -8,10 +8,14 @@ namespace Schema.NET.Tool
     {
         public static IEnumerable<T> Traverse<T>(T node, Func<T, T> parent)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(parent);
+#else
             if (parent is null)
             {
                 throw new ArgumentNullException(nameof(parent));
             }
+#endif
 
             for (var x = node; x is not null; x = parent(x))
             {
@@ -21,10 +25,14 @@ namespace Schema.NET.Tool
 
         public static IEnumerable<T> Traverse<T>(T node, Func<T, IEnumerable<T>> children)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(children);
+#else
             if (children is null)
             {
                 throw new ArgumentNullException(nameof(children));
             }
+#endif
 
             yield return node;
 

--- a/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
+++ b/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
@@ -74,7 +74,7 @@ namespace Schema.NET.Tool.Repositories
 #if NETSTANDARD2_0
                 layer = isPartOf.Host.Replace(".schema.org", string.Empty);
 #else
-                layer = isPartOf.Host.Replace(".schema.org", string.Empty, StringComparison.OrdinalIgnoreCase);
+                layer = isPartOf.Host.Replace(".schema.org", string.Empty, StringComparison.Ordinal);
 #endif
             }
 

--- a/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
+++ b/Tools/Schema.NET.Tool/Repositories/SchemaPropertyJsonConverter.cs
@@ -12,10 +12,14 @@ namespace Schema.NET.Tool.Repositories
     {
         public override List<SchemaObject> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(typeToConvert);
+#else
             if (typeToConvert is null)
             {
                 throw new ArgumentNullException(nameof(typeToConvert));
             }
+#endif
 
             if (reader.TokenType == JsonTokenType.StartObject)
             {
@@ -67,7 +71,11 @@ namespace Schema.NET.Tool.Repositories
             var layer = LayerName.Core;
             if (isPartOf is not null && isPartOf.Host != "schema.org")
             {
+#if NETSTANDARD2_0
                 layer = isPartOf.Host.Replace(".schema.org", string.Empty);
+#else
+                layer = isPartOf.Host.Replace(".schema.org", string.Empty, StringComparison.OrdinalIgnoreCase);
+#endif
             }
 
             if (types.Any(type => string.Equals(type, "rdfs:Class", StringComparison.Ordinal)))

--- a/Tools/Schema.NET.Tool/Resources.Designer.cs
+++ b/Tools/Schema.NET.Tool/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Schema.NET.Tool {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
+++ b/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>

--- a/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
+++ b/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
@@ -20,24 +20,24 @@
     .NET SDK issue with related transient dependency discussion https://github.com/dotnet/sdk/issues/17775
   -->
   <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-rc.2.21480.5" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0-rc.2.21480.5" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0-rc.2.21480.5" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0-rc.2.21480.5" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
-    <PackageReference Include="System.Text.Json" Version="5.0.2" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -12,6 +12,8 @@ namespace Schema.NET.Tool
     [Generator]
     public class SchemaSourceGenerator : ISourceGenerator
     {
+        private const string SchemaDataName = "Schema.NET.Tool.Data.schemaorg-all-https.jsonld";
+
         public void Initialize(GeneratorInitializationContext context)
         {
         }
@@ -20,7 +22,11 @@ namespace Schema.NET.Tool
         {
             var schemaDataStream = Assembly
                 .GetExecutingAssembly()
-                .GetManifestResourceStream("Schema.NET.Tool.Data.schemaorg-all-https.jsonld");
+                .GetManifestResourceStream(SchemaDataName);
+            if (schemaDataStream == null)
+            {
+                throw new InvalidOperationException($"Schema data file '{SchemaDataName}' not found.");
+            }
 
             var schemaRepository = new SchemaRepository(schemaDataStream);
             var schemaService = new SchemaService(

--- a/Tools/Schema.NET.Tool/Services/EnumerationValueComparer.cs
+++ b/Tools/Schema.NET.Tool/Services/EnumerationValueComparer.cs
@@ -16,8 +16,12 @@ namespace Schema.NET.Tool.Services
             { "SATURDAY", 6 },
         };
 
-        public int Compare(string x, string y)
+        public int Compare(string? x, string? y)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(x);
+            ArgumentNullException.ThrowIfNull(y);
+#else
             if (x is null)
             {
                 throw new ArgumentNullException(nameof(x));
@@ -27,6 +31,7 @@ namespace Schema.NET.Tool.Services
             {
                 throw new ArgumentNullException(nameof(y));
             }
+#endif
 
             x = x.ToUpperInvariant();
             y = y.ToUpperInvariant();

--- a/Tools/Schema.NET.Tool/Services/PropertyNameComparer.cs
+++ b/Tools/Schema.NET.Tool/Services/PropertyNameComparer.cs
@@ -15,8 +15,12 @@ namespace Schema.NET.Tool.Services
             { "DESCRIPTION", 5 },
         };
 
-        public int Compare(string x, string y)
+        public int Compare(string? x, string? y)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(x);
+            ArgumentNullException.ThrowIfNull(y);
+#else
             if (x is null)
             {
                 throw new ArgumentNullException(nameof(x));
@@ -26,6 +30,7 @@ namespace Schema.NET.Tool.Services
             {
                 throw new ArgumentNullException(nameof(y));
             }
+#endif
 
             if (x.Equals("ENDDATE", StringComparison.Ordinal))
             {

--- a/Tools/Schema.NET.Tool/Services/SchemaService.cs
+++ b/Tools/Schema.NET.Tool/Services/SchemaService.cs
@@ -240,7 +240,11 @@ namespace Schema.NET.Tool.Services
                         })
                         .Select(id =>
                         {
+#if NETSTANDARD2_0
                             var propertyTypeName = id.ToString().Replace("https://schema.org/", string.Empty);
+#else
+                            var propertyTypeName = id.ToString().Replace("https://schema.org/", string.Empty, StringComparison.OrdinalIgnoreCase);
+#endif
                             var isPropertyTypeEnum = isEnumMap.Contains(propertyTypeName);
                             var csharpTypeStrings = GetCSharpTypeStrings(
                                 propertyName,
@@ -306,16 +310,30 @@ namespace Schema.NET.Tool.Services
                     return new string[] { "DateTimeOffset?" };
                 case "Integer":
                 case "Number" when
+#if NETSTANDARD2_0
                     propertyName.Contains("NumberOf") ||
                     propertyName.Contains("Year") ||
                     propertyName.Contains("Count") ||
                     propertyName.Contains("Age"):
+#else
+                    propertyName.Contains("NumberOf", StringComparison.OrdinalIgnoreCase) ||
+                    propertyName.Contains("Year", StringComparison.OrdinalIgnoreCase) ||
+                    propertyName.Contains("Count", StringComparison.OrdinalIgnoreCase) ||
+                    propertyName.Contains("Age", StringComparison.OrdinalIgnoreCase):
+#endif
                     return new string[] { "int?" };
                 case "Number" when
+#if NETSTANDARD2_0
                     propertyName.Contains("Price") ||
                     propertyName.Contains("Amount") ||
                     propertyName.Contains("Salary") ||
                     propertyName.Contains("Discount"):
+#else
+                    propertyName.Contains("Price", StringComparison.OrdinalIgnoreCase) ||
+                    propertyName.Contains("Amount", StringComparison.OrdinalIgnoreCase) ||
+                    propertyName.Contains("Salary", StringComparison.OrdinalIgnoreCase) ||
+                    propertyName.Contains("Discount", StringComparison.OrdinalIgnoreCase):
+#endif
                     return new string[] { "decimal?" };
                 case "Number":
                     return new string[] { "double?" };

--- a/Tools/Schema.NET.Tool/Services/SchemaService.cs
+++ b/Tools/Schema.NET.Tool/Services/SchemaService.cs
@@ -243,7 +243,7 @@ namespace Schema.NET.Tool.Services
 #if NETSTANDARD2_0
                             var propertyTypeName = id.ToString().Replace("https://schema.org/", string.Empty);
 #else
-                            var propertyTypeName = id.ToString().Replace("https://schema.org/", string.Empty, StringComparison.OrdinalIgnoreCase);
+                            var propertyTypeName = id.ToString().Replace("https://schema.org/", string.Empty, StringComparison.Ordinal);
 #endif
                             var isPropertyTypeEnum = isEnumMap.Contains(propertyTypeName);
                             var csharpTypeStrings = GetCSharpTypeStrings(
@@ -316,10 +316,10 @@ namespace Schema.NET.Tool.Services
                     propertyName.Contains("Count") ||
                     propertyName.Contains("Age"):
 #else
-                    propertyName.Contains("NumberOf", StringComparison.OrdinalIgnoreCase) ||
-                    propertyName.Contains("Year", StringComparison.OrdinalIgnoreCase) ||
-                    propertyName.Contains("Count", StringComparison.OrdinalIgnoreCase) ||
-                    propertyName.Contains("Age", StringComparison.OrdinalIgnoreCase):
+                    propertyName.Contains("NumberOf", StringComparison.Ordinal) ||
+                    propertyName.Contains("Year", StringComparison.Ordinal) ||
+                    propertyName.Contains("Count", StringComparison.Ordinal) ||
+                    propertyName.Contains("Age", StringComparison.Ordinal):
 #endif
                     return new string[] { "int?" };
                 case "Number" when
@@ -329,10 +329,10 @@ namespace Schema.NET.Tool.Services
                     propertyName.Contains("Salary") ||
                     propertyName.Contains("Discount"):
 #else
-                    propertyName.Contains("Price", StringComparison.OrdinalIgnoreCase) ||
-                    propertyName.Contains("Amount", StringComparison.OrdinalIgnoreCase) ||
-                    propertyName.Contains("Salary", StringComparison.OrdinalIgnoreCase) ||
-                    propertyName.Contains("Discount", StringComparison.OrdinalIgnoreCase):
+                    propertyName.Contains("Price", StringComparison.Ordinal) ||
+                    propertyName.Contains("Amount", StringComparison.Ordinal) ||
+                    propertyName.Contains("Salary", StringComparison.Ordinal) ||
+                    propertyName.Contains("Discount", StringComparison.Ordinal):
 #endif
                     return new string[] { "decimal?" };
                 case "Number":

--- a/Tools/Schema.NET.Tool/SourceUtility.cs
+++ b/Tools/Schema.NET.Tool/SourceUtility.cs
@@ -23,6 +23,10 @@ namespace Schema.NET.Tool
 
         public static string RenderItems<T>(IEnumerable<T> items, Func<T, string> action)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+            ArgumentNullException.ThrowIfNull(action);
+#else
             if (items is null)
             {
                 throw new ArgumentNullException(nameof(items));
@@ -32,6 +36,7 @@ namespace Schema.NET.Tool
             {
                 throw new ArgumentNullException(nameof(action));
             }
+#endif
 
             var stringBuilder = new StringBuilder();
             foreach (var item in items)
@@ -44,6 +49,10 @@ namespace Schema.NET.Tool
 
         public static string RenderItems<T>(IEnumerable<T> items, Func<T, int, string> action)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(items);
+            ArgumentNullException.ThrowIfNull(action);
+#else
             if (items is null)
             {
                 throw new ArgumentNullException(nameof(items));
@@ -53,6 +62,7 @@ namespace Schema.NET.Tool
             {
                 throw new ArgumentNullException(nameof(action));
             }
+#endif
 
             var stringBuilder = new StringBuilder();
             var i = 0;

--- a/Tools/Schema.NET.Updater/Schema.NET.Updater.csproj
+++ b/Tools/Schema.NET.Updater/Schema.NET.Updater.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,16 @@ stages:
           - checkout: self
             lfs: true
           - task: UseDotNet@2
+            displayName: "Install .NET Core 3.1 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 3.1.x
+          - task: UseDotNet@2
+            displayName: "Install .NET Core 5.0 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 5.0.x
+          - task: UseDotNet@2
             displayName: "Install .NET Core SDK"
             inputs:
               packageType: "sdk"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
+    "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "5.0.401"
+    "version": "6.0.100-rc.2.21505.57"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "6.0.100-rc.2.21505.57"
+    "version": "6.0.100"
   }
 }


### PR DESCRIPTION
- Add embedded `README.md` to NuGet packages (https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile).
- Add `net6.0`.
- Remove `net461`.
- Remove unused code.
- Use `ArgumentNullException.ThrowIfNull(...)`.

Will update the `.editorconfig` in a later PR and go with file scoped namespaces.