### PR TITLE
Split target of dotnet library versions

### DIFF
--- a/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
+++ b/Source/Schema.NET.Pending/Schema.NET.Pending.csproj
@@ -13,10 +13,14 @@
     <PackageTags>Schema;.NET;Schema.org;Schema.NET;Structured Data;Google Structured Data</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
+  <ItemGroup Label="Package References (Common)">
+    <PackageReference Include="System.Text.Json" Version="6.0.7" Condition="'$(TargetFramework)' != 'net7.0'" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package References (.NET 7)" Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET Framework)" Condition="'$(TargetFramework)' == 'net462'">

--- a/Source/Schema.NET/Schema.NET.csproj
+++ b/Source/Schema.NET/Schema.NET.csproj
@@ -13,10 +13,14 @@
     <PackageTags>Schema;.NET;Schema.org;Schema.NET;Structured Data;Google Structured Data</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Label="Package References">
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
+  <ItemGroup Label="Package References (Common)">
+    <PackageReference Include="System.Text.Json" Version="6.0.7" Condition="'$(TargetFramework)' != 'net7.0'" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <ProjectReference Include="../../Tools/Schema.NET.Tool/Schema.NET.Tool.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+  
+  <ItemGroup Label="Package References (.NET 7)" Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET Framework)" Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
This will make only .NET 7 pull in v7 of core .NET libraries. Fixes #598 

The downside to this is that Renovate and Dependabot will likely struggle updating System.Text.Json now so we will need to be extra careful.

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/RehanSaeed/Schema.NET/blob/main/.github/CONTRIBUTING.md
-->
