### PR TITLE
Fix HasValueX incorrectly returning true

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -84,6 +84,10 @@ spelling_checkable_types =            # NEW
 # Default Severity for all .NET Code Style rules below
 dotnet_analyzer_diagnostic.severity = warning
 
+# VSSpell001: Spell Check
+dotnet_diagnostic.VSSpell001.severity = suggestion
+dotnet_diagnostic.VSSpell002.severity = suggestion
+
 ##########################################
 # Language Rules - .NET
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
@@ -162,6 +166,7 @@ dotnet_diagnostic.IDE0063.severity = suggestion
 csharp_style_namespace_declarations = file_scoped
 csharp_style_prefer_method_group_conversion = true # NEW
 csharp_style_prefer_top_level_statements = true # NEW
+dotnet_diagnostic.IDE0290.severity = suggestion # NEW - Use primary constructor
 
 # Expression-bodied members
 csharp_style_expression_bodied_constructors = true
@@ -189,6 +194,11 @@ csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_prefer_null_check_over_type_check = true
 csharp_style_prefer_tuple_swap = true # NEW
 csharp_style_prefer_utf8_string_literals = true # NEW
+dotnet_diagnostic.IDE0028.severity = suggestion # NEW - Use collection initializers
+dotnet_diagnostic.IDE0090.severity = suggestion # NEW - Simplify new expression
+dotnet_diagnostic.IDE0300.severity = suggestion # NEW - Collection initialization can be simplified
+dotnet_diagnostic.IDE0301.severity = suggestion # NEW - Collection initialization can be simplified
+dotnet_diagnostic.IDE0305.severity = suggestion # NEW - Collection initialization can be simplified
 
 # Modifier preferences
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
@@ -293,6 +303,27 @@ csharp_space_between_square_brackets = false
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#wrap-options
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
+
+##########################################
+# Code Quality Rules - C#
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
+##########################################
+
+[*.{cs,csx,cake}]
+
+# Usage rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/usage-warnings
+dotnet_diagnostic.CA2249.severity = suggestion # NEW - Consider using String.Contains instead of String.IndexOf
+
+# Performance rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/performance-warnings
+dotnet_diagnostic.CA1854.severity = suggestion # NEW - Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1859.severity = suggestion # NEW - Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1861.severity = suggestion # NEW - Avoid constant arrays as arguments
+dotnet_diagnostic.CA1865.severity = suggestion # NEW - Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
+dotnet_diagnostic.CA1866.severity = suggestion # NEW - Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
+dotnet_diagnostic.CA1867.severity = suggestion # NEW - Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
+dotnet_diagnostic.CA1869.severity = suggestion # NEW - Cache and reuse 'JsonSerializerOptions' instances
 
 ##########################################
 # .NET Naming Rules

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -245,14 +245,6 @@ public readonly struct Values<T1, T2, T3, T4, T5, T6, T7>
             }
         }
 
-        this.HasValue1 = items1?.Count > 0;
-        this.HasValue2 = items2?.Count > 0;
-        this.HasValue3 = items3?.Count > 0;
-        this.HasValue4 = items4?.Count > 0;
-        this.HasValue5 = items5?.Count > 0;
-        this.HasValue6 = items6?.Count > 0;
-        this.HasValue7 = items7?.Count > 0;
-
         this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
         this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
         this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
@@ -260,6 +252,14 @@ public readonly struct Values<T1, T2, T3, T4, T5, T6, T7>
         this.Value5 = items5 == null ? default : (OneOrMany<T5>)items5;
         this.Value6 = items6 == null ? default : (OneOrMany<T6>)items6;
         this.Value7 = items7 == null ? default : (OneOrMany<T7>)items7;
+
+        this.HasValue1 = this.Value1.Count > 0;
+        this.HasValue2 = this.Value2.Count > 0;
+        this.HasValue3 = this.Value3.Count > 0;
+        this.HasValue4 = this.Value4.Count > 0;
+        this.HasValue5 = this.Value5.Count > 0;
+        this.HasValue6 = this.Value6.Count > 0;
+        this.HasValue7 = this.Value7.Count > 0;
     }
 
     /// <summary>

