### PR TITLE
Use Incremental Source Generators

### DIFF
--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -27,4 +27,8 @@
     <Compile Include="../Common/*.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Source Generation">
+    <AdditionalFiles Include="../../Data/*.*" LinkBase="Data" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -27,4 +27,8 @@
     <Compile Include="../Common/*.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Source Generation">
+    <AdditionalFiles Include="../../Data/*.*" LinkBase="Data" />
+  </ItemGroup>
+
 </Project>

--- a/Tools/Schema.NET.Tool/Repositories/ISchemaRepository.cs
+++ b/Tools/Schema.NET.Tool/Repositories/ISchemaRepository.cs
@@ -1,10 +1,9 @@
 namespace Schema.NET.Tool.Repositories;
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Schema.NET.Tool.Models;
 
 public interface ISchemaRepository
 {
-    Task<(IEnumerable<SchemaClass> Classes, IEnumerable<SchemaProperty> Properties, IEnumerable<SchemaEnumerationValue> EnumerationValues)> GetObjectsAsync();
+    (IEnumerable<SchemaClass> Classes, IEnumerable<SchemaProperty> Properties, IEnumerable<SchemaEnumerationValue> EnumerationValues) GetObjects();
 }

--- a/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
+++ b/Tools/Schema.NET.Tool/Schema.NET.Tool.csproj
@@ -68,7 +68,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="../../Data/*.*" LinkBase="Data" />
   </ItemGroup>
 
 </Project>

--- a/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
+++ b/Tools/Schema.NET.Tool/SchemaSourceGenerator.cs
@@ -1,31 +1,41 @@
 namespace Schema.NET.Tool;
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Schema.NET.Tool.CustomOverrides;
 using Schema.NET.Tool.GeneratorModels;
 using Schema.NET.Tool.Repositories;
 using Schema.NET.Tool.Services;
 
 [Generator]
-public class SchemaSourceGenerator : ISourceGenerator
+public class SchemaSourceGenerator : IIncrementalGenerator
 {
-    private const string SchemaDataName = "Schema.NET.Tool.Data.schemaorg-all-https.jsonld";
+    private const string SchemaDataName = "schemaorg-all-https.jsonld";
 
-    public void Initialize(GeneratorInitializationContext context)
+    public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        var schemaJsonLdDataFile = context.AdditionalTextsProvider
+            .Where(static text => text.Path.EndsWith(SchemaDataName, StringComparison.OrdinalIgnoreCase))
+            .Collect();
+
+        var configuration = context.AnalyzerConfigOptionsProvider
+            .Select((provider, _) => provider.GlobalOptions);
+
+        context.RegisterSourceOutput(configuration.Combine(schemaJsonLdDataFile), Generate);
     }
 
-    public void Execute(GeneratorExecutionContext context)
+    private static void Generate(SourceProductionContext context, (AnalyzerConfigOptions Options, ImmutableArray<AdditionalText> AdditionalText) data)
     {
-        var schemaDataStream = Assembly
-            .GetExecutingAssembly()
-            .GetManifestResourceStream(SchemaDataName) ??
-            throw new InvalidOperationException($"Schema data file '{SchemaDataName}' not found.");
+        var schemaJsonLdDataFile = data.AdditionalText.SingleOrDefault() ??
+            throw new InvalidOperationException($"Schema data file '{SchemaDataName}' not configured.");
 
-        var schemaRepository = new SchemaRepository(schemaDataStream);
+        var schemaJsonLdData = schemaJsonLdDataFile.GetText(context.CancellationToken) ??
+            throw new InvalidOperationException($"Unable to read schema data file '{SchemaDataName}'.");
+
+        var schemaRepository = new SchemaRepository(schemaJsonLdData);
         var schemaService = new SchemaService(
             new IClassOverride[]
             {
@@ -36,12 +46,9 @@ public class SchemaSourceGenerator : ISourceGenerator
             },
             Array.Empty<IEnumerationOverride>(),
             schemaRepository,
-            IncludePendingSchemaObjects(context));
+            IncludePendingSchemaObjects(data.Options));
 
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-        var schemaObjects = schemaService.GetObjectsAsync().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-
+        var schemaObjects = schemaService.GetObjects();
         if (schemaObjects is not null)
         {
             foreach (var schemaObject in schemaObjects)
@@ -61,12 +68,9 @@ public class SchemaSourceGenerator : ISourceGenerator
         }
     }
 
-    private static bool IncludePendingSchemaObjects(GeneratorExecutionContext context)
-    {
-        var configuration = context.AnalyzerConfigOptions.GlobalOptions;
-        return configuration.TryGetValue($"build_property.IncludePendingSchemaObjects", out var value) &&
+    private static bool IncludePendingSchemaObjects(AnalyzerConfigOptions options) =>
+        options.TryGetValue($"build_property.IncludePendingSchemaObjects", out var value) &&
             value.Equals("true", StringComparison.OrdinalIgnoreCase);
-    }
 
     private static string RenderClass(GeneratorSchemaClass schemaClass)
     {

--- a/Tools/Schema.NET.Tool/Services/SchemaService.cs
+++ b/Tools/Schema.NET.Tool/Services/SchemaService.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Schema.NET.Tool.CustomOverrides;
 using Schema.NET.Tool.GeneratorModels;
 using Schema.NET.Tool.Repositories;
@@ -32,11 +31,10 @@ public class SchemaService
         this.includePending = includePending;
     }
 
-    public async Task<IEnumerable<GeneratorSchemaObject>> GetObjectsAsync()
+    public IEnumerable<GeneratorSchemaObject> GetObjects()
     {
-        var (schemaClasses, schemaProperties, schemaValues) = await this.schemaRepository
-            .GetObjectsAsync()
-            .ConfigureAwait(false);
+        var (schemaClasses, schemaProperties, schemaValues) = this.schemaRepository
+            .GetObjects();
 
         var isEnumMap = new HashSet<string>(
             schemaClasses.Where(c => c.IsEnum).Select(c => c.Label),


### PR DESCRIPTION
This should do a few little things for us:
- Uses the typical source generator way for referencing files
- Simplifies the source generation by removing the async/await path (drops the use of `Stream` due to the first point)

This _may_ make it a little faster/easier in Visual Studio to use the solution (I've had issues in the past and basically just have been disabling `Schema.NET.Pending` so it wasn't so slow).