### PR TITLE
Additional checks around enum parsing

### DIFF
--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 /// <summary>
 /// Helper for parsing strings into Enum values.
 /// </summary>
-internal static class EnumHelper
+public static class EnumHelper
 {
     /// <summary>
     /// Converts the string representation of the name or numeric value of one or more
@@ -61,7 +61,7 @@ internal static class EnumHelper
         out object? result)
     {
         string? enumString;
-        if (value is not null && value.StartsWith(Constants.HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
+        if (value is not null && value.Length > Constants.HttpSchemaOrgUrl.Length && value.StartsWith(Constants.HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
         {
 #if NETCOREAPP3_0_OR_GREATER
             enumString = value[(Constants.HttpSchemaOrgUrl.Length + 1)..];
@@ -69,7 +69,7 @@ internal static class EnumHelper
             enumString = value.Substring(Constants.HttpSchemaOrgUrl.Length + 1);
 #endif
         }
-        else if (value is not null && value.StartsWith(Constants.HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
+        else if (value is not null && value.Length > Constants.HttpsSchemaOrgUrl.Length && value.StartsWith(Constants.HttpsSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
         {
 #if NETCOREAPP3_0_OR_GREATER
             enumString = value[(Constants.HttpsSchemaOrgUrl.Length + 1)..];

--- a/Source/Common/EnumHelper.cs
+++ b/Source/Common/EnumHelper.cs
@@ -60,6 +60,14 @@ public static class EnumHelper
         string? value,
         out object? result)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(enumType);
+#else
+        if (enumType is null)
+        {
+            throw new ArgumentNullException(nameof(enumType));
+        }
+#endif
         string? enumString;
         if (value is not null && value.Length > Constants.HttpSchemaOrgUrl.Length && value.StartsWith(Constants.HttpSchemaOrgUrl, StringComparison.OrdinalIgnoreCase))
         {

--- a/Tests/Schema.NET.Test/EnumHelperTest.cs
+++ b/Tests/Schema.NET.Test/EnumHelperTest.cs
@@ -1,0 +1,47 @@
+namespace Schema.NET.Test;
+
+using Xunit;
+
+public class EnumHelperTest
+{
+    private enum TestEnum
+    {
+        DefaultValue,
+        RealValue,
+    }
+
+    [Theory]
+    [InlineData("RealValue")]
+    [InlineData("http://schema.org/RealValue")]
+    [InlineData("https://schema.org/RealValue")]
+    [InlineData("HTTPS://SCHEMA.ORG/RealValue")]
+    public void TryParseEnumFromSchemaUri_AllowedValues(string inputValue)
+    {
+        var result = EnumHelper.TryParseEnumFromSchemaUri(
+            typeof(TestEnum),
+            inputValue,
+            out var parsedValue);
+
+        Assert.True(result);
+        Assert.Equal(TestEnum.RealValue, parsedValue);
+    }
+
+    [Theory]
+    [InlineData("REALVALUE")]
+    [InlineData("http://schema.org/REALVALUE")]
+    [InlineData("http://schema.org")]
+    [InlineData("https://schema.org")]
+    [InlineData("http://schema.org/")]
+    [InlineData("https://schema.org/")]
+    [InlineData("NonValue")]
+    [InlineData("http://example.org/RealValue")]
+    public void TryParseEnumFromSchemaUri_InvalidValues(string inputValue)
+    {
+        var result = EnumHelper.TryParseEnumFromSchemaUri(
+            typeof(TestEnum),
+            inputValue,
+            out _);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
Closes #547

This includes additional tests for `EnumHelper`. I did look at using `InternalsVisibleTo` instead of making `EnumHelper` public but that was going to be a pain due to the strong naming of the main projects, needing to have a public key (not just the public token) within the declaration of `InternalsVisibleTo` for `Schema.NET.Test`.