--- a/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5,T6}.cs
@@ -204,19 +204,19 @@ public readonly struct Values<T1, T2, T3, T4, T5, T6>
             }
         }
 
-        this.HasValue1 = items1?.Count > 0;
-        this.HasValue2 = items2?.Count > 0;
-        this.HasValue3 = items3?.Count > 0;
-        this.HasValue4 = items4?.Count > 0;
-        this.HasValue5 = items5?.Count > 0;
-        this.HasValue6 = items6?.Count > 0;
-
         this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
         this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
         this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
         this.Value4 = items4 == null ? default : (OneOrMany<T4>)items4;
         this.Value5 = items5 == null ? default : (OneOrMany<T5>)items5;
         this.Value6 = items6 == null ? default : (OneOrMany<T6>)items6;
+
+        this.HasValue1 = this.Value1.Count > 0;
+        this.HasValue2 = this.Value2.Count > 0;
+        this.HasValue3 = this.Value3.Count > 0;
+        this.HasValue4 = this.Value4.Count > 0;
+        this.HasValue5 = this.Value5.Count > 0;
+        this.HasValue6 = this.Value6.Count > 0;
     }
 
     /// <summary>

--- a/Source/Common/Values{T1,T2,T3,T4,T5}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4,T5}.cs
@@ -167,17 +167,17 @@ public readonly struct Values<T1, T2, T3, T4, T5>
             }
         }
 
-        this.HasValue1 = items1?.Count > 0;
-        this.HasValue2 = items2?.Count > 0;
-        this.HasValue3 = items3?.Count > 0;
-        this.HasValue4 = items4?.Count > 0;
-        this.HasValue5 = items5?.Count > 0;
-
         this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
         this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
         this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
         this.Value4 = items4 == null ? default : (OneOrMany<T4>)items4;
         this.Value5 = items5 == null ? default : (OneOrMany<T5>)items5;
+
+        this.HasValue1 = this.Value1.Count > 0;
+        this.HasValue2 = this.Value2.Count > 0;
+        this.HasValue3 = this.Value3.Count > 0;
+        this.HasValue4 = this.Value4.Count > 0;
+        this.HasValue5 = this.Value5.Count > 0;
     }
 
     /// <summary>

--- a/Source/Common/Values{T1,T2,T3,T4}.cs
+++ b/Source/Common/Values{T1,T2,T3,T4}.cs
@@ -134,15 +134,15 @@ public readonly struct Values<T1, T2, T3, T4>
             }
         }
 
-        this.HasValue1 = items1?.Count > 0;
-        this.HasValue2 = items2?.Count > 0;
-        this.HasValue3 = items3?.Count > 0;
-        this.HasValue4 = items4?.Count > 0;
-
         this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
         this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
         this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
         this.Value4 = items4 == null ? default : (OneOrMany<T4>)items4;
+
+        this.HasValue1 = this.Value1.Count > 0;
+        this.HasValue2 = this.Value2.Count > 0;
+        this.HasValue3 = this.Value3.Count > 0;
+        this.HasValue4 = this.Value4.Count > 0;
     }
 
     /// <summary>

--- a/Source/Common/Values{T1,T2,T3}.cs
+++ b/Source/Common/Values{T1,T2,T3}.cs
@@ -105,13 +105,13 @@ public readonly struct Values<T1, T2, T3>
             }
         }
 
-        this.HasValue1 = items1?.Count > 0;
-        this.HasValue2 = items2?.Count > 0;
-        this.HasValue3 = items3?.Count > 0;
-
         this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
         this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
         this.Value3 = items3 == null ? default : (OneOrMany<T3>)items3;
+
+        this.HasValue1 = this.Value1.Count > 0;
+        this.HasValue2 = this.Value2.Count > 0;
+        this.HasValue3 = this.Value3.Count > 0;
     }
 
     /// <summary>

--- a/Source/Common/Values{T1,T2}.cs
+++ b/Source/Common/Values{T1,T2}.cs
@@ -80,11 +80,11 @@ public readonly struct Values<T1, T2>
             }
         }
 
