### PR TITLE
Use UriKind.RelativeOrAbsolute to allow deserializing of relative URIs

### DIFF
--- a/Source/Common/ValuesJsonConverter.cs
+++ b/Source/Common/ValuesJsonConverter.cs
@@ -379,7 +379,7 @@ public class ValuesJsonConverter : JsonConverter<IValues>
             }
             else if (targetType == typeof(Uri))
             {
-                success = Uri.TryCreate(valueString, UriKind.Absolute, out var localResult);
+                success = Uri.TryCreate(valueString, UriKind.RelativeOrAbsolute, out var localResult);
                 result = localResult;
             }
             else if (targetType == typeof(Guid))

--- a/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
+++ b/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
@@ -266,9 +266,9 @@ public class ValuesJsonConverterTest
     [Fact]
     public void ReadJson_ParseValueToken_RelativeUriAsString()
     {
-        var json = "{\"Property\":\"/Thing\"}";
+        var json = "{\"Property\":\"thing\"}";
         var result = DeserializeObject<Values<string, Uri>>(json);
-        Assert.Equal(new Uri("/Thing", UriKind.RelativeOrAbsolute), result.Value2.First());
+        Assert.Equal(new Uri("thing", UriKind.Relative), result.Value2.First());
     }
 
     [Fact]
@@ -281,7 +281,7 @@ public class ValuesJsonConverterTest
                 "\"@id\":\"https://example.com/book/1\"," +
                 "\"name\":\"The Catcher in the Rye\"," +
                 "\"url\":\"https://www.barnesandnoble.com/store/info/offer/JDSalinger\"," +
-                "\"image\":\"/images/book/1\"," +
+                "\"image\":\"book1.jpg\"," +
                 "\"author\":{" +
                     "\"@type\":\"Person\"," +
                     "\"name\":\"J.D. Salinger\"" +
@@ -294,7 +294,7 @@ public class ValuesJsonConverterTest
         Assert.Equal(new Uri("https://example.com/book/1"), ((Book)actual).Id);
         Assert.Equal("The Catcher in the Rye", actual.Name);
         Assert.Equal(new Uri("https://www.barnesandnoble.com/store/info/offer/JDSalinger"), (Uri)actual.Url!);
-        Assert.Equal(new Uri("/images/book/1", UriKind.RelativeOrAbsolute), (Uri)actual.Image!);
+        Assert.Equal(new Uri("book1.jpg", UriKind.Relative), (Uri)actual.Image!);
         var author = Assert.Single(actual.Author.Value2);
         Assert.Equal("J.D. Salinger", author.Name);
     }

--- a/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
+++ b/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
@@ -264,6 +264,14 @@ public class ValuesJsonConverterTest
     }
 
     [Fact]
+    public void ReadJson_ParseValueToken_RelativeUriAsString()
+    {
+        var json = "{\"Property\":\"/Thing\"}";
+        var result = DeserializeObject<Values<string, Uri>>(json);
+        Assert.Equal(new Uri("/Thing", UriKind.Relative), result.Value2.First());
+    }
+
+    [Fact]
     public void ReadJson_Values_SingleValue_ThingInterface()
     {
         var json = "{\"Property\":" +
@@ -273,6 +281,7 @@ public class ValuesJsonConverterTest
                 "\"@id\":\"https://example.com/book/1\"," +
                 "\"name\":\"The Catcher in the Rye\"," +
                 "\"url\":\"https://www.barnesandnoble.com/store/info/offer/JDSalinger\"," +
+                "\"image\":\"/images/book/1\"," +
                 "\"author\":{" +
                     "\"@type\":\"Person\"," +
                     "\"name\":\"J.D. Salinger\"" +
@@ -285,6 +294,7 @@ public class ValuesJsonConverterTest
         Assert.Equal(new Uri("https://example.com/book/1"), ((Book)actual).Id);
         Assert.Equal("The Catcher in the Rye", actual.Name);
         Assert.Equal(new Uri("https://www.barnesandnoble.com/store/info/offer/JDSalinger"), (Uri)actual.Url!);
+        Assert.Equal(new Uri("/images/book/1", UriKind.Relative), (Uri)actual.Image!);
         var author = Assert.Single(actual.Author.Value2);
         Assert.Equal("J.D. Salinger", author.Name);
     }

--- a/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
+++ b/Tests/Schema.NET.Test/ValuesJsonConverterTest.cs
@@ -268,7 +268,7 @@ public class ValuesJsonConverterTest
     {
         var json = "{\"Property\":\"/Thing\"}";
         var result = DeserializeObject<Values<string, Uri>>(json);
-        Assert.Equal(new Uri("/Thing", UriKind.Relative), result.Value2.First());
+        Assert.Equal(new Uri("/Thing", UriKind.RelativeOrAbsolute), result.Value2.First());
     }
 
     [Fact]
@@ -294,7 +294,7 @@ public class ValuesJsonConverterTest
         Assert.Equal(new Uri("https://example.com/book/1"), ((Book)actual).Id);
         Assert.Equal("The Catcher in the Rye", actual.Name);
         Assert.Equal(new Uri("https://www.barnesandnoble.com/store/info/offer/JDSalinger"), (Uri)actual.Url!);
-        Assert.Equal(new Uri("/images/book/1", UriKind.Relative), (Uri)actual.Image!);
+        Assert.Equal(new Uri("/images/book/1", UriKind.RelativeOrAbsolute), (Uri)actual.Image!);
         var author = Assert.Single(actual.Author.Value2);
         Assert.Equal("J.D. Salinger", author.Name);
     }


### PR DESCRIPTION
Fixing issue where relative URIs in JSON are ignored and not included in the deserialized schema.org objects, as discussed in #391 
