### PR TITLE
Switch to Dotnet.ReproducibleBuilds

### DIFF
--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -208,64 +208,43 @@ public readonly struct Values<T1, T2, T3, T4, T5, T6, T7>
         {
             if (item is T7 itemT7)
             {
-                if (items7 == null)
-                {
-                    items7 = new List<T7>();
-                }
+                items7 ??= new List<T7>();
 
                 items7.Add(itemT7);
             }
             else if (item is T6 itemT6)
             {
-                if (items6 == null)
-                {
-                    items6 = new List<T6>();
-                }
+                items6 ??= new List<T6>();
 
                 items6.Add(itemT6);
             }
             else if (item is T5 itemT5)
             {
-                if (items5 == null)
-                {
-                    items5 = new List<T5>();
-                }
+                items5 ??= new List<T5>();
 
                 items5.Add(itemT5);
             }
             else if (item is T4 itemT4)
             {
-                if (items4 == null)
-                {
-                    items4 = new List<T4>();
-                }
+                items4 ??= new List<T4>();
 
                 items4.Add(itemT4);
             }
             else if (item is T3 itemT3)
             {
-                if (items3 == null)
-                {
-                    items3 = new List<T3>();
-                }
+                items3 ??= new List<T3>();
 
                 items3.Add(itemT3);
             }
             else if (item is T2 itemT2)
             {
-                if (items2 == null)
-                {
-                    items2 = new List<T2>();
-                }
+                items2 ??= new List<T2>();
 
                 items2.Add(itemT2);
             }
             else if (item is T1 itemT1)
             {
-                if (items1 == null)
-                {
-                    items1 = new List<T1>();
-                }
+                items1 ??= new List<T1>();
 
                 items1.Add(itemT1);
             }

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
@@ -172,55 +172,37 @@ public readonly struct Values<T1, T2, T3, T4, T5, T6>
         {
             if (item is T6 itemT6)
             {
-                if (items6 == null)
-                {
-                    items6 = new List<T6>();
-                }
+                items6 ??= new List<T6>();
 
                 items6.Add(itemT6);
             }
             else if (item is T5 itemT5)
             {
-                if (items5 == null)
-                {
-                    items5 = new List<T5>();
-                }
+                items5 ??= new List<T5>();
 
                 items5.Add(itemT5);
             }
             else if (item is T4 itemT4)
             {
-                if (items4 == null)
-                {
-                    items4 = new List<T4>();
-                }
+                items4 ??= new List<T4>();
 
                 items4.Add(itemT4);
             }
             else if (item is T3 itemT3)
             {
-                if (items3 == null)
-                {
-                    items3 = new List<T3>();
-                }
+                items3 ??= new List<T3>();
 
                 items3.Add(itemT3);
             }
             else if (item is T2 itemT2)
             {
-                if (items2 == null)
-                {
-                    items2 = new List<T2>();
-                }
+                items2 ??= new List<T2>();
 
                 items2.Add(itemT2);
             }
             else if (item is T1 itemT1)
             {
-                if (items1 == null)
-                {
-                    items1 = new List<T1>();
-                }
+                items1 ??= new List<T1>();
 
                 items1.Add(itemT1);
             }

--- a/Source/Common/Values{T1,T2,T3,T4}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4}.cs
@@ -112,37 +112,25 @@ public readonly struct Values<T1, T2, T3, T4>
         {
             if (item is T4 itemT4)
             {
-                if (items4 == null)
-                {
-                    items4 = new List<T4>();
-                }
+                items4 ??= new List<T4>();
 
                 items4.Add(itemT4);
             }
             else if (item is T3 itemT3)
             {
-                if (items3 == null)
-                {
-                    items3 = new List<T3>();
-                }
+                items3 ??= new List<T3>();
 
                 items3.Add(itemT3);
             }
             else if (item is T2 itemT2)
             {
-                if (items2 == null)
-                {
-                    items2 = new List<T2>();
-                }
+                items2 ??= new List<T2>();
 
                 items2.Add(itemT2);
             }
             else if (item is T1 itemT1)
             {
-                if (items1 == null)
-                {
-                    items1 = new List<T1>();
-                }
+                items1 ??= new List<T1>();
 
                 items1.Add(itemT1);
             }

--- a/Source/Common/Values{T1,T2,T3}.cs
+++ b/Source/Common/Values{T1,T2,T3}.cs
@@ -88,28 +88,19 @@ public readonly struct Values<T1, T2, T3>
         {
             if (item is T3 itemT3)
             {
-                if (items3 == null)
-                {
-                    items3 = new List<T3>();
-                }
+                items3 ??= new List<T3>();
 
                 items3.Add(itemT3);
             }
             else if (item is T2 itemT2)
             {
-                if (items2 == null)
-                {
-                    items2 = new List<T2>();
-                }
+                items2 ??= new List<T2>();
 
                 items2.Add(itemT2);
             }
             else if (item is T1 itemT1)
             {
-                if (items1 == null)
-                {
-                    items1 = new List<T1>();
-                }
+                items1 ??= new List<T1>();
 
                 items1.Add(itemT1);
             }

--- a/Source/Common/Values{T1,T2}.cs
+++ b/Source/Common/Values{T1,T2}.cs
@@ -68,19 +68,13 @@ public readonly struct Values<T1, T2>
         {
             if (item is T2 itemT2)
             {
-                if (items2 == null)
-                {
-                    items2 = new List<T2>();
-                }
+                items2 ??= new List<T2>();
 
                 items2.Add(itemT2);
             }
             else if (item is T1 itemT1)
             {
-                if (items1 == null)
-                {
-                    items1 = new List<T1>();
-                }
+                items1 ??= new List<T1>();
 
                 items1.Add(itemT1);
             }

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,7 +4,6 @@
 
   <PropertyGroup Label="Build">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup Label="Source Generator Options">
@@ -16,17 +15,8 @@
     <AssemblyOriginatorKeyFile>../../Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Label="Source Link">
-    <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- Optional: Include PDB in the built .nupkg -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
-
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.1.1" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="all" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup Label="Files">

--- a/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
+++ b/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
   </ItemGroup>
 
   <!--
@@ -26,7 +26,7 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="6.0.4" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="6.0.6" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 
@@ -37,7 +37,7 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="6.0.4" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="6.0.6" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": true,
-    "rollForward": "disable",
+    "rollForward": "latestMajor",
     "version": "6.0.401"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": true,
-    "rollForward": "latestMajor",
-    "version": "6.0.300"
+    "rollForward": "disable",
+    "version": "6.0.401"
   }
 }


### PR DESCRIPTION
- Switch to Dotnet.ReproducibleBuilds.
- Upgrade .NET SDK.
- Upgrade tools packages.
- Use compound assignments to satisfy new build warnings.