-        this.HasValue1 = items1?.Count > 0;
-        this.HasValue2 = items2?.Count > 0;
-
         this.Value1 = items1 == null ? default : (OneOrMany<T1>)items1;
         this.Value2 = items2 == null ? default : (OneOrMany<T2>)items2;
+
+        this.HasValue1 = this.Value1.Count > 0;
+        this.HasValue2 = this.Value2.Count > 0;
     }
 
     /// <summary>

--- a/Tests/Schema.NET.Test/AssertEx.cs
+++ b/Tests/Schema.NET.Test/AssertEx.cs
@@ -1,0 +1,18 @@
+namespace Schema.NET.Test;
+
+using System.Collections;
+using Xunit;
+
+/// <summary>
+/// Provides extended methods and helpers to the Xunit.Assert class.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Name needs to be short to ensure readability of consuming code.")]
+public static class AssertEx
+{
+    /// <summary>
+    /// Verifies that a <see cref="OneOrMany{T}"/> collection is empty.
+    /// </summary>
+    /// <typeparam name="T">The type of the values.</typeparam>
+    /// <inheritdoc cref="Assert.Empty(IEnumerable)"/>
+    public static void Empty<T>(OneOrMany<T> collection) => Assert.Empty(collection);
+}

--- a/Tests/Schema.NET.Test/OneOrManyTest.cs
+++ b/Tests/Schema.NET.Test/OneOrManyTest.cs
@@ -60,7 +60,7 @@ public class OneOrManyTest
     public void Count_DefaultStructConstructor_ReturnsZero() => Assert.Empty(default(OneOrMany<int>));
 
     [Fact]
-    public void Count_DefaultClassConstructor_ReturnsZero() => Assert.Empty(default(OneOrMany<string>)!);
+    public void Count_DefaultClassConstructor_ReturnsZero() => AssertEx.Empty(default(OneOrMany<string>));
 
     [Fact]
     public void Count_NullItem_ReturnsZero() => Assert.Empty(new OneOrMany<int?>((int?)null));

--- a/Tests/Schema.NET.Test/Values2Test.cs
+++ b/Tests/Schema.NET.Test/Values2Test.cs
@@ -15,7 +15,7 @@ public class Values2Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1 }, values.Cast<object>().ToList());
     }
 
@@ -88,7 +88,7 @@ public class Values2Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1 }, values.Cast<object>().ToList());
     }
 
@@ -112,7 +112,7 @@ public class Values2Test
         Assert.True(values.HasValue1);
         Assert.Equal(2, values.Value1.Count);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1, 2 }, values.Cast<object>().ToList());
     }
 

--- a/Tests/Schema.NET.Test/Values2Test.cs
+++ b/Tests/Schema.NET.Test/Values2Test.cs
@@ -44,6 +44,23 @@ public class Values2Test
     }
 
     [Fact]
+    public void Constructor_StringItems_NullOrWhitespaceDoesntHaveValue()
+    {
+        object[] nullOrWhitespaceValues = new[]
+        {
+            string.Empty,
+            null!,
+            "\u2028 \u2029 \u0009 \u000A \u000B \u000C \u000D \u0085",
+        };
+        var values = new Values<int, string>(nullOrWhitespaceValues);
+
+        Assert.False(values.HasValue1);
+        Assert.Empty(values.Value1);
+        Assert.False(values.HasValue2, $"{nameof(values.HasValue2)}: Expected: False, Actual: True");
+        AssertEx.Empty(values.Value2);
+    }
+
+    [Fact]
     public void Constructor_NullList_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new Values<int, string>((List<object>)null!));
 

--- a/Tests/Schema.NET.Test/Values3Test.cs
+++ b/Tests/Schema.NET.Test/Values3Test.cs
@@ -60,6 +60,25 @@ public class Values3Test
     }
 
     [Fact]
+    public void Constructor_StringItems_NullOrWhitespaceDoesntHaveValue()
+    {
+        object[] nullOrWhitespaceValues = new[]
+        {
+            string.Empty,
+            null!,
+            "\u2028 \u2029 \u0009 \u000A \u000B \u000C \u000D \u0085",
+        };
+        var values = new Values<int, string, DayOfWeek>(nullOrWhitespaceValues);
+
+        Assert.False(values.HasValue1);
+        Assert.Empty(values.Value1);
+        Assert.False(values.HasValue2, $"{nameof(values.HasValue2)}: Expected: False, Actual: True");
+        AssertEx.Empty(values.Value2);
+        Assert.False(values.HasValue3);
+        Assert.Empty(values.Value3);
+    }
+
+    [Fact]
     public void Constructor_NullList_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new Values<int, string, DayOfWeek>((List<object>)null!));
 

--- a/Tests/Schema.NET.Test/Values3Test.cs
+++ b/Tests/Schema.NET.Test/Values3Test.cs
@@ -15,7 +15,7 @@ public class Values3Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1 }, values.Cast<object>().ToList());
     }
 
@@ -39,7 +39,7 @@ public class Values3Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.Equal(new List<object>() { DayOfWeek.Friday }, values.Cast<object>().ToList());
@@ -119,7 +119,7 @@ public class Values3Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1 }, values.Cast<object>().ToList());
     }
 
@@ -143,7 +143,7 @@ public class Values3Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.Equal(new List<object>() { DayOfWeek.Friday }, values.Cast<object>().ToList());
@@ -157,7 +157,7 @@ public class Values3Test
         Assert.True(values.HasValue1);
         Assert.Equal(2, values.Value1.Count);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1, 2 }, values.Cast<object>().ToList());
     }
 
@@ -181,7 +181,7 @@ public class Values3Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Equal(2, values.Value3.Count);
         Assert.Equal(new List<object>() { DayOfWeek.Friday, DayOfWeek.Monday }, values.Cast<object>().ToList());

--- a/Tests/Schema.NET.Test/Values4Test.cs
+++ b/Tests/Schema.NET.Test/Values4Test.cs
@@ -82,6 +82,27 @@ public class Values4Test
     }
 
     [Fact]
+    public void Constructor_StringItems_NullOrWhitespaceDoesntHaveValue()
+    {
+        object[] nullOrWhitespaceValues = new[]
+        {
+            string.Empty,
+            null!,
+            "\u2028 \u2029 \u0009 \u000A \u000B \u000C \u000D \u0085",
+        };
+        var values = new Values<int, string, DayOfWeek, Person>(nullOrWhitespaceValues);
+
+        Assert.False(values.HasValue1);
+        Assert.Empty(values.Value1);
+        Assert.False(values.HasValue2, $"{nameof(values.HasValue2)}: Expected: False, Actual: True");
+        AssertEx.Empty(values.Value2);
+        Assert.False(values.HasValue3);
+        Assert.Empty(values.Value3);
+        Assert.False(values.HasValue4);
+        Assert.Empty(values.Value4);
+    }
+
+    [Fact]
     public void Constructor_NullList_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new Values<int, string, DayOfWeek, Person>((List<object>)null!));
 

--- a/Tests/Schema.NET.Test/Values4Test.cs
+++ b/Tests/Schema.NET.Test/Values4Test.cs
@@ -15,7 +15,7 @@ public class Values4Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1 }, values.Cast<object>().ToList());
     }
 
@@ -39,7 +39,7 @@ public class Values4Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.Equal(new List<object>() { DayOfWeek.Friday }, values.Cast<object>().ToList());
@@ -53,7 +53,7 @@ public class Values4Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -149,7 +149,7 @@ public class Values4Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1 }, values.Cast<object>().ToList());
     }
 
@@ -173,7 +173,7 @@ public class Values4Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.Equal(new List<object>() { DayOfWeek.Friday }, values.Cast<object>().ToList());
@@ -187,7 +187,7 @@ public class Values4Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -204,7 +204,7 @@ public class Values4Test
         Assert.True(values.HasValue1);
         Assert.Equal(2, values.Value1.Count);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.Equal(new List<object>() { 1, 2 }, values.Cast<object>().ToList());
     }
 
@@ -228,7 +228,7 @@ public class Values4Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Equal(2, values.Value3.Count);
         Assert.Equal(
@@ -244,7 +244,7 @@ public class Values4Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);

--- a/Tests/Schema.NET.Test/Values5Test.cs
+++ b/Tests/Schema.NET.Test/Values5Test.cs
@@ -121,6 +121,29 @@ public class Values5Test
     }
 
     [Fact]
+    public void Constructor_StringItems_NullOrWhitespaceDoesntHaveValue()
+    {
+        object[] nullOrWhitespaceValues = new[]
+        {
+            string.Empty,
+            null!,
+            "\u2028 \u2029 \u0009 \u000A \u000B \u000C \u000D \u0085",
+        };
+        var values = new Values<int, string, DayOfWeek, Person, DateTime>(nullOrWhitespaceValues);
+
+        Assert.False(values.HasValue1);
+        Assert.Empty(values.Value1);
+        Assert.False(values.HasValue2, $"{nameof(values.HasValue2)}: Expected: False, Actual: True");
+        AssertEx.Empty(values.Value2);
+        Assert.False(values.HasValue3);
+        Assert.Empty(values.Value3);
+        Assert.False(values.HasValue4);
+        Assert.Empty(values.Value4);
+        Assert.False(values.HasValue5);
+        Assert.Empty(values.Value5);
+    }
+
+    [Fact]
     public void Constructor_NullList_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new Values<int, string, DayOfWeek, Person, DateTime>((List<object>)null!));
 

--- a/Tests/Schema.NET.Test/Values5Test.cs
+++ b/Tests/Schema.NET.Test/Values5Test.cs
@@ -15,7 +15,7 @@ public class Values5Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -51,7 +51,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.False(values.HasValue4);
@@ -69,7 +69,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -88,7 +88,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -196,7 +196,7 @@ public class Values5Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -232,7 +232,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.False(values.HasValue4);
@@ -250,7 +250,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -269,7 +269,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -288,7 +288,7 @@ public class Values5Test
         Assert.True(values.HasValue1);
         Assert.Equal(2, values.Value1.Count);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -324,7 +324,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Equal(2, values.Value3.Count);
         Assert.False(values.HasValue4);
@@ -344,7 +344,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -362,7 +362,7 @@ public class Values5Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);

--- a/Tests/Schema.NET.Test/Values6Test.cs
+++ b/Tests/Schema.NET.Test/Values6Test.cs
@@ -154,6 +154,31 @@ public class Values6Test
     }
 
     [Fact]
+    public void Constructor_StringItems_NullOrWhitespaceDoesntHaveValue()
+    {
+        object[] nullOrWhitespaceValues = new[]
+        {
+            string.Empty,
+            null!,
+            "\u2028 \u2029 \u0009 \u000A \u000B \u000C \u000D \u0085",
+        };
+        var values = new Values<int, string, DayOfWeek, Person, DateTime, bool>(nullOrWhitespaceValues);
+
+        Assert.False(values.HasValue1);
+        Assert.Empty(values.Value1);
+        Assert.False(values.HasValue2, $"{nameof(values.HasValue2)}: Expected: False, Actual: True");
+        AssertEx.Empty(values.Value2);
+        Assert.False(values.HasValue3);
+        Assert.Empty(values.Value3);
+        Assert.False(values.HasValue4);
+        Assert.Empty(values.Value4);
+        Assert.False(values.HasValue5);
+        Assert.Empty(values.Value5);
+        Assert.False(values.HasValue6);
+        Assert.Empty(values.Value6);
+    }
+
+    [Fact]
     public void Constructor_NullList_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new Values<int, string, DayOfWeek, Person, DateTime, bool>((List<object>)null!));
 

--- a/Tests/Schema.NET.Test/Values6Test.cs
+++ b/Tests/Schema.NET.Test/Values6Test.cs
@@ -15,7 +15,7 @@ public class Values6Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -55,7 +55,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.False(values.HasValue4);
@@ -75,7 +75,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -96,7 +96,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -117,7 +117,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -237,7 +237,7 @@ public class Values6Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -277,7 +277,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.False(values.HasValue4);
@@ -297,7 +297,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -318,7 +318,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -339,7 +339,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -360,7 +360,7 @@ public class Values6Test
         Assert.True(values.HasValue1);
         Assert.Equal(2, values.Value1.Count);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -400,7 +400,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Equal(2, values.Value3.Count);
         Assert.False(values.HasValue4);
@@ -422,7 +422,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -442,7 +442,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -462,7 +462,7 @@ public class Values6Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);

--- a/Tests/Schema.NET.Test/Values7Test.cs
+++ b/Tests/Schema.NET.Test/Values7Test.cs
@@ -191,6 +191,33 @@ public class Values7Test
     }
 
     [Fact]
+    public void Constructor_StringItems_NullOrWhitespaceDoesntHaveValue()
+    {
+        object[] nullOrWhitespaceValues = new[]
+        {
+            string.Empty,
+            null!,
+            "\u2028 \u2029 \u0009 \u000A \u000B \u000C \u000D \u0085",
+        };
+        var values = new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>(nullOrWhitespaceValues);
+
+        Assert.False(values.HasValue1);
+        Assert.Empty(values.Value1);
+        Assert.False(values.HasValue2, $"{nameof(values.HasValue2)}: Expected: False, Actual: True");
+        AssertEx.Empty(values.Value2);
+        Assert.False(values.HasValue3);
+        Assert.Empty(values.Value3);
+        Assert.False(values.HasValue4);
+        Assert.Empty(values.Value4);
+        Assert.False(values.HasValue5);
+        Assert.Empty(values.Value5);
+        Assert.False(values.HasValue6);
+        Assert.Empty(values.Value6);
+        Assert.False(values.HasValue7);
+        Assert.Empty(values.Value7);
+    }
+
+    [Fact]
     public void Constructor_NullList_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new Values<int, string, DayOfWeek, Person, DateTime, bool, TimeSpan>((List<object>)null!));
 

--- a/Tests/Schema.NET.Test/Values7Test.cs
+++ b/Tests/Schema.NET.Test/Values7Test.cs
@@ -15,7 +15,7 @@ public class Values7Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -59,7 +59,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.False(values.HasValue4);
@@ -81,7 +81,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -104,7 +104,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -127,7 +127,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -150,7 +150,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -282,7 +282,7 @@ public class Values7Test
         Assert.True(values.HasValue1);
         Assert.Single(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -326,7 +326,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Single(values.Value3);
         Assert.False(values.HasValue4);
@@ -348,7 +348,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -371,7 +371,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -394,7 +394,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -417,7 +417,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -440,7 +440,7 @@ public class Values7Test
         Assert.True(values.HasValue1);
         Assert.Equal(2, values.Value1.Count);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -484,7 +484,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.True(values.HasValue3);
         Assert.Equal(2, values.Value3.Count);
         Assert.False(values.HasValue4);
@@ -506,7 +506,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.True(values.HasValue4);
@@ -528,7 +528,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -550,7 +550,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);
@@ -572,7 +572,7 @@ public class Values7Test
         Assert.False(values.HasValue1);
         Assert.Empty(values.Value1);
         Assert.False(values.HasValue2);
-        Assert.Empty(values.Value2!);
+        AssertEx.Empty(values.Value2);
         Assert.False(values.HasValue3);
         Assert.Empty(values.Value3);
         Assert.False(values.HasValue4);


### PR DESCRIPTION
# Overview

As per issue #675, when a whitespace string is passed to the `Values(params object[] items)` or `Values(IEnumerable<object?> items)` constructors of any of the `Values<>` classes, the `HasValueX` property will return `true`, where the corresponding `ValueX` will be empty.

# Primary changes

- Added tests to handle the known failure scenario.
- Moved `this.HasValueX` evaluation and assignment to after `this.ValueX` assignment.

# Ancillary changes

- Updated `.editorconfig` to redefine new Roslyn analysers, ensuring that newer warnings don't fail the build.
- Added a helper method to `Schema.NET.Test`, `AssertEx.Empty<T>(OneOrMany<T> collection)`, which addresses the instances where the compiler was implicitly using `string` for `Assert.Empty(OneOrMany<string>)`, instead of treating the input as an enumerable.